### PR TITLE
Fix 'ant publish-local'

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -134,7 +134,7 @@
     <!-- =================================
           target: publish-local
          ================================= -->
-    <target name="publish-local" depends="define-ivy-task"
+    <target name="publish-local" depends="define-ivy-task,jar"
             description="Publishes this project to the local ivy repo (artifacts need to be in ./dist)">
         <property name="revision" value="${version}"/>
 
@@ -158,6 +158,8 @@
 
         <!-- artifactspattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]" -->
         <delete file="${dist.dir}/README"/>
+
+        <ivy:resolve file="ivy.xml"/>
 
         <ivy:publish artifactspattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"
                      publishivy="false"


### PR DESCRIPTION
-  make sure that the required artifacts are built first, by depending on the "jar" task
-  ivy:resolve all dependencies

I'm no ivy expert but google told me to do the second thing and it worked.  Prior to that I was hitting 

    impossible to publish artifacts for org.jgroups#jgroups;3.6.3.Final: java.lang.IllegalStateException: Ivy file not found in cache for org.jgroups#jgroups;3.6.3.Final!

To reproduce this problem I think that you may need to `rm -fr ~/.ivy2/cache` before trying `ant publish-local`