### PR TITLE
When creating a view, the creator should be our own address

### DIFF
--- a/src/org/jgroups/Membership.java
+++ b/src/org/jgroups/Membership.java
@@ -8,7 +8,7 @@ import java.util.*;
  * Represents a membership of a cluster group. Class Membership is not exposed to clients and is
  * used by JGroups internally. The membership object holds a list of Address objects that are in the
  * same membership. Each unique address can only exist once.
- * 
+ *
  * @since 2.0
  * @author Bela Ban
  */
@@ -16,7 +16,7 @@ public class Membership {
     /* private vector to hold all the addresses */
     private final List<Address> members=new LinkedList<Address>();
 
-    
+
    /**
     * Creates a member ship object with zero members
     */
@@ -28,7 +28,7 @@ public class Membership {
     * Creates a Membership with a given initial members. The Address references are copied out of
     * the vector, so that the vector passed in as parameters is not the same reference as the vector
     * that the membership class is using
-    * 
+    *
     * @param initial_members
     *           - a list of members that belong to this membership
     */
@@ -43,7 +43,7 @@ public class Membership {
     * Returns a copy (clone) of the members in this membership. The vector returned is immutable in
     * reference to this object. ie, modifying the vector that is being returned in this method will
     * not modify this membership object.
-    * 
+    *
     * @return a list of members
     */
     public List<Address> getMembers() {
@@ -72,12 +72,12 @@ public class Membership {
 
    /**
     * Adds a list of members to this membership
-    * 
+    *
     * @param v
     *           - a vector containing Address objects
     * @throws ClassCastException
     *            if v contains objects that don't implement the Address interface
-    * 
+    *
     */
     public final void add(Collection<Address> v) {
         if(v != null)
@@ -89,7 +89,7 @@ public class Membership {
    /**
     * Removes an member from the membership. If this member doesn't exist, no action will be
     * performed on the existing membership
-    * 
+    *
     * @param old_member
     *           - the member to be removed
     */
@@ -104,7 +104,7 @@ public class Membership {
 
    /**
     * Removes all the members contained in v from this membership
-    * 
+    *
     * @param v a list of all the members to be removed
     */
     public void remove(Collection<Address> v) {
@@ -138,7 +138,7 @@ public class Membership {
     * Clears the membership and adds all members of v This method will clear out all the old members
     * of this membership by invoking the <code>Clear</code> method. Then it will add all the all
     * members provided in the vector v
-    * 
+    *
     * @param v
     *           - a vector containing all the members this membership will contain
     */
@@ -152,7 +152,7 @@ public class Membership {
     * Clears the membership and adds all members of a given membership parameter. Prior to setting
     * membership this method will clear out all the old members of this membership by invoking the
     * <code>clear</code> method.
-    * 
+    *
     * @param m
     *           - a membership containing all the members this membership will contain
     */
@@ -160,6 +160,26 @@ public class Membership {
         clear();
         if(m != null)
             add(m.getMembers());
+    }
+
+   /**
+    * Rearranges the members so that the specified address is the first in the list, and therefore will
+    * act as coordinator.
+    *
+    * @param coord
+    *          - the address that should become coordinator
+    * @return true on success, else false.
+    */
+    public boolean setCoordinator(Address coord) {
+      if(coord == null) return false;
+      synchronized(members) {
+          if (!members.contains(coord))
+              return false;
+
+          members.remove(coord);
+          members.add(0, coord);
+      }
+      return true;
     }
 
 
@@ -182,7 +202,7 @@ public class Membership {
 
    /**
     * Returns true if the provided member belongs to this membership
-    * 
+    *
     * @param member
     * @return true if the member belongs to this membership
     */
@@ -215,7 +235,7 @@ public class Membership {
 
    /**
     * Returns the number of addresses in this membership
-    * 
+    *
     * @return the number of addresses in this membership
     */
     public int size() {
@@ -226,7 +246,7 @@ public class Membership {
 
    /**
     * Returns the component at the specified index
-    * 
+    *
     * @param index
     *           - 0..size()-1
     * @throws ArrayIndexOutOfBoundsException

--- a/src/org/jgroups/protocols/pbcast/Merger.java
+++ b/src/org/jgroups/protocols/pbcast/Merger.java
@@ -726,8 +726,8 @@ public class Merger {
          * this method is prepared to resolve duplicate entries (for the same member). Resolution strategy for
          * views is to merge only 1 of the duplicate members. Resolution strategy for digests is to take the higher
          * seqnos for duplicate digests.<p>
-         * After merging all members into a Membership and subsequent sorting, the first member of the sorted membership
-         * will be the new coordinator. This method has a lock on merge_rsps.
+         * After merging all members into a Membership, arrange for the local node to be the new coordinator.
+         * This method has a lock on merge_rsps.
          * @param merge_rsps A list of MergeData items. Elements with merge_rejected=true were removed before. Is guaranteed
          *          not to be null and to contain at least 1 member.
          */
@@ -758,10 +758,8 @@ public class Merger {
             // remove all members from the new member list that are not in the digest
             new_mbrs.retainAll(new_digest.getMembers());
 
-            // the new coordinator is the first member of the consolidated & sorted membership list
-            new_mbrs.sort();
-            Address new_coord = new_mbrs.size() > 0 ? new_mbrs.elementAt(0) : null;
-            if(new_coord == null)
+            // We will be the new coordinator
+            if (!new_mbrs.setCoordinator(gms.local_addr))
                 return null;
 
             // should be the highest view ID seen up to now plus 1


### PR DESCRIPTION
I don't think that I've seen this cause problems, but it seems surprising and dangerous for a node A to create a view whose ViewID says that its creator is B (say).  This must open up the possibility of two nodes creating two different views with the same ViewID, with confusion to follow.

(I considered also changing this bit of code so that the local node was the coordinator.  But I don't think that this ought to be necessary, so I've stuck with the smallest change that I think needs making).
