### PR TITLE
Logging improvements in JDBC_PING

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -127,7 +127,13 @@ public class JDBC_PING extends FILE_PING {
                     preparedStatement.execute();
                     log.info("Table created for JDBC_PING Discovery Protocol");
                 } catch (SQLException e) {
-                    log.info("Could not execute initialize_sql statement; not necessarily an error.", e);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Could not execute initialize_sql statement; not necessarily an error.", e);
+                    }
+                    else {
+                        //avoid printing out the stacktrace
+                        log.info("Could not execute initialize_sql statement; not necessarily an error. Set to debug logging level for details.");
+                    }
                 }
             } finally {
                 try {


### PR DESCRIPTION
For existing tables we log an info() to warn that the table exists, but as it might be an issue we also forward the stacktrace to help understand SQL errors.
I've changed it to only forward the full stacktrace when logging at debug level, so we don't have a stacktrace at every normal startup as described on http://old.nabble.com/Using-JGroups-on-EC2-autoscaling-group-td30775776.html

Do you track minor issues of not-yet released versions like this? i.e. should I open a JIRA?
