### PR TITLE
Fix project description on jboss.org project matrix

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -14,7 +14,7 @@ homePage=http://www.jgroups.org
 
 # Miscellaneous fields
 #######################################################
-description=An application server for Clojure, built on JBoss AS
+description=Java library for reliable group communication
 # ASL, LGPL, LGPL2, LGPL3, EPL, other
 license=other
 # if license is other, fill the URL of the license here


### PR DESCRIPTION
Upon merge and reindex by jgroups, it fixes the description here http://www.jboss.org/projects/ and searching for jgroups and clicking the project logo.