### PR TITLE
Move getTimestamp before ping block to avoid false suspect

### DIFF
--- a/src/org/jgroups/protocols/FD_HOST.java
+++ b/src/org/jgroups/protocols/FD_HOST.java
@@ -381,6 +381,8 @@ public class FD_HOST extends Protocol {
             }
             targets.remove(local_host);
 
+            long current_time=getTimestamp();
+
             // 1. Ping each host
             for(InetAddress target: targets) {
                 try {
@@ -397,7 +399,6 @@ public class FD_HOST extends Protocol {
             }
 
             // 2. Check timestamps
-            long current_time=getTimestamp();
             for(Map.Entry<InetAddress,Long> entry: timestamps.entrySet()) {
                 InetAddress host=entry.getKey();
                 long timestamp=entry.getValue();


### PR DESCRIPTION
If ping takes long time or GC pause during pings, it could suspect members incorrectly. It's safer to get the current timestamp before the ping block.
