### PR TITLE
Fixes FILE_PING discovery method, when filename contains '/' (or '\' …

### DIFF
--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -149,7 +149,8 @@ public class FILE_PING extends Discovery {
 
     protected static String addressToFilename(Address mbr) {
         String logical_name=UUID.get(mbr);
-        return addressAsString(mbr) + (logical_name != null? "." + logical_name + SUFFIX : SUFFIX);
+        return (addressAsString(mbr) + (logical_name != null? "." + logical_name + SUFFIX : SUFFIX))
+            .replace(File.separatorChar, '-');
     }
 
     protected void createRootDir() {


### PR DESCRIPTION
…on windows).

When the addressToFilename() returns a String with '/' (directory separator) FILE_PING discovery method cannot work. I found this issue while trying to use FILE_PING with infinispan server.

I simply replace File.separatorChar() with the character '-' and this fixes the problem. 
