### PR TITLE
Fix flakey unit test

### DIFF
--- a/tests/junit/org/jgroups/tests/SequencerMergeTest.java
+++ b/tests/junit/org/jgroups/tests/SequencerMergeTest.java
@@ -116,6 +116,10 @@ public class SequencerMergeTest {
             if(all_ok)
                 break;
             Util.sleep(500);
+            list_a=ra.getList();
+            list_b=rb.getList();
+            list_c=rc.getList();
+            list_d=rd.getList();
         }
 
         System.out.println("A: " + list_a + "\nB: " + list_b + "\nC: " + list_c + "\nD: " + list_d);


### PR DESCRIPTION
The intention of this loop is that if at first the four members don't have the right details, then wait a bit and try again.  Only it misses the "try again" part.