### PR TITLE
Jgrp 1298

### DIFF
--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -1083,7 +1083,6 @@ abstract public class Locking extends Protocol {
             try {
                 long value = await(nanosTimeout);
                 long begin = System.nanoTime();
-                lock.lock();
                 return value - System.nanoTime() + begin;
             }
             catch (InterruptedException e) {


### PR DESCRIPTION
I thought about this morning after I woke up, that it is possible with a few edge cases to be inside the try/finally block for the lock after an await and not obtain the lock.  These changes should guarantee that doesn't happen.

I didn't know if you wanted me to create a different branch or JIRA for it.
