### PR TITLE
Mutual AUTH

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
         build.xml file for JGroups. Needs Ant (jakarta.apache.org) to run
     </description>
 
-    <property name="version" value="3.4.6.SNAPSHOT"/>
+    <property name="version" value="3.4.5.Final"/>
     <property name="build.properties.file" value="build.properties"/>
     <property file="${build.properties.file}"/>
     <property name="root.dir" value="${basedir}"/>


### PR DESCRIPTION
Hi.

The current implementation of AUTH provides no means to perform authentication on coordinator also. I implemented a fairly straightforward way to authenticate join/merge responses also.

The feature is configurable through property and is disabled by default.

Best regards,
Tero Leppikangas

PS. I already managed to accidentally create another pull request with no information so I closed it and created this one instead.
