### PR TITLE
Fully initialise FORK protocol before adding it to the stack.

### DIFF
--- a/src/org/jgroups/fork/ForkChannel.java
+++ b/src/org/jgroups/fork/ForkChannel.java
@@ -270,8 +270,9 @@ public class ForkChannel extends JChannel implements ChannelListener {
         if(fork == null) {
             if(!create_fork_if_absent)
                 throw new IllegalArgumentException("FORK not found in main stack");
-            stack.insertProtocol(fork=new FORK(), position, neighbor);
+            fork = new FORK();
             fork.setProtocolStack(stack);
+            stack.insertProtocol(fork, position, neighbor);
         }
         return fork;
     }


### PR DESCRIPTION
Whilst it may not be an issue now since there is a sync block on the main channel around getFORK I think it is better to make this thread safe now instead of trying to catch a race condition later.