### PR TITLE
JGRP-1909 Use org.jgroups.azure for the protocol ID instead

### DIFF
--- a/conf/jg-protocol-ids.xml
+++ b/conf/jg-protocol-ids.xml
@@ -81,7 +81,7 @@
     <class id="521" name="org.jgroups.protocols.raft.RAFT"        external="true"/>
     <class id="522" name="org.jgroups.protocols.raft.REDIRECT"    external="true"/>
     <class id="523" name="org.jgroups.protocols.raft.CLIENT"      external="true"/>
-    <class id="530" name="org.jgroups.protocols.azure.AZURE_PING" external="true"/>
+    <class id="530" name="org.jgroups.azure.protocols.AZURE_PING" external="true"/>
 
     <!-- User-defined protocols should use IDs > 1000 -->
 


### PR DESCRIPTION
Hi Bela,

The clean approach is that extra projects should actually use org.jgroups.PROJECT package name, so that a repository jgroups-PROJECT contains the relevant classes/files. So e.g. in repo jgroups-azure shoud reside all classes in org.jgroups.azure package.

Cheers,
Rado