### PR TITLE
Fix variables which control parallelism to be configured from build.xml only.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -566,6 +566,8 @@
                     listeners="org.jgroups.util.JUnitXMLReporter"
             		timeout="${unittest.timeout}"
             	    verbose="${test.verbose}"
+                    parallel="@{parallel}"
+                    threadcount="@{threadcount}"
                     >
                 <xmlfileset dir="${testng.conf.dir}" includes="@{testng.xmlfile}"/>
                 <sysproperty key="test.suffix" value="@{testname.ext}"/>

--- a/conf/testng/byteman.xml
+++ b/conf/testng/byteman.xml
@@ -1,8 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="byteman"
-       parallel="false"
-       thread-count="1" >
-
+<suite name="byteman">
     <test name="byteman" junit="false" time-out="1200000">
         <groups>
             <run>            	

--- a/conf/testng/functional.xml
+++ b/conf/testng/functional.xml
@@ -1,8 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="functional"
-       parallel="methods"
-       thread-count="10" >
-
+<suite name="functional">
     <test name="functional" junit="false" time-out="1200000">
         <groups>
             <run>            	

--- a/conf/testng/stack-independent.xml
+++ b/conf/testng/stack-independent.xml
@@ -1,8 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="stack-independent"
-       parallel="tests"
-       thread-count="1" >
-
+<suite name="stack-independent">
     <test name="stack-independent" junit="false" time-out="1200000">
         <groups>
             <run>            	

--- a/conf/testng/testng-tcp-flush.xml
+++ b/conf/testng/testng-tcp-flush.xml
@@ -1,8 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="tcp-flush"
-       parallel="methods"
-       thread-count="5">
-
+<suite name="tcp-flush">
 	<parameter name="channel.conf" value="flush-tcp.xml"/>
 	<parameter name="use_blocking" value="true"/>
     <test name="tcp-flush" junit="false" time-out="1200000">

--- a/conf/testng/testng-tcp-stress.xml
+++ b/conf/testng/testng-tcp-stress.xml
@@ -1,9 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="tcp"
-       parallel="methods"
-       thread-count="1"
-        >
-
+<suite name="tcp">
     <test name="tcp" junit="false" time-out="1200000">
         <parameter name="channel.conf" value="tcp.xml"/>
         <groups>

--- a/conf/testng/testng-tcp.xml
+++ b/conf/testng/testng-tcp.xml
@@ -1,9 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="tcp"
-       parallel="methods"
-       thread-count="5"
-        >
-
+<suite name="tcp">
     <test name="tcp" junit="false" time-out="1200000">
         <parameter name="channel.conf" value="tcp.xml"/>
         <groups>

--- a/conf/testng/testng-udp-flush.xml
+++ b/conf/testng/testng-udp-flush.xml
@@ -1,9 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="udp-flush"
-       parallel="methods"
-       thread-count="5">
-
-
+<suite name="udp-flush">
 	<parameter name="channel.conf" value="flush-udp.xml"/>
 	<parameter name="use_blocking" value="true"/>
     <test name="udp-flush" junit="false" time-out="1200000">

--- a/conf/testng/testng-udp.xml
+++ b/conf/testng/testng-udp.xml
@@ -1,9 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="udp"
-       parallel="methods"
-       thread-count="5"
-        >
-
+<suite name="udp">
     <test name="udp" junit="false" time-out="1200000">
         <parameter name="channel.conf" value="udp.xml"/>
         <groups>

--- a/conf/testng/time-sensitive.xml
+++ b/conf/testng/time-sensitive.xml
@@ -1,8 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="time-sensitive"
-       parallel="methods"
-       thread-count="1" >
-
+<suite name="time-sensitive">
     <test name="time-sensitive" junit="false" time-out="1200000">
         <groups>
             <run>            	


### PR DESCRIPTION
See the issue: https://issues.jboss.org/browse/JGRP-1728
