### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/org/jgroups/Global.java
+++ b/src/org/jgroups/Global.java
@@ -9,7 +9,7 @@ import org.jgroups.protocols.SCOPE;
  * @since 2.0
  * @author Bela Ban 
  */
-public class Global {
+public final class Global {
     public static final int BYTE_SIZE   = Byte.SIZE    / 8; // 1
     public static final int SHORT_SIZE  = Short.SIZE   / 8; // 2
     public static final int INT_SIZE    = Integer.SIZE / 8; // 4
@@ -107,6 +107,9 @@ public class Global {
     public static final int IPV4_SIZE=4;
     public static final int IPV6_SIZE=16;
 
+	private Global() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     public static boolean getPropertyAsBoolean(String property, boolean defaultValue) {
         boolean result = defaultValue;

--- a/src/org/jgroups/auth/sasl/SecurityActions.java
+++ b/src/org/jgroups/auth/sasl/SecurityActions.java
@@ -14,6 +14,11 @@ import java.util.Properties;
  * @since 3.6
  */
 final class SecurityActions {
+	
+	private SecurityActions() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
+
    private static <T> T doPrivileged(PrivilegedAction<T> action) {
       if (System.getSecurityManager() != null) {
          return AccessController.doPrivileged(action);

--- a/src/org/jgroups/blocks/executor/Executions.java
+++ b/src/org/jgroups/blocks/executor/Executions.java
@@ -11,7 +11,12 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
-public class Executions {
+public final class Executions {
+	
+	private Executions() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
+
     /**
      * This method should be used to convert a callable that would not normally
      * be serializable, externalizable or streamable but has serializable,

--- a/src/org/jgroups/conf/PropertyConverters.java
+++ b/src/org/jgroups/conf/PropertyConverters.java
@@ -28,7 +28,11 @@ import java.util.concurrent.Callable;
  *
  * @author Vladimir Blagojevic
  */
-public class PropertyConverters {
+public final class PropertyConverters {
+
+	private PropertyConverters() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     public static class NetworkInterfaceList implements PropertyConverter {
 

--- a/src/org/jgroups/conf/PropertyHelper.java
+++ b/src/org/jgroups/conf/PropertyHelper.java
@@ -14,10 +14,14 @@ import java.util.Map;
     /*
      * A class of static methods for performing commonly used functions with @Property annotations.
      */
-    public class PropertyHelper {
+    public final class PropertyHelper {
     	
         protected static final Log log=LogFactory.getLog(PropertyHelper.class);
     	
+    	private PropertyHelper() {
+    		throw new InstantiationError( "Must not instantiate this class" );
+    	}
+
     	public static String getPropertyName(Field field, Map<String,String> props) throws IllegalArgumentException {
     		if (field == null) {
     			throw new IllegalArgumentException("Cannot get property name: field is null") ;

--- a/src/org/jgroups/demos/KeyStoreGenerator.java
+++ b/src/org/jgroups/demos/KeyStoreGenerator.java
@@ -30,13 +30,17 @@ import javax.crypto.SecretKey;
  * @author S Woodcock
  * 
  */
-public class KeyStoreGenerator {
+public final class KeyStoreGenerator {
 
     static String symAlg="AES";
     static int keySize=128;
     static String keyStoreName="defaultStore.keystore";
     static String storePass="changeit";
     static String alias="myKey";
+
+	private KeyStoreGenerator() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     public static void main(String[] args) {
 

--- a/src/org/jgroups/fork/ForkConfig.java
+++ b/src/org/jgroups/fork/ForkConfig.java
@@ -17,11 +17,14 @@ import java.util.Map;
  * @author Bela Ban
  * @since  3.4
  */
-public class ForkConfig {
+public final class ForkConfig {
     protected static final String FORK_STACKS   = "fork-stacks";
     protected static final String FORK_STACK    = "fork-stack";
     protected static final String ID            = "id";
 
+	private ForkConfig() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     /**
      * Parses the input and returns a map of fork-stack IDs and lists of ProtocolConfigurations

--- a/src/org/jgroups/jmx/JmxConfigurator.java
+++ b/src/org/jgroups/jmx/JmxConfigurator.java
@@ -11,14 +11,19 @@ import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 
 import javax.management.*;
+
 import java.util.List;
 import java.util.Set;
 
 /**
  * @author Bela Ban, Vladimir Blagojevic
  */
-public class JmxConfigurator {
+public final class JmxConfigurator {
     static final Log log = LogFactory.getLog(JmxConfigurator.class);
+
+	private JmxConfigurator() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     /**
      * Registers an already created channel with the given MBeanServer. Wraps instance of JChannel

--- a/src/org/jgroups/logging/LogFactory.java
+++ b/src/org/jgroups/logging/LogFactory.java
@@ -10,12 +10,15 @@ import org.jgroups.Global;
  * @author Bela Ban
  * @since 4.0
  */
-public class LogFactory {
+public final class LogFactory {
     public static final boolean    IS_LOG4J2_AVAILABLE; // log4j2 is the default
     protected static final boolean USE_JDK_LOGGER;
 
     protected static CustomLogFactory custom_log_factory;
 
+	private LogFactory() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     static {
         String customLogFactoryClass=System.getProperty(Global.CUSTOM_LOG_FACTORY);

--- a/src/org/jgroups/protocols/relay/config/RelayConfig.java
+++ b/src/org/jgroups/protocols/relay/config/RelayConfig.java
@@ -15,7 +15,7 @@ import java.util.*;
  * @author Bela Ban
  * @since 3.2
  */
-public class RelayConfig {
+public final class RelayConfig {
     protected static final String RELAY_CONFIG  = "RelayConfiguration";
     protected static final String SITES         = "sites";
     protected static final String SITE          = "site";
@@ -24,6 +24,9 @@ public class RelayConfig {
     protected static final String FORWARDS      = "forwards";
     protected static final String FORWARD       = "forward";
     
+	private RelayConfig() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 
     /*public String toString() {

--- a/src/org/jgroups/util/Bits.java
+++ b/src/org/jgroups/util/Bits.java
@@ -32,8 +32,11 @@ import java.nio.ByteBuffer;
  * @author Sanne Grinovero
  * @since  3.5
  */
-public class Bits {
+public final class Bits {
 
+	private Bits() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     // -------------------- char ------------------------ //
 

--- a/src/org/jgroups/util/Headers.java
+++ b/src/org/jgroups/util/Headers.java
@@ -24,8 +24,12 @@ import java.util.Map;
  * This class is synchronized for writes (put(), resize()), but not for reads (size(), get())
  * @author Bela Ban
  */
-public class Headers {
+public final class Headers {
     private static final int RESIZE_INCR=3;
+
+	private Headers() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     /**
      * Returns the header associated with an ID


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
M-Ezzat