### PR TITLE
Per notes in JGRP-1481

### DIFF
--- a/src/org/jgroups/protocols/SEQUENCER.java
+++ b/src/org/jgroups/protocols/SEQUENCER.java
@@ -278,6 +278,8 @@ public class SEQUENCER extends Protocol {
     }
 
     protected void flush() {
+        if(log.isTraceEnabled())
+            log.trace("Flush starts");
         flushing=true;  // causes subsequent message sends (broadcasts and forwards) to block
 
         // wait until all threads currently sending messages have returned (new threads after flushing=true) will block
@@ -292,6 +294,8 @@ public class SEQUENCER extends Protocol {
             flushMessagesInForwardTable();
         }
         finally {
+            if(log.isTraceEnabled())
+                log.trace("Flush ends");
             flushing=false;
             ack_mode=true; // go to ack-mode after flushing
             num_acks=0;


### PR DESCRIPTION
-  make sure that we set the coordinator in the thread dealing with a view change
-  remove a parameter that becomes redundant as a result of the previous change
-  add some trace (because I'm still not convinced I've got to the bottom of what happened to my group)
