### PR TITLE
Fix regression with ForkChannel

### DIFF
--- a/src/org/jgroups/fork/ForkChannel.java
+++ b/src/org/jgroups/fork/ForkChannel.java
@@ -271,6 +271,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
             if(!create_fork_if_absent)
                 throw new IllegalArgumentException("FORK not found in main stack");
             stack.insertProtocol(fork=new FORK(), position, neighbor);
+            fork.setProtocolStack(stack);
         }
         return fork;
     }

--- a/tests/junit-functional/org/jgroups/tests/ForkChannelTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ForkChannelTest.java
@@ -10,6 +10,7 @@ import org.jgroups.fork.ForkChannel;
 import org.jgroups.fork.ForkProtocolStack;
 import org.jgroups.protocols.COUNTER;
 import org.jgroups.protocols.FORK;
+import org.jgroups.protocols.FRAG2;
 import org.jgroups.protocols.pbcast.STATE;
 import org.jgroups.stack.Protocol;
 import org.jgroups.stack.ProtocolStack;
@@ -43,6 +44,20 @@ public class ForkChannelTest {
     }
 
 
+    @Test
+    public void testCreateForkIfAbsent() throws Exception {
+        JChannel c = new JChannel(Util.getTestStack(new STATE())).name("C");
+
+        ForkChannel fc = new ForkChannel(c,
+                "hijack-stack",
+                "lead-hijacker",
+                true,
+                ProtocolStack.ABOVE,
+                FRAG2.class);
+        assert fc.isOpen() && !fc.isConnected() && !fc.isClosed() : "state=" + fc.getState();
+
+        Util.close(fc, c);
+    }
 
     public void testLifecycle() throws Exception {
         fc1=new ForkChannel(a, "stack", "fc1");


### PR DESCRIPTION
When the ForkChannel constructor is called with create_fork_if_absent as
true a FORK protocol should be created if it does not exist. After
fba4f23282c281873a09256b038f2251829596ba
org.jgroups.protocols.FORK#createForkStack sets the channel from stack
which is never set resulting in an NPE..

channel = new ForkChannel(baseChannel,
                            "hijack-stack",
                            "lead-hijacker",
                            true,
                            ProtocolStack.ABOVE,
                            FRAG2.class);

Caused by: java.lang.NullPointerException
	at org.jgroups.protocols.FORK.createForkStack(FORK.java:199)
	at org.jgroups.fork.ForkChannel.<init>(ForkChannel.java:79)

