### PR TITLE
[3.2.x] JGRP-1611 Update log messages to follow TAG-2 message format

### DIFF
--- a/conf/jg-messages.properties
+++ b/conf/jg-messages.properties
@@ -1,16 +1,16 @@
-ConfigurationError          = [JGRP00001] configuration error: the following properties in {0} are not recognized: {1}
-ProtocolLoadError           = [JGRP00002] unable to load protocol {0} (either with relative - {0} - or absolute - {1} - class name)
-FileNotFound                = [JGRP00003] file \"{0}\" not found
-ParseError                  = [JGRP00004] parsing failure; the XML document is not correct: {0}
-ProtocolCreateError         = [JGRP00005] failure creating protocol {0}: {1}
-AcceptError                 = [JGRP00006] failed accepting connection from peer: {0}
-AttrReadFailure             = [JGRP00007] failed reading value of attribute {0}: {1}
-MissingAttribute            = [JGRP00008] did not find attribute with name {0}
-AttrWriteFailure            = [JGRP00009] failed writing to attribute {0}: {1}
-VersionMismatch             = [JGRP00010] packet from {0} has different version ({1}) than ours ({2}); packet is discarded
-MsgDroppedNak               = [JGRP00011] {0}: dropped message {1} from non-member {2} (view={3})
-MsgDroppedDiffCluster       = [JGRP00012] discarded message from different cluster {0} (our cluster is {1}). Sender was {2}
+ConfigurationError          = JGRP000001: configuration error: the following properties in {0} are not recognized: {1}
+ProtocolLoadError           = JGRP000002: unable to load protocol {0} (either with relative - {0} - or absolute - {1} - class name)
+FileNotFound                = JGRP000003: file \"{0}\" not found
+ParseError                  = JGRP000004: parsing failure; the XML document is not correct: {0}
+ProtocolCreateError         = JGRP000005: failure creating protocol {0}: {1}
+AcceptError                 = JGRP000006: failed accepting connection from peer: {0}
+AttrReadFailure             = JGRP000007: failed reading value of attribute {0}: {1}
+MissingAttribute            = JGRP000008: did not find attribute with name {0}
+AttrWriteFailure            = JGRP000009: failed writing to attribute {0}: {1}
+VersionMismatch             = JGRP000010: packet from {0} has different version ({1}) than ours ({2}); packet is discarded
+MsgDroppedNak               = JGRP000011: {0}: dropped message {1} from non-member {2} (view={3})
+MsgDroppedDiffCluster       = JGRP000012: discarded message from different cluster {0} (our cluster is {1}). Sender was {2}
 SuppressMsg                 = (received {0} identical messages from {1} in the last {2} ms)
-Deprecated                  = [JGRP00013] {0} has been deprecated: {1}
-IncorrectBufferSize         = [JGRP00014] the {0} buffer of socket {1} was set to {2}, but the OS only allocated {3}. \
+Deprecated                  = JGRP000013: {0} has been deprecated: {1}
+IncorrectBufferSize         = JGRP000014: the {0} buffer of socket {1} was set to {2}, but the OS only allocated {3}. \
   This might lead to performance problems. Please set your max {4} buffer in the OS correctly (e.g. {5} on Linux)

--- a/conf/jg-messages_de.properties
+++ b/conf/jg-messages_de.properties
@@ -1,16 +1,16 @@
-ConfigurationError          = [JGRP00001] Konfigurationsfehler: die folgenden Parameter in {0} sind nicht erlaubt: {1}
-ProtocolLoadError           = [JGRP00002] Fehler beim Laden des Protokolls {0} (sowohl mit relativem - {0} - als auch absolutem - {1} - Pfadnamen)
-FileNotFound                = [JGRP00003] Datei \"{0}\" nicht gefunden
-ParseError                  = [JGRP00004] Fehler beim Parsen von XML; das Dokument ist nicht korrekt: {0}
-ProtocolCreateError         = [JGRP00005] Protokoll {0} konnte nicht instantiiert werden: {1}
-AcceptError                 = [JGRP00006] Verbindung vom Peer konnte nicht hergestellt werden: {0}
-AttrReadFailure             = [JGRP00007] Attribut {0} konnte nicht gelesen werden: {1}
-MissingAttribute            = [JGRP00008] Attribut {0} wurde nicht gefunden
-AttrWriteFailure            = [JGRP00009] Attribut {0} konnte nicht geschrieben werden: {1}
-VersionMismatch             = [JGRP00010] Nachricht von {0} hat eine andere Version ({1}) als unsere ({2}); Nachricht wird verworfen
-MsgDroppedNak               = [JGRP00011] {0}: Nachricht {1} von Nicht-Mitglied {2} wurde verworfen (View={3})
-MsgDroppedDiffCluster       = [JGRP00012] Nachricht von Cluster {0} wurde verworfen (unser Cluster ist {1}). Der Sender war {2}
+ConfigurationError          = JGRP000001: Konfigurationsfehler: die folgenden Parameter in {0} sind nicht erlaubt: {1}
+ProtocolLoadError           = JGRP000002: Fehler beim Laden des Protokolls {0} (sowohl mit relativem - {0} - als auch absolutem - {1} - Pfadnamen)
+FileNotFound                = JGRP000003: Datei \"{0}\" nicht gefunden
+ParseError                  = JGRP000004: Fehler beim Parsen von XML; das Dokument ist nicht korrekt: {0}
+ProtocolCreateError         = JGRP000005: Protokoll {0} konnte nicht instantiiert werden: {1}
+AcceptError                 = JGRP000006: Verbindung vom Peer konnte nicht hergestellt werden: {0}
+AttrReadFailure             = JGRP000007: Attribut {0} konnte nicht gelesen werden: {1}
+MissingAttribute            = JGRP000008: Attribut {0} wurde nicht gefunden
+AttrWriteFailure            = JGRP000009: Attribut {0} konnte nicht geschrieben werden: {1}
+VersionMismatch             = JGRP000010: Nachricht von {0} hat eine andere Version ({1}) als unsere ({2}); Nachricht wird verworfen
+MsgDroppedNak               = JGRP000011: {0}: Nachricht {1} von Nicht-Mitglied {2} wurde verworfen (View={3})
+MsgDroppedDiffCluster       = JGRP000012: Nachricht von Cluster {0} wurde verworfen (unser Cluster ist {1}). Der Sender war {2}
 SuppressMsg                 = ({0} identische Nachrichten erhalten von {1} in den letzten {2} ms)
-Deprecated                  = [JGRP00013] {0} wird nicht mehr unterstuetzt: {1}
-IncorrectBufferSize         = [JGRP00014] Der {0} Puffer des Sockets {1} wurde auf {2} gesetzt, aber das Betriebssystem stellt nur {3} zur Verfuegung. \
+Deprecated                  = JGRP000013: {0} wird nicht mehr unterstuetzt: {1}
+IncorrectBufferSize         = JGRP000014: Der {0} Puffer des Sockets {1} wurde auf {2} gesetzt, aber das Betriebssystem stellt nur {3} zur Verfuegung. \
   Dies koennte zu Performanzproblemen fuehren. Bitte setzen Sie den max {4} Puffer im Betriebssystem korrekt (z.B. {5} unter Linux)


### PR DESCRIPTION
i.e. no brackets, 6 digit padded message IDs

This is required for:
https://bugzilla.redhat.com/show_bug.cgi?id=999671

and will require a 3.2.11 release.
