### PR TITLE
The FD_SOCK.handleSocketClose() debug log doesn't print the exception me...

### DIFF
--- a/src/org/jgroups/protocols/FD_SOCK.java
+++ b/src/org/jgroups/protocols/FD_SOCK.java
@@ -489,7 +489,7 @@ public class FD_SOCK extends Protocol implements Runnable {
         teardownPingSocket();     // make sure we have no leftovers
         if(!regular_sock_close) { // only suspect if socket was not closed regularly (by interruptPingerThread())
             if(log.isDebugEnabled())
-                log.debug("peer " + ping_dest + " closed socket (" + (ex != null ? ex.getClass().getName() : "eof") + ')');
+                log.debug("peer " + ping_dest + " closed socket (" + (ex != null ? ex.toString() : "eof") + ')');
             broadcastSuspectMessage(ping_dest);
             pingable_mbrs.remove(ping_dest);
         }


### PR DESCRIPTION
...ssage part:

> peer node1 closed socket (java.net.SocketException)

It would be better to use toString() instead of class name so we can see why it's disconnected:

> peer node1 closed socket (java.net.SocketException: Connection reset by peer)
> peer node1 closed socket (java.net.SocketException: Read timeout)
> peer node1 closed socket (java.net.SocketException: No route to host)
> peer node1 closed socket (java.net.SocketException: Unexpected end of file from server)
