### PR TITLE
JGRP-1905 FORK: RPCs might block if fork channel or fork stack is not available

### DIFF
--- a/src/org/jgroups/fork/ForkChannel.java
+++ b/src/org/jgroups/fork/ForkChannel.java
@@ -77,7 +77,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
             FORK fork=getFORK(main_channel, position, neighbor, create_fork_if_absent);
             bottom_prot=fork.get(fork_stack_id);
             if(bottom_prot == null) // Create the fork-stack if absent
-                bottom_prot=fork.createForkStack(fork_stack_id, new ForkProtocolStack(), false,
+                bottom_prot=fork.createForkStack(fork_stack_id, new ForkProtocolStack(fork.getUnknownForkHandler()), false,
                                                  protocols == null? null : Arrays.asList(protocols));
         }
         prot_stack=getForkStack(bottom_prot);

--- a/src/org/jgroups/fork/UnknownForkHandler.java
+++ b/src/org/jgroups/fork/UnknownForkHandler.java
@@ -1,0 +1,26 @@
+package org.jgroups.fork;
+
+import org.jgroups.Message;
+
+/**
+ * Allows a user of fork to define the handling of a message for which no fork stack or fork channel exists.
+ * @author Paul Ferraro
+ */
+public interface UnknownForkHandler {
+
+    /**
+     * Handle a message that refers to an unknown fork stack
+     * @param message an incoming message
+     * @param forkStackId the identifier of a fork stack
+     * @return the result of the up handler
+     */
+    Object handleUnknownForkStack(Message message, String forkStackId);
+
+    /**
+     * Handle a message that refers to an unknown fork channel
+     * @param message an incoming message
+     * @param forkStackId the identifier of a fork channel
+     * @return the result of the up handler
+     */
+    Object handleUnknownForkChannel(Message message, String forkChannelId);
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-1905
Exposes a mechanism to allow the creator of FORK to define how unknown forks should be handled.