### PR TITLE
Replace mod operations with bitwise AND where possible

### DIFF
--- a/src/org/jgroups/blocks/ReplCache.java
+++ b/src/org/jgroups/blocks/ReplCache.java
@@ -777,11 +777,11 @@ public class ReplCache<K,V> implements MembershipListener, Cache.ChangeListener 
     
     public static class ConsistentHashFunction<K> implements HashFunction<K> {
         private SortedMap<Short,Address> nodes=new TreeMap<Short,Address>();
-        private final static int HASH_SPACE=2000; // must be > max number of nodes in a cluster
+        private final static int HASH_SPACE=2048; // must be > max number of nodes in a cluster and a power of 2
         private final static int FACTOR=3737; // to better spread the node out across the space
 
         public List<Address> hash(K key, short replication_count) {
-            int index=Math.abs(key.hashCode() % HASH_SPACE);
+            int index=Math.abs(key.hashCode() & (HASH_SPACE - 1));
             
             Set<Address> results=new LinkedHashSet<Address>();
             List<Address> retval=new ArrayList<Address>();
@@ -812,9 +812,9 @@ public class ReplCache<K,V> implements MembershipListener, Cache.ChangeListener 
         public void installNodes(List<Address> new_nodes) {
             nodes.clear();
             for(Address node: new_nodes) {
-                int hash=Math.abs((node.hashCode() * FACTOR) % HASH_SPACE);
+                int hash=Math.abs((node.hashCode() * FACTOR) & (HASH_SPACE - 1));
                 for(int i=hash; i < hash + HASH_SPACE; i++) {
-                    short new_index=(short)(i % HASH_SPACE);
+                    short new_index=(short)(i & (HASH_SPACE - 1));
                     if(!nodes.containsKey(new_index)) {
                         nodes.put(new_index, node);
                         break;

--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -1,19 +1,21 @@
 package org.jgroups.client;
 
 import org.jgroups.annotations.Experimental;
-import org.jgroups.annotations.Unsupported;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
 import org.jgroups.protocols.STOMP;
 import org.jgroups.util.Util;
 
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.net.*;
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLSocketFactory;
-import java.util.*;
+import java.net.Socket;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * STOMP client to access the STOMP [1] protocol. Note that the full STOMP protocol is not implemented, e.g. transactions
@@ -190,7 +192,7 @@ public class StompConnection implements Runnable {
             sb.append("destination: ").append(destination).append("\n");
         if(buf != null)
             sb.append("content-length: ").append(length).append("\n");
-        if(headers != null && headers.length % 2 == 0) { // must be even
+        if(headers != null && (headers.length & 1) == 0) { // must be even
             for(int i=0; i < headers.length; i++)
                 sb.append(headers[i]).append(": ").append(headers[++i]).append("\n");
         }

--- a/src/org/jgroups/util/RetransmitTable.java
+++ b/src/org/jgroups/util/RetransmitTable.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 public class RetransmitTable {
     protected final int    num_rows;
+
+   /** Must be a power of 2 for efficient modular arithmetic **/
     protected final int    msgs_per_row;
     protected final double resize_factor;
     protected Message[][]  matrix;
@@ -73,7 +75,13 @@ public class RetransmitTable {
     public RetransmitTable(int num_rows, int msgs_per_row, long offset, double resize_factor, long max_compaction_time,
                            boolean automatic_purging) {
         this.num_rows=num_rows;
-        this.msgs_per_row=msgs_per_row;
+
+        // Find a power of 2 >= msgs_per_row
+        int mpr = 1;
+        while (msgs_per_row < mpr)
+           mpr <<= 1;
+
+        this.msgs_per_row=mpr;
         this.resize_factor=resize_factor;
         this.max_compaction_time=max_compaction_time;
         this.automatic_purging=automatic_purging;
@@ -460,7 +468,7 @@ public class RetransmitTable {
         int diff=(int)(seqno - offset);
         if(diff < 0)
             return diff;
-        return diff % msgs_per_row;
+        return diff & (msgs_per_row - 1);
     }
 
     


### PR DESCRIPTION
This pull request replaces modular operations (%) with bitwise AND operations where used in a hot code path or in a loop.  Modulus invokes division in most CPUs, and this is often 1 to 2 orders of magnitude slower than a bitwise AND.

Reflected in several places:

http://dhruba.name/2011/07/12/performance-pattern-modulo-and-powers-of-two/
http://scicomp.stackexchange.com/questions/187/why-is-division-so-much-more-complex-than-other-arithmetic-operations
http://disruptor.googlecode.com/files/Disruptor-1.0.pdf (Page 5, last paragraph)

I have also identified other areas in JGroups where this will apply, however it would require enforcing that certain configuration parameters are powers of 2 (or are internally upgraded to the closest power of two).  These include STABLE, HashedTimingWheel and RATE_LIMITER.
