### PR TITLE
JGRP-1930 RELAY2: SiteUUID and regular UUID are bundled by TransferQu…

### DIFF
--- a/src/org/jgroups/protocols/relay/SiteUUID.java
+++ b/src/org/jgroups/protocols/relay/SiteUUID.java
@@ -1,5 +1,6 @@
 package org.jgroups.protocols.relay;
 
+import org.jgroups.Address;
 import org.jgroups.util.AsciiString;
 import org.jgroups.util.ExtendedUUID;
 import org.jgroups.util.UUID;
@@ -57,6 +58,16 @@ public class SiteUUID extends ExtendedUUID implements SiteAddress {
     @Override
     public String toString() {
         return print(false);
+    }
+
+    @Override
+    public int compareTo(Address other) {
+        if (other instanceof SiteUUID) {
+            int siteCompare = Util.compare(get(SITE_NAME), ((SiteUUID) other).get(SITE_NAME));
+            //compareTo will check the bits.
+            return siteCompare == 0 ? super.compareTo(other) : siteCompare;
+        }
+        return super.compareTo(other);
     }
 
     public String print(boolean detailed) {

--- a/src/org/jgroups/util/SingletonAddress.java
+++ b/src/org/jgroups/util/SingletonAddress.java
@@ -1,6 +1,7 @@
 package org.jgroups.util;
 
 import org.jgroups.Address;
+import org.jgroups.protocols.relay.SiteUUID;
 
 import java.io.*;
 
@@ -82,6 +83,12 @@ public class SingletonAddress implements Address {
             return -1;
         if(addr != null && other.addr == null)
             return 1;
+
+        if (addr instanceof SiteUUID && !(other.addr instanceof SiteUUID)) {
+            return 1;
+        } else if (!(addr instanceof SiteUUID) &&  other.addr instanceof SiteUUID) {
+            return -1;
+        }
 
         assert addr != null; // this is here to make the (incorrect) 'addr' NPE warning below disappear !
         return addr.compareTo(other.addr);


### PR DESCRIPTION
…eueBundler

* Make sure that the SingletonAddress makes the distinction between SiteUUID and UUID.

https://issues.jboss.org/browse/JGRP-1930

note: I had to change the SingletonAddress. I couldn't change the compareTo from SiteUUID and UUID to return always different because jgroups was unable to find the physical address. 