### PR TITLE
BZ1247250: Jgroups: null: logical address cache didn't contain all physical address

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -96,7 +96,7 @@ public abstract class TP extends Protocol {
     		description="The interface (NIC) which should be used by this transport", dependsUpon="bind_addr",
             exposeAsManagedAttribute=false)
     protected String bind_interface_str=null;
-    
+
     @Property(description="If true, the transport should use all available interfaces to receive multicast messages")
     protected boolean receive_on_all_interfaces=false;
 
@@ -124,7 +124,7 @@ public abstract class TP extends Protocol {
     @Property(description="The range of valid ports, from bind_port to end_port. 0 only binds to bind_port and fails if taken")
     protected int port_range=50; // 27-6-2003 bgooren, Only try one port by default
 
-  
+
     /**
      * If true, messages sent to self are treated specially: unicast messages are looped back immediately,
      * multicast messages get a local copy first and - when the real copy arrives - it will be discarded. Useful for
@@ -225,7 +225,7 @@ public abstract class TP extends Protocol {
     @Property(description="Switch to enable diagnostic probing. Default is true")
     protected boolean enable_diagnostics=true;
 
-    @Property(description="Address for diagnostic probing. Default is 224.0.75.75", 
+    @Property(description="Address for diagnostic probing. Default is 224.0.75.75",
     		defaultValueIPv4="224.0.75.75",defaultValueIPv6="ff0e::0:75:75")
     protected InetAddress diagnostics_addr=null;
 
@@ -239,7 +239,7 @@ public abstract class TP extends Protocol {
 
     @Property(description="TTL of the diagnostics multicast socket")
     protected int diagnostics_ttl=8;
-    
+
     @Property(description="Authorization passcode for diagnostics. If specified every probe query will be authorized")
     protected String diagnostics_passcode;
 
@@ -301,7 +301,7 @@ public abstract class TP extends Protocol {
     }
 
     public long getMaxBundleTimeout() {return max_bundle_timeout;}
-    
+
 
     @Property(name="max_bundle_timeout", description="Max number of milliseconds until queued messages are sent")
     public void setMaxBundleTimeout(long timeout) {
@@ -484,7 +484,7 @@ public abstract class TP extends Protocol {
 
     //http://jira.jboss.org/jira/browse/JGRP-849
     protected final ReentrantLock connectLock = new ReentrantLock();
-    
+
 
     // ================================== OOB thread pool ========================
     protected Executor oob_thread_pool;
@@ -574,7 +574,7 @@ public abstract class TP extends Protocol {
     /** Log to suppress identical warnings for messages from members in different clusters */
     protected SuppressLog<Address>   suppress_log_different_cluster;
 
-    
+
 
 
 
@@ -747,7 +747,7 @@ public abstract class TP extends Protocol {
 
     public ConcurrentMap<String,Protocol> getUpProtocols() {return up_prots;}
 
-    
+
     @ManagedAttribute(description="Current number of threads in the OOB thread pool")
     public int getOOBPoolSize() {
         return oob_thread_pool instanceof ThreadPoolExecutor? ((ThreadPoolExecutor)oob_thread_pool).getPoolSize() : 0;
@@ -886,7 +886,7 @@ public abstract class TP extends Protocol {
 
         if(default_thread_factory == null)
             default_thread_factory=new DefaultThreadFactory("Incoming", false, true);
-        
+
         if(oob_thread_factory == null)
             oob_thread_factory=new DefaultThreadFactory("OOB", false, true);
 
@@ -967,7 +967,7 @@ public abstract class TP extends Protocol {
             up(new Event(Event.CONFIG, m));
 
         logical_addr_cache=new LazyRemovalCache<Address,PhysicalAddress>(logical_addr_cache_max_size, logical_addr_cache_expiration);
-        
+
         if(logical_addr_cache_reaper == null || logical_addr_cache_reaper.isDone()) {
             if(logical_addr_cache_expiration <= 0)
                 throw new IllegalArgumentException("logical_addr_cache_expiration has to be > 0");
@@ -1058,14 +1058,14 @@ public abstract class TP extends Protocol {
             });
             if(diag_handler_created)
                 diag_handler.start();
-            
+
             for(DiagnosticsHandler.ProbeHandler handler: preregistered_probe_handlers)
                 diag_handler.registerProbeHandler(handler);
             preregistered_probe_handlers.clear();
         }
 
         if(enable_bundling) {
-            if(bundler_type.equals("new")) 
+            if(bundler_type.equals("new"))
                 bundler=new TransferQueueBundler(bundler_capacity);
             else if(bundler_type.equals("new2"))
                 bundler=new TransferQueueBundler2(bundler_capacity);
@@ -1385,8 +1385,8 @@ public abstract class TP extends Protocol {
             synchronized(this) {
                 if(last_discovery_request == 0 || (current_time=System.currentTimeMillis()) - last_discovery_request >= 10000) {
                     last_discovery_request=current_time == 0? System.currentTimeMillis() : current_time;
-                    if(log.isWarnEnabled())
-                        log.warn(local_addr + ": logical address cache didn't contain all physical address, sending up a discovery request");
+                    if(log.isTraceEnabled())
+                        log.trace(local_addr + ": logical address cache didn't contain all physical address, sending up a discovery request");
                     up(new Event(Event.FIND_INITIAL_MBRS));
                 }
             }
@@ -2028,7 +2028,7 @@ public abstract class TP extends Protocol {
                 lock.unlock();
             }
         }
-        
+
 
         /** Run with lock acquired */
         private void addMessage(Message msg) {
@@ -2351,7 +2351,7 @@ public abstract class TP extends Protocol {
         public int getBufferSize() {
             return buffer.size();
         }
-        
+
 
 
         public void run() {
@@ -2578,7 +2578,7 @@ public abstract class TP extends Protocol {
                 case Event.CONNECT:
                 case Event.CONNECT_WITH_STATE_TRANSFER:
                 case Event.CONNECT_USE_FLUSH:
-                case Event.CONNECT_WITH_STATE_TRANSFER_USE_FLUSH:  
+                case Event.CONNECT_WITH_STATE_TRANSFER_USE_FLUSH:
                     cluster_name=(String)evt.getArg();
                     factory.setClusterName(cluster_name);
                     this.header=new TpHeader(cluster_name);
@@ -2587,7 +2587,7 @@ public abstract class TP extends Protocol {
                     Address addr=(Address)evt.getArg();
                     if(addr != null) {
                         local_addr=addr;
-                        factory.setAddress(addr.toString()); // used for thread naming                        
+                        factory.setAddress(addr.toString()); // used for thread naming
                     }
                     break;
             }


### PR DESCRIPTION
Hi Bela,

As discussed over IRC, as a fix for this issue, I've switched notification to trace - which is matching what you end up doing upstream (more/less). Let me know if you feel we should handle this issue differently.