### PR TITLE
[JGRP-1619] Update OSGi manifest

### DIFF
--- a/conf/jgroups.bnd
+++ b/conf/jgroups.bnd
@@ -8,6 +8,6 @@ Bundle-SymbolicName: org.jgroups
 Bundle-Vendor: JBoss, a division of Red Hat
 Bundle-Version: ${version}
 Export-Package: ${javadoc.packages};version=${version},
-Import-Package: org.bouncycastle.jce.provider;resolution:=optional,!org.testng.*,*
+Import-Package: org.bouncycastle.jce.provider;resolution:=optional,org.apache.log4j;resolution:=optional,org.apache.logging.log4j.*;resolution:=optional,!org.testng.*,*
 Implementation-Version: ${version}
 Main-Class: org.jgroups.Version


### PR DESCRIPTION
The log4j 1.x and log4j 2.x dependencies should be optional in the osgi manifest
