### PR TITLE
Fix NPE if message arrives for unregistered fork.

### DIFF
--- a/src/org/jgroups/fork/ForkProtocolStack.java
+++ b/src/org/jgroups/fork/ForkProtocolStack.java
@@ -49,6 +49,10 @@ public class ForkProtocolStack extends ProtocolStack {
                 if(hdr.getForkChannelId() == null)
                     throw new IllegalArgumentException("header has a null fork_channel_id");
                 JChannel fork_channel=get(hdr.getForkChannelId());
+                if (fork_channel == null) {
+                    log.warn("fork-channel for id=%s not found; discarding message", hdr.getForkChannelId());
+                    return null;
+                }
                 return fork_channel.up(evt);
 
             case Event.VIEW_CHANGE:


### PR DESCRIPTION
For JGRP-1905.  Better to drop the message (i.e. like we already to for message batches) than throw an NPE.