### PR TITLE
Correcting incorrect parameter javadoc

### DIFF
--- a/src/org/jgroups/Message.java
+++ b/src/org/jgroups/Message.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * <p>
  * The byte buffer can point to a reference, and we can subset it using index and length. However,
  * when the message is serialized, we only write the bytes between index and length.
- * 
+ *
  * @since 2.0
  * @author Bela Ban
  */
@@ -101,7 +101,7 @@ public class Message implements Streamable {
 
    /**
     * Constructs a Message given a destination Address
-    * 
+    *
     * @param dest
     *           Address of receiver. If it is <em>null</em> then the message sent to the group.
     *           Otherwise, it contains a single destination and is sent to that member.
@@ -114,7 +114,7 @@ public class Message implements Streamable {
 
    /**
     * Constructs a Message given a destination Address, a source Address and the payload byte buffer
-    * 
+    *
     * @param dest
     *           Address of receiver. If it is <em>null</em> then the message sent to the group.
     *           Otherwise, it contains a single destination and is sent to that member.
@@ -145,7 +145,7 @@ public class Message implements Streamable {
     * message, it would still have a ref to the original byte[] buffer passed in as argument, and so we would
     * retransmit a changed byte[] buffer !
     * </em>
-    * 
+    *
     * @param dest
     *           Address of receiver. If it is <em>null</em> then the message sent to the group.
     *           Otherwise, it contains a single destination and is sent to that member.
@@ -174,7 +174,7 @@ public class Message implements Streamable {
 
    /**
     * Constructs a Message given a destination Address, a source Address and the payload Object
-    * 
+    *
     * @param dest
     *           Address of receiver. If it is <em>null</em> then the message sent to the group.
     *           Otherwise, it contains a single destination and is sent to that member.
@@ -231,7 +231,7 @@ public class Message implements Streamable {
 
    /**
     * Returns a copy of the buffer if offset and length are used, otherwise a reference.
-    * 
+    *
     * @return byte array with a copy of the buffer.
     */
     final public byte[] getBuffer() {
@@ -317,9 +317,9 @@ public class Message implements Streamable {
     }
 
    /**
-    * 
+    *
     * Returns the number of bytes in the buffer
-    * 
+    *
     */
     public int getLength() {
         return length;
@@ -438,7 +438,7 @@ public class Message implements Streamable {
 
    /**
     * Same as {@link #setFlag(Flag...)} except that transient flags are not marshalled
-    * @param flag The flag
+    * @param flags The flag
     */
    public Message setTransientFlag(TransientFlag ... flags) {
        if(flags != null)
@@ -452,7 +452,7 @@ public class Message implements Streamable {
     * Atomically checks if a given flag is set and - if not - sets it. When multiple threads
     * concurrently call this method with the same flag, only one of them will be able to set the
     * flag
-    * 
+    *
     * @param flag
     * @return True if the flag could be set, false if not (was already set)
     */
@@ -501,7 +501,7 @@ public class Message implements Streamable {
 
    /**
     * Puts a header given a key into the map, only if the key doesn't exist yet
-    * 
+    *
     * @param id
     * @param hdr
     * @return the previous value associated with the specified key, or <tt>null</tt> if there was no
@@ -532,7 +532,7 @@ public class Message implements Streamable {
     * Create a copy of the message. If offset and length are used (to refer to another buffer), the
     * copy will contain only the subset offset and length point to, copying the subset into the new
     * copy.
-    * 
+    *
     * @param copy_buffer
     * @return Message with specified data
     */
@@ -547,7 +547,7 @@ public class Message implements Streamable {
     * Note that for headers, only the arrays holding references to the headers are copied, not the headers themselves !
     * The consequence is that the headers array of the copy hold the *same* references as the original, so do *not*
     * modify the headers ! If you want to change a header, copy it and call {@link Message#putHeader(short,Header)} again.
-    * 
+    *
     * @param copy_buffer
     * @param copy_headers
     *           Copy the headers
@@ -572,7 +572,7 @@ public class Message implements Streamable {
 
    /**
     * Doesn't copy any headers except for those with ID >= copy_headers_above
-    * 
+    *
     * @param copy_buffer
     * @param starting_id
     * @return A message with headers whose ID are >= starting_id
@@ -718,7 +718,7 @@ public class Message implements Streamable {
    /**
     * Writes the message to the output stream, but excludes the dest and src addresses unless the
     * src address given as argument is different from the message's src address
-    * 
+    *
     * @param src
     * @param out
     * @param excluded_headers Don't marshal headers that are part of excluded_headers
@@ -813,7 +813,7 @@ public class Message implements Streamable {
     * the size, so if a Header subclass doesn't implement size() we will use an approximation.
     * However, most relevant header subclasses have size() implemented correctly. (See
     * org.jgroups.tests.SizeTest).
-    * 
+    *
     * @return The number of bytes for the marshalled message
     */
     public long size() {


### PR DESCRIPTION
Very minor, correcting parameter javadoc spelling in 'setTransientFlag' method
