### PR TITLE
BZ1211227 Extracting version dynamically

### DIFF
--- a/conf/jgroups-version.properties
+++ b/conf/jgroups-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
             <resource>
                 <directory>conf</directory>
                 <includes>
+                    <include>jgroups-version.properties</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>conf</directory>
+                <includes>
                     <include>*.xml</include>
                     <include>jg-messages*.properties</include>
                 </includes>

--- a/tests/junit-functional/org/jgroups/tests/VersionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/VersionTest.java
@@ -4,6 +4,11 @@ import org.jgroups.Version;
 import org.jgroups.Global;
 import org.testng.annotations.Test;
 
+import java.util.Properties;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
 /**
  * @author Bela Ban April 4 2003
  * @version $Revision: 1.2 $
@@ -11,33 +16,45 @@ import org.testng.annotations.Test;
 @Test(groups=Global.FUNCTIONAL)
 public class VersionTest {
 
+    public void testIfManifestContainsImplementationVersion() throws Exception {
+        //given
+        Properties properties = new Properties();
+        properties.load(getClass().getResourceAsStream("/jgroups-version.properties"));
 
+        //when
+        String version = properties.getProperty("version");
 
-    public static void testVersionPrint() {
-        System.out.println("version is " +Version.printVersion());
-        assert true;
+        //then
+        assertNotNull(version);
     }
 
+    public void testIfVersionWasExtracted() throws Exception {
+        //when
+        String version = Version.printDescription();
 
-    public static void testNullVersion() {
+        //then
+        assertTrue(version.matches("JGroups [1-9].\\d.\\d.Final"), "Extracted version: " + version);
+    }
+
+    public void testVersionPrint() {
+        assertNotNull(Version.printVersion());
+    }
+
+    public void testNullVersion() {
         assert !(Version.isSame((short)0));
     }
 
-
-    public static void testDifferentLengthVersion1() {
+    public void testDifferentLengthVersion1() {
         short version2=Version.encode(2,0,7);
         assert !(Version.isSame(version2));
     }
 
-
-
-    public static void testDifferentVersion() {
+    public void testDifferentVersion() {
         short version1=Version.encode(2,0,7), version2=Version.encode(2,0,6);
         assert !(version1 == version2);
     }
 
-
-    public static void testSameVersion() {
+    public void testSameVersion() {
         assert match(0,0,1, 0,0,1);
         assert match(1,0,0, 1,0,0);
         assert match(10,2,60, 10,2,60);
@@ -46,9 +63,7 @@ public class VersionTest {
         assert !(match(2, 5, 0, 2, 5, 1));
     }
 
-
-    
-    public static void testBinaryCompatibility() {
+    public void testBinaryCompatibility() {
         assert isBinaryCompatible(0,0,0, 0,0,0);
         assert isBinaryCompatible(1,2,0, 1,2,1);
         assert isBinaryCompatible(1,2,0, 1,2,60);
@@ -56,14 +71,13 @@ public class VersionTest {
         assert !(isBinaryCompatible(2, 5, 0, 2, 6, 0));
     }
 
-
-    private static boolean match(int major_1, int minor_1, int micro_1, int major_2, int minor_2, int micro_2) {
+    private boolean match(int major_1, int minor_1, int micro_1, int major_2, int minor_2, int micro_2) {
         short version1=Version.encode(major_1, minor_1, micro_1);
         short version2=Version.encode(major_2, minor_2, micro_2);
         return version1 == version2;
     }
 
-    private static boolean isBinaryCompatible(int major_1, int minor_1, int micro_1, int major_2, int minor_2, int micro_2) {
+    private boolean isBinaryCompatible(int major_1, int minor_1, int micro_1, int major_2, int minor_2, int micro_2) {
         short version1=Version.encode(major_1, minor_1, micro_1);
         short version2=Version.encode(major_2, minor_2, micro_2);
         boolean retval=Version.isBinaryCompatible(version1, version2);
@@ -71,6 +85,4 @@ public class VersionTest {
         return Version.isBinaryCompatible(version1, version2);
     }
 
-
-   
 }


### PR DESCRIPTION
Hey @belaban !

Please take a look at proposed solution of https://bugzilla.redhat.com/show_bug.cgi?id=1211227.

During JDG development we use our private fork and it is very easy to forget about updating the version. With "automatic" approach we won't have to do it manually.

Could you please double check if I used the correct Classloader? I thought about using the one, which loaded the `Version` class (`manifestAsStream = Version.class.getResourceAsStream("/version.properties");`)

Thanks!