### PR TITLE
Fix maven "test" goal by delegating to ant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,41 @@
                     </instructions>
                 </configuration>
             </plugin>
+
+            <!-- Disable default tests: they won't run since they are lacking configuration -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Run the tests via ant -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <configuration>
+                            <tasks unless="maven.test.skip">
+                                <ant antfile="${basedir}/build.xml" target="all-tests">
+                                    <property name="build.compiler" value="extJavac"/>
+                                </ant>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Add some maven magic so maven runs correctly by default.

So now `[rhusar@rhusar jgroups]$ mvn clean install`  or `[rhusar@rhusar jgroups]$ mvn test` runs fine instaded of NPEs all around.
