### PR TITLE
Added option to not wrap exceptions with InvocationTargetException

### DIFF
--- a/src/org/jgroups/Global.java
+++ b/src/org/jgroups/Global.java
@@ -105,7 +105,7 @@ public class Global {
     public static final int IPV4_SIZE=4;
     public static final int IPV6_SIZE=16;
 
-
+    public static final String DONT_WRAP_EXCEPTIONS = "jgroups.dont.wrap.exceptions";
 
 
     public static boolean getPropertyAsBoolean(String property, boolean defaultValue) {

--- a/src/org/jgroups/blocks/RequestCorrelator.java
+++ b/src/org/jgroups/blocks/RequestCorrelator.java
@@ -449,6 +449,7 @@ public class RequestCorrelator {
     protected void handleRequest(Message req, Header hdr) {
         Object        retval;
         boolean       threw_exception=false;
+        boolean       wrap_exception=System.getProperty(Global.DONT_WRAP_EXCEPTIONS, "false").equals("false");
 
         if(log.isTraceEnabled()) {
             log.trace(new StringBuilder("calling (").append((request_handler != null? request_handler.getClass().getName() : "null")).
@@ -461,7 +462,7 @@ public class RequestCorrelator {
             }
             catch(Throwable t) {
                 if(rsp != null)
-                    rsp.send(new InvocationTargetException(t), true);
+                    rsp.send(wrap_exception ? new InvocationTargetException(t) : t, true);
                 else
                     log.error(local_addr + ": failed dispatching request asynchronously: " + t);
             }
@@ -473,7 +474,7 @@ public class RequestCorrelator {
         }
         catch(Throwable t) {
             threw_exception=true;
-            retval=new InvocationTargetException(t);
+            retval=wrap_exception ? new InvocationTargetException(t) : t;
         }
         if(hdr.rsp_expected)
             sendReply(req, hdr.id, retval, threw_exception);

--- a/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
@@ -83,6 +83,12 @@ public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
         }
     }
 
+    @Test(expectedExceptions=TimeoutException.class)
+    public void testMethodWithExceptionWithoutWrapping() throws Exception {
+        System.setProperty(Global.DONT_WRAP_EXCEPTIONS, "true");
+        disp.callRemoteMethod(channel.getAddress(),"bar",null,null,RequestOptions.SYNC());
+    }
+
     // @Test(expectedExceptions=IllegalArgumentException.class)
     public void testMethodWithException2() throws Exception {
         try {
@@ -95,6 +101,12 @@ public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
         }
     }
 
+    @Test(expectedExceptions=IllegalArgumentException.class)
+    public void testMethodWithException2WithoutWrapping() throws Exception {
+        System.setProperty(Global.DONT_WRAP_EXCEPTIONS, "true");
+        disp.callRemoteMethod(channel.getAddress(),"foobar",null,null,RequestOptions.SYNC());
+    }
+
     // @Test(expectedExceptions=AssertionError.class)
     public void testMethodWithError() throws Exception {
         try {
@@ -105,6 +117,12 @@ public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
             assert t instanceof InvocationTargetException;
             assert t.getCause() instanceof AssertionError;
         }
+    }
+
+    @Test(expectedExceptions=AssertionError.class)
+    public void testMethodWithErrorWithoutWrapping() throws Exception {
+        System.setProperty(Global.DONT_WRAP_EXCEPTIONS, "true");
+        disp.callRemoteMethod(channel.getAddress(),"foofoobar",null,null,RequestOptions.SYNC());
     }
 
     // @Test(expectedExceptions=Throwable.class)
@@ -120,5 +138,9 @@ public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
     }
 
 
-
+    @Test(expectedExceptions=Throwable.class)
+    public void testMethodWithThrowableWithoutWrapping() throws Exception {
+        System.setProperty(Global.DONT_WRAP_EXCEPTIONS, "true");
+        disp.callRemoteMethod(channel.getAddress(),"fooWithThrowable",null,null,RequestOptions.SYNC());
+    }
 }


### PR DESCRIPTION
Wasn't sure what branch to push this to, I didn't see one with 3.6.7-SNAPSHOT.  So i'll let you guys figure that out.  

I encountered a problem with wrapped exceptions between JDK 6 (Android-18) & JDK 7.   ```RequestCorrelator``` wraps *thrown* exceptions with ```InvocationTargetException```.. which has had the same ```serialVersionUID``` since Java 1.1.  But on JDK 1.7 ```InvocationTargetException extends ReflectiveOperationException``` *(which has a different serialVersionUID)*. Exceptions thrown are serialized and I get an exception because the serialVersionUID doesn't match.

```
java.io.InvalidClassException: java.lang.ReflectiveOperationException; Incompatible class (SUID): java.lang.ReflectiveOperationException: static final long serialVersionUID =123456789L; but expected java.lang.ReflectiveOperationException: static final long serialVersionUID =2505831918131413020L;
at java.io.ObjectInputStream.verifyAndInit(ObjectInputStream.java:2343)
at java.io.ObjectInputStream.readNewClassDesc(ObjectInputStream.java:1643)
at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:657)
at java.io.ObjectInputStream.readNewClassDesc(ObjectInputStream.java:1663)
at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:657)
at java.io.ObjectInputStream.readNewObject(ObjectInputStream.java:1784)
at java.io.ObjectInputStream.readNonPrimitiveContent(ObjectInputStream.java:761)
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:1985)
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:1942)
at org.jgroups.util.Util.objectFromByteBuffer(Util.java:501)
```
```123456789L``` is the ```serialVersionUID``` of ```ReflectionOperationException``` in JDK 7


The default behavior is unchanged.  It is only changed if you set the system property to true.

Returning exceptions is not really an option in my application as there are already return values.  If you can suggest a better solution I'm all ears.  