### PR TITLE
Moved to 4.0.0-SNAPSHOT

### DIFF
--- a/conf/VERSION.properties
+++ b/conf/VERSION.properties
@@ -1,4 +1,4 @@
 
 ## Defines the JGroups version
 ## This file should be the *only place* to change when changing the version number
-jgroups.version=3.6.4.Final
+jgroups.version=4.0.0-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>jgroups</artifactId>
     <packaging>bundle</packaging>
     <name>JGroups</name>
-    <version>3.6.4.Final</version>
+    <version>4.0.0-SNAPSHOT</version>
     <url>http://www.jgroups.org</url>
 
     <properties>


### PR DESCRIPTION
Hey @belaban !

Please take a look at proposed changes in versioning.

Release repositories don't accept SNAPSHOTs by default and vice versa - snapshot repositories don't accept releases. Working on SNAPSHOT on daily basis will protect us from releasing artifacts by a mistake. Also this change is needed by CI SNAPSHOT job.

Thanks
Sebastian