### PR TITLE
yes..I delete the schema reference because it is not in the jar built by 

### DIFF
--- a/conf/jgroups.bnd
+++ b/conf/jgroups.bnd
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-SymbolicName: org.jgroups
 Bundle-Vendor: JBoss, a division of Red Hat
 Bundle-Version: ${version}
-Export-Package: schema;version=${version},${javadoc.packages};version=${version},
+Export-Package: ${javadoc.packages};version=${version},
 Import-Package: bsh|org.bouncycastle.jce.provider;resolution:=optional,!org.testng.*,*
 Implementation-Version: ${version}
 Main-Class: org.jgroups.Version


### PR DESCRIPTION
yes..I delete the schema reference because it is not in the jar built by ant. I leave it in the maven version because it is in the built jar. Maybe need a synchronization of the maven version
