### PR TITLE
JGRP-1711 - handle outcoming messages in separate thread

### DIFF
--- a/src/org/jgroups/protocols/DELAY.java
+++ b/src/org/jgroups/protocols/DELAY.java
@@ -1,6 +1,11 @@
 package org.jgroups.protocols;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
 
 import org.jgroups.Event;
 import org.jgroups.annotations.Property;
@@ -19,6 +24,7 @@ import org.jgroups.util.Util;
  *
  * @author Bela Ban
  * @author Sanne Grinovero
+ * @author Matej Cimbora
  */
 public class DELAY extends Protocol {
 
@@ -32,6 +38,11 @@ public class DELAY extends Protocol {
     protected int in_delay_nanos;
     @Property(description = "Number of nanoseconds to delay passing a message down the stack")
     protected int out_delay_nanos;
+    @Property(description = "Keep the delay constant. By default delay time randoms between 0 and upper bound")
+    protected boolean constant_delay;
+
+    protected DelayedMessageHandler delayed_message_handler;
+    protected DelayQueue<DelayedMessage> delayed_messages = new DelayQueue<DelayedMessage>();
 
     public int  getInDelay()               {return in_delay;}
     public void setInDelay(int in_delay)   {this.in_delay=in_delay;}
@@ -42,10 +53,29 @@ public class DELAY extends Protocol {
     public int  getOutDelayNanos()              {return out_delay_nanos;}
     public void setOutDelayNanos(int out_delay_nanos) {this.out_delay_nanos=out_delay_nanos;}
 
+    @Override
+    public void init() throws Exception {
+        super.init();
+        delayed_message_handler = new DelayedMessageHandler();
+        delayed_message_handler.start();
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        if (delayed_message_handler != null)
+            Util.interruptAndWaitToDie(delayed_message_handler);
+    }
+
     public Object down(final Event evt) {
-        if (isMessage(evt))
-            sleep(out_delay, out_delay_nanos);
-        return down_prot.down(evt);
+        if (isMessage(evt)) {
+            delayed_messages.add(new DelayedMessage(evt, System.nanoTime()));
+            // don't wait for the result, return immediately
+            return null;
+        }
+        else {
+            return down_prot.down(evt);
+        }
     }
 
     public Object up(final Event evt) {
@@ -66,19 +96,62 @@ public class DELAY extends Protocol {
     /**
      * Compute a random number between 0 and n
      */
-    private static int computeDelay(final int n) {
+    private int computeDelay(final int n) {
         if (n <= 1) {
             return 0;
         }
-        return randomNumberGenerator.nextInt(n);
+        return constant_delay ? n : randomNumberGenerator.nextInt(n);
     }
 
-    private static void sleep(final int variable_milliseconds_delay, final int nano_delay) {
+    private void sleep(final int variable_milliseconds_delay, final int nano_delay) {
         final int millis = computeDelay(variable_milliseconds_delay);
         if (millis != 0 || nano_delay != 0) {
             Util.sleep(millis, nano_delay);
         }
     }
 
-}
+    private class DelayedMessage implements Delayed {
 
+        private final Event event;
+        private final long start;
+        private final long delay_time;
+
+        public DelayedMessage(Event event, long start) {
+            this.event = event;
+            this.start = start;
+            this.delay_time = TimeUnit.NANOSECONDS.convert(computeDelay(out_delay), TimeUnit.MILLISECONDS) + out_delay_nanos;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(start + delay_time - System.nanoTime(), TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            if (o == this)
+                return 0;
+            return Long.compare(this.getDelay(TimeUnit.NANOSECONDS), o.getDelay(TimeUnit.NANOSECONDS));
+        }
+    }
+
+    private class DelayedMessageHandler extends Thread {
+
+        private List<DelayedMessage> buffer = new ArrayList<DelayedMessage>();
+
+        @Override
+        public void run() {
+            for (;;) {
+                try {
+                    delayed_messages.drainTo(buffer);
+                    for (DelayedMessage evt : buffer)
+                        down_prot.down(evt.event);
+                    buffer.clear();
+                } catch (Exception e) {
+                    // handling thread should never die
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- Outcoming messages are now handled by separate thread
- Added 'constant_delay' property to enforce stable delay
