### PR TITLE
wrap exceptions test wrong setting

### DIFF
--- a/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
@@ -155,7 +155,7 @@ public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
 
     @Test(expectedExceptions=Throwable.class)
     public void testMethodWithThrowableWithoutWrapping() throws Exception {
-        disp.wrapExceptions(true);
+        disp.wrapExceptions(false);
         try {
             disp.callRemoteMethod(channel.getAddress(), "fooWithThrowable", null, null, RequestOptions.SYNC());
         }


### PR DESCRIPTION
One of the RpcDispatcher tests without exception wrapping had the wrong setting. easy fix.