### PR TITLE
squid:S2786 - Nested enums should not be declared static

### DIFF
--- a/src/org/jgroups/blocks/MemcachedConnector.java
+++ b/src/org/jgroups/blocks/MemcachedConnector.java
@@ -359,7 +359,7 @@ public class MemcachedConnector implements Runnable {
 
 
     public static class Request {
-        public static enum Type {SET, ADD, REPLACE, PREPEND, APPEND, CAS, INCR, DECR, GET, GETS, DELETE, STAT, STATS};
+        public enum Type {SET, ADD, REPLACE, PREPEND, APPEND, CAS, INCR, DECR, GET, GETS, DELETE, STAT, STATS};
 
         Type type;
         String key;

--- a/src/org/jgroups/demos/StompChat.java
+++ b/src/org/jgroups/demos/StompChat.java
@@ -31,7 +31,7 @@ public class StompChat implements StompConnection.Listener {
     private final Set<String>      clients=new HashSet<>();
     protected StompConnection      stomp_client;
 
-    static enum Destination {
+    enum Destination {
         messages("/messages"),
         client_joined("/client-joined");
 

--- a/src/org/jgroups/protocols/ABP.java
+++ b/src/org/jgroups/protocols/ABP.java
@@ -105,7 +105,7 @@ public class ABP extends Protocol {
         return entry;
     }
 
-    protected static enum Type {data, ack};
+    protected enum Type {data, ack};
 
     protected class Entry implements Runnable {
         protected byte                         bit=0;

--- a/src/org/jgroups/protocols/COUNTER.java
+++ b/src/org/jgroups/protocols/COUNTER.java
@@ -64,7 +64,7 @@ public class COUNTER extends Protocol {
     protected static final byte RESPONSE = 2;
     
 
-    protected static enum RequestType {
+    protected enum RequestType {
         GET_OR_CREATE,
         DELETE,
         SET,
@@ -75,7 +75,7 @@ public class COUNTER extends Protocol {
         RESEND_PENDING_REQUESTS
     }
 
-    protected static enum ResponseType {
+    protected enum ResponseType {
         VOID,
         GET_OR_CREATE,
         BOOLEAN,

--- a/src/org/jgroups/protocols/DUPL.java
+++ b/src/org/jgroups/protocols/DUPL.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @author Bela Ban
  */
 public class DUPL extends Protocol {
-    protected static enum Direction {UP,DOWN};
+    protected enum Direction {UP,DOWN};
 
     @Property(description="Number of copies of each incoming message (0=no copies)")
     protected int incoming_copies=1;

--- a/src/org/jgroups/protocols/Executing.java
+++ b/src/org/jgroups/protocols/Executing.java
@@ -121,7 +121,7 @@ abstract public class Executing extends Protocol {
      */
     protected Queue<Owner> _consumersAvailable = new ArrayDeque<>();
     
-    protected static enum Type {
+    protected enum Type {
         RUN_REQUEST,            // request to coordinator from client to tell of a new task request
         CONSUMER_READY,         // request to coordinator from server to tell of a new consumer ready
         CONSUMER_UNREADY,       // request to coordinator from server to tell of a consumer stopping

--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -66,7 +66,7 @@ abstract public class Locking extends Protocol {
     
 
 
-    protected static enum Type {
+    protected enum Type {
         GRANT_LOCK,        // request to acquire a lock
         LOCK_GRANTED,      // response to sender of GRANT_LOCK on succcessful lock acquisition
         LOCK_DENIED,       // response to sender of GRANT_LOCK on unsuccessful lock acquisition (e.g. on tryLock())

--- a/src/org/jgroups/protocols/MERGE3.java
+++ b/src/org/jgroups/protocols/MERGE3.java
@@ -576,6 +576,6 @@ public class MERGE3 extends Protocol {
             return sb.toString();
         }
 
-        protected static enum Type {INFO, VIEW_REQ, VIEW_RSP}
+        protected enum Type {INFO, VIEW_REQ, VIEW_RSP}
     }
 }

--- a/src/org/jgroups/protocols/RELAY.java
+++ b/src/org/jgroups/protocols/RELAY.java
@@ -622,7 +622,7 @@ public class RELAY extends Protocol {
 
 
     public static class RelayHeader extends Header {
-        public static enum Type {DISSEMINATE, FORWARD, VIEW, BROADCAST_VIEW};
+        public enum Type {DISSEMINATE, FORWARD, VIEW, BROADCAST_VIEW};
         protected Type                type;
         protected Address             original_sender; // with DISSEMINATE
 

--- a/src/org/jgroups/protocols/STOMP.java
+++ b/src/org/jgroups/protocols/STOMP.java
@@ -82,8 +82,8 @@ public class STOMP extends Protocol implements Runnable {
     // Subscriptions and connections which are subscribed
     protected final ConcurrentMap<String,Set<Connection>> subscriptions=Util.createConcurrentMap(20);
 
-    public static enum ClientVerb      {CONNECT, SEND, SUBSCRIBE, UNSUBSCRIBE, BEGIN, COMMIT, ABORT, ACK, DISCONNECT}
-    public static enum ServerVerb      {MESSAGE, RECEIPT, ERROR, CONNECTED, INFO}
+    public enum ClientVerb      {CONNECT, SEND, SUBSCRIBE, UNSUBSCRIBE, BEGIN, COMMIT, ABORT, ACK, DISCONNECT}
+    public enum ServerVerb      {MESSAGE, RECEIPT, ERROR, CONNECTED, INFO}
 
     public static final byte           NULL_BYTE=0;
 
@@ -613,7 +613,7 @@ public class STOMP extends Protocol implements Runnable {
 
 
     public static class StompHeader extends org.jgroups.Header {
-        public static enum Type {MESSAGE, ENDPOINT}
+        public enum Type {MESSAGE, ENDPOINT}
 
         protected Type                      type;
         protected final Map<String,String>  headers=new HashMap<>();

--- a/src/org/jgroups/protocols/SWIFT_PING.java
+++ b/src/org/jgroups/protocols/SWIFT_PING.java
@@ -190,7 +190,7 @@ public class SWIFT_PING extends FILE_PING {
     /**
      * Supported Swift authentication providers
      */
-    private static enum AUTH_TYPE {
+    private enum AUTH_TYPE {
 
         KEYSTONE_V_2_0("keystone_v_2_0");
 

--- a/src/org/jgroups/protocols/tom/StatsCollector.java
+++ b/src/org/jgroups/protocols/tom/StatsCollector.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class StatsCollector {
 
-    private static enum Counter {
+    private enum Counter {
         PROPOSE_MESSAGE_RECEIVED,
         LAST_PROPOSE_MESSAGE_RECEIVED,
         FINAL_MESSAGE_RECEIVED,
@@ -22,7 +22,7 @@ public class StatsCollector {
         UNICAST_MESSAGE_SENT
     }
 
-    private static enum Duration {
+    private enum Duration {
         PROPOSE_MESSAGE,
         LAST_PROPOSE_MESSAGE,
         FINAL_MESSAGE,

--- a/src/org/jgroups/util/SuppressLog.java
+++ b/src/org/jgroups/util/SuppressLog.java
@@ -13,7 +13,7 @@ public class SuppressLog<T> {
     protected final String           message_format;
     protected final String           suppress_format;
 
-    public static enum Level {error,warn,trace};
+    public enum Level {error,warn,trace};
 
     public SuppressLog(Log log, String message_key, String suppress_msg) {
         this.log=log;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2786 - Nested "enum"s should not be declared static
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2786
Please let me know if you have any questions.
M-Ezzat