### PR TITLE
New constructor to MuxRpcDispatcher with MethodLookup as parameter 

### DIFF
--- a/src/org/jgroups/blocks/mux/MuxRpcDispatcher.java
+++ b/src/org/jgroups/blocks/mux/MuxRpcDispatcher.java
@@ -9,6 +9,7 @@ import org.jgroups.Message;
 import org.jgroups.MessageListener;
 import org.jgroups.UpHandler;
 import org.jgroups.blocks.GroupRequest;
+import org.jgroups.blocks.MethodLookup;
 import org.jgroups.blocks.RequestCorrelator;
 import org.jgroups.blocks.RequestHandler;
 import org.jgroups.blocks.RequestOptions;
@@ -52,6 +53,18 @@ public class MuxRpcDispatcher extends RpcDispatcher {
         start();
     }
 
+    public MuxRpcDispatcher(short scopeId, Channel channel, MessageListener messageListener, MembershipListener membershipListener, Object serverObject, MethodLookup method_lookup) {
+        this(scopeId);
+        
+        setMethodLookup(method_lookup);
+        setMessageListener(messageListener);
+        setMembershipListener(membershipListener);
+        setServerObject(serverObject);
+        setChannel(channel);
+        channel.addChannelListener(this);
+        start();
+    }
+    
     private Muxer<UpHandler> getMuxer() {
         UpHandler handler = channel.getUpHandler();
         return ((handler != null) && (handler instanceof MuxUpHandler)) ? (MuxUpHandler) handler : null;


### PR DESCRIPTION
Hi Bala,

We have two components using the same channel: the first one allows sending notifications and the second one allows rpc method calls (an RpcDispatcher with MethodLookup)
When we create a MuxRpcDispatcher and set its MethodLookup later, the following exception is raised :

Exception received java.lang.Exception: MethodCall uses ID=0, but method_lookup has not been set

```
at org.jgroups.blocks.RpcDispatcher.handle(RpcDispatcher.java:468) at org.jgroups.blocks.RequestCorrelator.handleRequest(RequestCorrelator.java:578) at org.jgroups.blocks.RequestCorrelator.receiveMessage(RequestCorrelator.java:489) at org.jgroups.blocks.RequestCorrelator.receive(RequestCorrelator.java:365) at org.jgroups.blocks.MessageDispatcher$ProtocolAdapter.up(MessageDispatcher.java:771) at org.jgroups.blocks.mux.MuxUpHandler.up(MuxUpHandler.java:100) at org.jgroups.JChannel.up(JChannel.java:1465) at org.jgroups.stack.ProtocolStack.up(ProtocolStack.java:954) at org.jgroups.protocols.COMPRESS.up(COMPRESS.java:167) at org.jgroups.protocols.FRAG2.up(FRAG2.java:190) at org.jgroups.protocols.pbcast.GMS.up(GMS.java:888) at org.jgroups.protocols.pbcast.STABLE.up(STABLE.java:234) at org.jgroups.protocols.UNICAST.up(UNICAST.java:310) at org.jgroups.protocols.pbcast.NAKACK.handleMessage(NAKACK.java:836) at org.jgroups.protocols.pbcast.NAKACK.up(NAKACK.java:671) at org.jgroups.protocols.VERIFY_SUSPECT.up(VERIFY_SUSPECT.java:132) at org.jgroups.protocols.FD_ALL.up(FD_ALL.java:169) at org.jgroups.protocols.MERGE2.up(MERGE2.java:210) at org.jgroups.protocols.Discovery.up(Discovery.java:292) at org.jgroups.protocols.PING.up(PING.java:67) at org.jgroups.protocols.TP.passMessageUp(TP.java:1093) at org.jgroups.protocols.TP.access$100(TP.java:56) at org.jgroups.protocols.TP$IncomingPacket.handleMyMessage(TP.java:1633) at org.jgroups.protocols.TP$IncomingPacket.run(TP.java:1615) at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(Unknown Source) at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) at java.lang.Thread.run(Unknown Source)
```

We propose to add a new constructor to MuxRpcDispatcher with MethodLookup as parameter.

PS: I make a revert on last code changes so that you can see only modifications that concerns current proposition
