### PR TITLE
JGRP-1992 GOOGLE_PING discovery fails if port 443 isn't used

### DIFF
--- a/src/org/jgroups/protocols/GOOGLE_PING.java
+++ b/src/org/jgroups/protocols/GOOGLE_PING.java
@@ -17,8 +17,9 @@ public class GOOGLE_PING extends S3_PING {
     }
 
     protected AWSAuthConnection createConnection() {
+       // Fix for JGRP-1992. Always use secure port, if port is not specified
         return port > 0? new AWSAuthConnection(access_key, secret_access_key, use_ssl, host, port)
-          : new AWSAuthConnection(access_key, secret_access_key, use_ssl, host, Utils.INSECURE_PORT);
+          : new AWSAuthConnection(access_key, secret_access_key, use_ssl, host, Utils.SECURE_PORT);
     }
 }
 


### PR DESCRIPTION
Change GOOGLE_PING to use port 443 when creating a connection and no
port is specified in the configuration.