### PR TITLE
Fixed typo when checking views in GMS_MergeTest._testSimpleMerge()

### DIFF
--- a/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
@@ -155,7 +155,7 @@ public class GMS_MergeTest {
             checkViews(channels, "A", "A", "B");
             checkViews(channels, "B", "A", "B");
             checkViews(channels, "C", "C", "D");
-            checkViews(channels, "C", "C", "D");
+            checkViews(channels, "D", "C", "D");
 
             System.out.println("\ndigests:");
             printDigests(channels);


### PR DESCRIPTION
Hi Bela, minor fix to a GMS unit test