### PR TITLE
JGRP-1485: Don't allow JOIN attempts to timeout indefinitely

### DIFF
--- a/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
@@ -21,7 +21,7 @@ import java.util.*;
  * @author Bela Ban
  * @version $Revision: 1.78 $
  */
-public class ClientGmsImpl extends GmsImpl {   
+public class ClientGmsImpl extends GmsImpl {
     private final Promise<JoinRsp> join_promise=new Promise<JoinRsp>();
 
 
@@ -30,17 +30,17 @@ public class ClientGmsImpl extends GmsImpl {
     }
 
     public void init() throws Exception {
-        super.init();     
+        super.init();
         join_promise.reset();
     }
-    
+
     public void join(Address address,boolean useFlushIfPresent) {
-    	joinInternal(address, false,useFlushIfPresent);
+      joinInternal(address, false,useFlushIfPresent);
     }
-    
-	public void joinWithStateTransfer(Address local_addr, boolean useFlushIfPresent) {
-    	joinInternal(local_addr,true,useFlushIfPresent);
-	}
+
+  public void joinWithStateTransfer(Address local_addr, boolean useFlushIfPresent) {
+      joinInternal(local_addr,true,useFlushIfPresent);
+  }
 
     /**
      * Joins this process to a group. Determines the coordinator and sends a
@@ -58,13 +58,14 @@ public class ClientGmsImpl extends GmsImpl {
      * When GMS.disable_initial_coord is set to true, then we won't become
      * coordinator on receiving an initial membership of 0, but instead will
      * retry (forever) until we get an initial membership of > 0.
-     * 
+     *
      * @param mbr Our own address (assigned through SET_LOCAL_ADDRESS)
      */
     private void joinInternal(Address mbr, boolean joinWithStateTransfer,boolean useFlushIfPresent) {
         Address coord=null;
         JoinRsp rsp=null;
         View tmp_view;
+        long join_attempts=0;
         leaving=false;
 
         join_promise.reset();
@@ -138,11 +139,19 @@ public class ClientGmsImpl extends GmsImpl {
                 if(rsp == null)
                     rsp=join_promise.getResult(gms.join_timeout);
                 if(rsp == null) {
+                    join_attempts++;
                     if(log.isWarnEnabled())
-                        log.warn("JOIN(" + mbr + ") sent to " + coord + " timed out (after " + gms.join_timeout + " ms), retrying");
+                        log.warn("JOIN(" + mbr + ") sent to " + coord + " timed out (after " + gms.join_timeout + " ms), on try " + join_attempts);
+
+                    if ((gms.max_join_timeouts != 0) && (join_attempts >= gms.max_join_timeouts)) {
+                        if(log.isWarnEnabled())
+                            log.warn("Too many JOIN timeouts: becoming singleton");
+                        becomeSingletonMember(mbr);
+                        return;
+                    }
                     continue;
                 }
-                
+
                 // 1. check whether JOIN was rejected
                 String failure=rsp.getFailReason();
                 if(failure != null)
@@ -218,7 +227,7 @@ public class ClientGmsImpl extends GmsImpl {
         List<PingData> responses=(List<PingData>)gms.getDownProtocol().down(new Event(Event.FIND_INITIAL_MBRS, promise));
         if(responses != null) {
             for(Iterator<PingData> iter=responses.iterator(); iter.hasNext();) {
-                Address address=iter.next().getAddress();                
+                Address address=iter.next().getAddress();
                 if(address != null && address.equals(gms.local_addr))
                     iter.remove();
             }
@@ -238,7 +247,7 @@ public class ClientGmsImpl extends GmsImpl {
 
 
     /* --------------------------- Private Methods ------------------------------------ */
-    
+
     /**
      * Called by join(). Installs the view returned by calling Coord.handleJoin() and
      * becomes coordinator.

--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -44,6 +44,9 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
     @Property(description="Timeout (in ms) to complete merge")
     long merge_timeout=5000; // time to wait for all MERGE_RSPS
 
+    @Property(description="Number of join timeouts before we give up and become a singleton.  Zero means 'never give up'.")
+    long max_join_timeouts=0;
+
     @Property(description="Print local address of this member after connect. Default is true")
     private boolean print_local_addr=true;
 
@@ -173,6 +176,8 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
     public void setJoinTimeout(long t) {join_timeout=t;}
     public long getMergeTimeout() {return merge_timeout;}
     public void setMergeTimeout(long timeout) {merge_timeout=timeout;}
+    public long getMaxJoinTimeouts() {return max_join_timeouts;}
+    public void setMaxJoinTimeouts(long t) {max_join_timeouts=t;}
 
     @ManagedAttribute(description="Stringified version of merge_id")
     public String getMergeId() {return merger.getMergeIdAsString();}


### PR DESCRIPTION
Added a configuration option so that if JOIN attempts keep timing out the member that is getting nowhere can instead form a singleton.  I've made the default be to retain the old behaviour, to try and mitigate any worries you might have about this...

This seems to be working out fine in my testing, though I've found a follow-up issue that I'll describe in the JIRA.
