### PR TITLE
squid:S00118 - Abstract class names should comply with a naming convention

### DIFF
--- a/conf/jg-magic-map.xml
+++ b/conf/jg-magic-map.xml
@@ -29,7 +29,7 @@
     <class id="61"  name="org.jgroups.protocols.FD_ALL$HeartbeatHeader"/>
     <class id="62"  name="org.jgroups.protocols.FD_ALL2$HeartbeatHeader"/>
     <class id="64"  name="org.jgroups.protocols.pbcast.FLUSH$FlushHeader"/>
-    <class id="65"  name="org.jgroups.protocols.pbcast.StreamingStateTransfer$StateHeader"/>
+    <class id="65"  name="org.jgroups.protocols.pbcast.AbstractStreamingStateTransfer$StateHeader"/>
     <class id="67"  name="org.jgroups.protocols.AuthHeader"/>
     <class id="68"  name="org.jgroups.util.UUID"/>
     <class id="71"  name="org.jgroups.blocks.RequestCorrelator$Header"/>
@@ -41,12 +41,12 @@
     <class id="77"  name="org.jgroups.protocols.RELAY$RelayHeader"/>
     <class id="78"  name="org.jgroups.protocols.STOMP$StompHeader"/>
     <class id="80"  name="org.jgroups.protocols.PrioHeader"/>
-    <class id="81"  name="org.jgroups.protocols.Locking$LockingHeader"/>
+    <class id="81"  name="org.jgroups.protocols.AbstractLocking$LockingHeader"/>
     <class id="82"  name="org.jgroups.util.PayloadUUID"/>
     <class id="83"  name="org.jgroups.util.AdditionalDataUUID"/>
     <class id="84"  name="org.jgroups.util.TopologyUUID"/>
-    <class id="85"  name="org.jgroups.protocols.Executing$ExecutorHeader"/>
-    <class id="86"  name="org.jgroups.protocols.Executing$Request"/>
+    <class id="85"  name="org.jgroups.protocols.AbstractExecuting$ExecutorHeader"/>
+    <class id="86"  name="org.jgroups.protocols.AbstractExecuting$Request"/>
     <class id="87"  name="org.jgroups.blocks.executor.ExecutionService$RunnableAdapter"/>
     <class id="88"  name="org.jgroups.blocks.executor.Executions$StreamableCallable"/>
     <class id="89"  name="org.jgroups.protocols.COUNTER$CounterHeader"/>

--- a/src/org/jgroups/AbstractChannel.java
+++ b/src/org/jgroups/AbstractChannel.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.DefaultSocketFactory;
 import org.jgroups.util.SocketFactory;
@@ -54,7 +54,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * @see JChannel
  */
 @MBean(description="Channel")
-public abstract class Channel implements Closeable {
+public abstract class AbstractChannel implements Closeable {
 
     public enum State {
         OPEN,       // initial state, after channel has been created, or after a disconnect()
@@ -88,7 +88,7 @@ public abstract class Channel implements Closeable {
     public void setSocketFactory(SocketFactory factory) {
         socket_factory=factory;
         ProtocolStack stack=getProtocolStack();
-        Protocol prot=stack != null? stack.getTopProtocol() : null;
+        AbstractProtocol prot=stack != null? stack.getTopProtocol() : null;
         if(prot != null)
             prot.setSocketFactory(factory);
     }
@@ -171,7 +171,7 @@ public abstract class Channel implements Closeable {
    @ManagedAttribute public boolean isConnected()  {return state == State.CONNECTED;}
 
     /**
-     * Determines whether the channel is in the connecting state; this means {@link Channel#connect(String)} has been
+     * Determines whether the channel is in the connecting state; this means {@link AbstractChannel#connect(String)} has been
      * called, but hasn't returned yet
      * @return true if the channel is in the connecting state, false otherwise
      */
@@ -317,7 +317,7 @@ public abstract class Channel implements Closeable {
     abstract public void setName(String name);
 
     /** Names a channel, same as {@link #setName(String)} */
-    abstract public Channel name(String name);
+    abstract public AbstractChannel name(String name);
 
 
    /**
@@ -402,7 +402,7 @@ public abstract class Channel implements Closeable {
 
    /**
     * Returns a receiver for this channel if it has been installed using
-    * {@link Channel#setReceiver(Receiver)} , null otherwise
+    * {@link AbstractChannel#setReceiver(Receiver)} , null otherwise
     * 
     * @return a receiver installed on this channel
     */
@@ -440,7 +440,7 @@ public abstract class Channel implements Closeable {
     * @param automatic_resume
     *           if true call {@link #stopFlush()} after the flush
     * @see #startFlush(boolean)
-    * @see Util#startFlush(Channel, List, int, long, long)
+    * @see Util#startFlush(AbstractChannel, List, int, long, long)
     */
     abstract public void startFlush(List<Address> flushParticipants, boolean automatic_resume)
                 throws Exception;
@@ -458,7 +458,7 @@ public abstract class Channel implements Closeable {
     * @param automatic_resume
     *           if true call {@link #stopFlush()} after the flush
     *
-    * @see Util#startFlush(Channel, List, int, long, long)
+    * @see Util#startFlush(AbstractChannel, List, int, long, long)
     */
     abstract public void startFlush(boolean automatic_resume) throws Exception;
     
@@ -466,8 +466,8 @@ public abstract class Channel implements Closeable {
     * Stops the current flush of the cluster. Cluster members are unblocked and allowed to send new
     * and pending messages.
     *
-    * @see Channel#startFlush(boolean)
-    * @see Channel#startFlush(List, boolean)
+    * @see AbstractChannel#startFlush(boolean)
+    * @see AbstractChannel#startFlush(List, boolean)
     */
    abstract public void stopFlush();
     
@@ -514,7 +514,7 @@ public abstract class Channel implements Closeable {
 
 
 
-    protected void notifyChannelConnected(Channel c) {
+    protected void notifyChannelConnected(AbstractChannel c) {
         if(channel_listeners == null) return;
         for(ChannelListener channelListener: channel_listeners) {
             try {
@@ -526,7 +526,7 @@ public abstract class Channel implements Closeable {
         }
     }
 
-    protected void notifyChannelDisconnected(Channel c) {
+    protected void notifyChannelDisconnected(AbstractChannel c) {
         if(channel_listeners == null) return;
         for(ChannelListener channelListener: channel_listeners) {
             try {
@@ -538,7 +538,7 @@ public abstract class Channel implements Closeable {
         }
     }
 
-    protected void notifyChannelClosed(Channel c) {
+    protected void notifyChannelClosed(AbstractChannel c) {
         if(channel_listeners == null) return;
         for(ChannelListener channelListener: channel_listeners) {
             try {

--- a/src/org/jgroups/AbstractHeader.java
+++ b/src/org/jgroups/AbstractHeader.java
@@ -10,12 +10,12 @@ import org.jgroups.util.Streamable;
  * @author Bela Ban
  * @since 2.0
  */
-public abstract class Header implements Streamable {
-    /** The ID of the protocol which added a header to a message. Set externally, e.g. by {@link Message#putHeader(short,Header)} */
+public abstract class AbstractHeader implements Streamable {
+    /** The ID of the protocol which added a header to a message. Set externally, e.g. by {@link Message#putHeader(short, AbstractHeader)} */
     protected short prot_id;
 
     public short  getProtId()         {return prot_id;}
-    public Header setProtId(short id) {this.prot_id=id; return this;}
+    public AbstractHeader setProtId(short id) {this.prot_id=id; return this;}
 
 
     /**

--- a/src/org/jgroups/ChannelListener.java
+++ b/src/org/jgroups/ChannelListener.java
@@ -10,9 +10,9 @@ package org.jgroups;
  * by JGroups building block installed on top of a channel (RpcDispatcher etc) while a client needs
  * to be notified about major channel lifecycle events.
  * 
- * @see Channel#addChannelListener(ChannelListener)
- * @see Channel#removeChannelListener(ChannelListener)
- * @see Channel#clearChannelListeners()
+ * @see AbstractChannel#addChannelListener(ChannelListener)
+ * @see AbstractChannel#removeChannelListener(ChannelListener)
+ * @see AbstractChannel#clearChannelListeners()
  * 
  * @author Bela Ban
  * @since 2.0
@@ -25,19 +25,19 @@ public interface ChannelListener {
     * 
     * @param channel the channel that has been connected
     */
-   void channelConnected(Channel channel);
+   void channelConnected(AbstractChannel channel);
 
    /**
     * Channel has been disconnected notification callback
     * 
     * @param channel the disconnected channel
     */
-   void channelDisconnected(Channel channel);
+   void channelDisconnected(AbstractChannel channel);
 
    /**
     * Channel has been closed notification callback
     * 
     * @param channel the closed channel
     */
-   void channelClosed(Channel channel);
+   void channelClosed(AbstractChannel channel);
 }

--- a/src/org/jgroups/JChannel.java
+++ b/src/org/jgroups/JChannel.java
@@ -8,7 +8,7 @@ import org.jgroups.conf.ConfiguratorFactory;
 import org.jgroups.conf.ProtocolConfiguration;
 import org.jgroups.conf.ProtocolStackConfigurator;
 import org.jgroups.jmx.ResourceDMBean;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.stack.*;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since 2.0
  */
 @MBean(description="JGroups channel")
-public class JChannel extends Channel {
+public class JChannel extends AbstractChannel {
 
     /** The default protocol stack used by the default constructor  */
     public static final String                      DEFAULT_PROTOCOL_STACK="udp.xml";
@@ -168,7 +168,7 @@ public class JChannel extends Channel {
      *                  the last the top protocol
      * @throws Exception
      */
-    public JChannel(Protocol ... protocols) throws Exception {
+    public JChannel(AbstractProtocol... protocols) throws Exception {
         this(Arrays.asList(protocols));
     }
 
@@ -180,19 +180,19 @@ public class JChannel extends Channel {
      *                  the last the top protocol
      * @throws Exception
      */
-    public JChannel(Collection<Protocol> protocols) throws Exception {
+    public JChannel(Collection<AbstractProtocol> protocols) throws Exception {
         prot_stack=new ProtocolStack();
         setProtocolStack(prot_stack);
-        for(Protocol prot: protocols) {
+        for(AbstractProtocol prot: protocols) {
             prot_stack.addProtocol(prot);
             prot.setProtocolStack(prot_stack);
         }
         prot_stack.init();
 
         // Substitute vars with defined system props (if any)
-        List<Protocol> prots=prot_stack.getProtocols();
+        List<AbstractProtocol> prots=prot_stack.getProtocols();
         Map<String,String> map=new HashMap<>();
-        for(Protocol prot: prots)
+        for(AbstractProtocol prot: prots)
             Configurator.resolveAndAssignFields(prot, map);
     }
 
@@ -894,7 +894,7 @@ public class JChannel extends Channel {
         t.add(local_addr);
         my_view=new View(local_addr, 0, t);  // create a dummy view
 
-        TP transport=prot_stack.getTransport();
+        AbstractTP transport=prot_stack.getTransport();
         transport.registerProbeHandler(probe_handler);
     }
 
@@ -1008,7 +1008,7 @@ public class JChannel extends Channel {
                 log.error(Util.getMessage("StackDestroyFailure"), e);
             }
 
-            TP transport=prot_stack.getTransport();
+            AbstractTP transport=prot_stack.getTransport();
             if(transport != null)
                 transport.unregisterProbeHandler(probe_handler);
         }
@@ -1076,7 +1076,7 @@ public class JChannel extends Channel {
 
     protected TimeScheduler getTimer() {
         if(prot_stack != null) {
-            TP transport=prot_stack.getTransport();
+            AbstractTP transport=prot_stack.getTransport();
             if(transport != null)
                 return transport.getTimer();
         }
@@ -1128,8 +1128,8 @@ public class JChannel extends Channel {
         }
 
         protected void resetAllStats() {
-            List<Protocol> prots=getProtocolStack().getProtocols();
-            for(Protocol prot: prots)
+            List<AbstractProtocol> prots=getProtocolStack().getProtocols();
+            for(AbstractProtocol prot: prots)
                 prot.resetStatistics();
             resetStats();
         }
@@ -1154,7 +1154,7 @@ public class JChannel extends Channel {
                         if(index != -1) {
                             String attrname=tmp.substring(0, index);
                             String attrvalue=tmp.substring(index+1);
-                            Protocol prot=prot_stack.findProtocol(protocol_name);
+                            AbstractProtocol prot=prot_stack.findProtocol(protocol_name);
                             Field field=prot != null? Util.getField(prot.getClass(), attrname) : null;
                             if(field != null) {
                                 Object value=MethodCall.convert(attrvalue,field.getType());
@@ -1216,7 +1216,7 @@ public class JChannel extends Channel {
             if(index == -1)
                 throw new IllegalArgumentException("operation " + operation + " is missing the protocol name");
             String prot_name=operation.substring(0, index);
-            Protocol prot=prot_stack.findProtocol(prot_name);
+            AbstractProtocol prot=prot_stack.findProtocol(prot_name);
             if(prot == null)
                 return; // less drastic than throwing an exception...
 

--- a/src/org/jgroups/MembershipListener.java
+++ b/src/org/jgroups/MembershipListener.java
@@ -25,7 +25,7 @@ public interface MembershipListener {
     * needs to be performed, it should be done in a separate thread.
     * <p/>
     * Note that on reception of the first view (a new member just joined), the channel will not yet
-    * be in the connected state. This only happens when {@link Channel#connect(String)} returns.
+    * be in the connected state. This only happens when {@link AbstractChannel#connect(String)} returns.
     */
     void viewAccepted(View new_view);
     

--- a/src/org/jgroups/Receiver.java
+++ b/src/org/jgroups/Receiver.java
@@ -3,7 +3,7 @@ package org.jgroups;
 /**
  * Defines the callbacks that are invoked when messages, views etc are received on a channel
  * 
- * @see Channel#setReceiver(Receiver)
+ * @see AbstractChannel#setReceiver(Receiver)
  * @since 2.0
  * @author Bela Ban
  */

--- a/src/org/jgroups/auth/AbstractAuthToken.java
+++ b/src/org/jgroups/auth/AbstractAuthToken.java
@@ -12,7 +12,7 @@ import org.jgroups.util.Streamable;
  * @author Chris Mills
  * @author Bela Ban
  */
-public abstract class AuthToken implements Streamable {
+public abstract class AbstractAuthToken implements Streamable {
     protected final Log log = LogFactory.getLog(this.getClass());
 
     /** A reference to AUTH */
@@ -49,5 +49,5 @@ public abstract class AuthToken implements Streamable {
      *            the Message object containing the actual JOIN_REQ
      * @return true if authenticaion passed or false if it failed.
      */
-    public abstract boolean authenticate(AuthToken token, Message msg);
+    public abstract boolean authenticate(AbstractAuthToken token, Message msg);
 }

--- a/src/org/jgroups/auth/DemoToken.java
+++ b/src/org/jgroups/auth/DemoToken.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  * @since  3.3
  */
-public class DemoToken extends AuthToken implements AUTH.UpHandler {
+public class DemoToken extends AbstractAuthToken implements AUTH.UpHandler {
     protected static final short ID=1555; // the ID to fetch a DemoHeader from a message
 
     @Property(description="How long to wait (in ms) for a response to a challenge")
@@ -38,7 +38,7 @@ public class DemoToken extends AuthToken implements AUTH.UpHandler {
     public void   init()    {auth.register(this);}
 
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         Address sender=msg.getSrc();
 
         // 1. send a challenge to the sender
@@ -141,7 +141,7 @@ public class DemoToken extends AuthToken implements AUTH.UpHandler {
     }
 
 
-    public static class DemoHeader extends Header {
+    public static class DemoHeader extends AbstractHeader {
         protected static final byte CHALLENGE = 1;
         protected static final byte RESPONSE  = 2;
 

--- a/src/org/jgroups/auth/FixedMembershipToken.java
+++ b/src/org/jgroups/auth/FixedMembershipToken.java
@@ -32,7 +32,7 @@ import java.util.StringTokenizer;
  * 
  * @author Chris Mills (millsy@jboss.com)
  */
-public class FixedMembershipToken extends AuthToken {
+public class FixedMembershipToken extends AbstractAuthToken {
     private final List<InetSocketAddress> memberList = new ArrayList<>();
     private String                        token = "emptyToken";
 
@@ -63,7 +63,7 @@ public class FixedMembershipToken extends AuthToken {
             throw new IllegalStateException("own physical address " + self + " is not in members (" + memberList + ")");
     } */
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         if ((token != null) && (token instanceof FixedMembershipToken) && (this.memberList != null)) {
             PhysicalAddress src = (PhysicalAddress) auth.down(new Event(Event.GET_PHYSICAL_ADDRESS, msg.getSrc()));
             if (src == null) {

--- a/src/org/jgroups/auth/Krb5Token.java
+++ b/src/org/jgroups/auth/Krb5Token.java
@@ -20,7 +20,7 @@ import java.util.Properties;
  * @since 3.4
  */
 @Experimental
-public class Krb5Token extends AuthToken {
+public class Krb5Token extends AbstractAuthToken {
     private static final String JASS_SECURITY_CONFIG   = "JGoupsKrb5TokenSecurityConf";
     public  static final String CLIENT_PRINCIPAL_NAME  = "client_principal_name";
     public  static final String CLIENT_PASSWORD        = "client_password";
@@ -72,7 +72,7 @@ public class Krb5Token extends AuthToken {
         return Krb5Token.class.getName();
     }
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         if (!isAuthenticated()) {
             log.error(Util.getMessage("Krb5TokenFailedToSetupCorrectlyCannotAuthenticateAnyPeers"));
             return false;

--- a/src/org/jgroups/auth/MD5Token.java
+++ b/src/org/jgroups/auth/MD5Token.java
@@ -22,10 +22,10 @@ import java.io.DataOutput;
  * <li>auth_value (required) = the string to encrypt</li>
  * </ul>
  * 
- * @see org.jgroups.auth.AuthToken
+ * @see AbstractAuthToken
  * @author Chris Mills
  */
-public class MD5Token extends AuthToken {
+public class MD5Token extends AbstractAuthToken {
 
     @Property(exposeAsManagedAttribute=false)
     private String auth_value = null;
@@ -91,7 +91,7 @@ public class MD5Token extends AuthToken {
         return hashedToken;
     }
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
 
         if ((token != null) && (token instanceof MD5Token)) {
             // Found a valid Token to authenticate against

--- a/src/org/jgroups/auth/RegexMembership.java
+++ b/src/org/jgroups/auth/RegexMembership.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  * pattern matching
  * @author Bela Ban
  */
-public class RegexMembership extends AuthToken {
+public class RegexMembership extends AbstractAuthToken {
 
     @Property(description="The regular expression against which the IP address or logical host of a joiner will be matched")
     protected String  match_string=null;
@@ -54,7 +54,7 @@ public class RegexMembership extends AuthToken {
     }
 
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         Address sender=msg.getSrc();
 
 

--- a/src/org/jgroups/auth/SimpleToken.java
+++ b/src/org/jgroups/auth/SimpleToken.java
@@ -21,9 +21,9 @@ import java.io.DataOutput;
  * </ul>
  * 
  * @author Chris Mills
- * @see org.jgroups.auth.AuthToken
+ * @see AbstractAuthToken
  */
-public class SimpleToken extends AuthToken {
+public class SimpleToken extends AbstractAuthToken {
 
     @Property(exposeAsManagedAttribute=false)
     private String auth_value = null;
@@ -47,7 +47,7 @@ public class SimpleToken extends AuthToken {
         this.auth_value = auth_value;
     }
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         if ((token != null) && (token instanceof SimpleToken)) {
             // Found a valid Token to authenticate against
             SimpleToken serverToken = (SimpleToken) token;

--- a/src/org/jgroups/auth/X509Token.java
+++ b/src/org/jgroups/auth/X509Token.java
@@ -41,9 +41,9 @@ import java.security.cert.X509Certificate;
  * </ul>
  * 
  * @author Chris Mills
- * @see org.jgroups.auth.AuthToken
+ * @see AbstractAuthToken
  */
-public class X509Token extends AuthToken {
+public class X509Token extends AbstractAuthToken {
 
     public static final String KEYSTORE_TYPE = "keystore_type";
     public static final String KEYSTORE_PATH = "keystore_path";
@@ -105,7 +105,7 @@ public class X509Token extends AuthToken {
         return "org.jgroups.auth.X509Token";
     }
 
-    public boolean authenticate(AuthToken token, Message msg) {
+    public boolean authenticate(AbstractAuthToken token, Message msg) {
         if (!this.valueSet) {
             if (log.isErrorEnabled()) {
                 log.error(Util.getMessage("X509TokenNotSetupCorrectlyCheckTokenAttrs"));

--- a/src/org/jgroups/blocks/AbstractBasicConnectionTable.java
+++ b/src/org/jgroups/blocks/AbstractBasicConnectionTable.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * Shared class for TCP connection tables.
  * @author Scott Marlow
  */
-public abstract class BasicConnectionTable {
+public abstract class AbstractBasicConnectionTable {
     private ThreadFactory factory;
     final Map<Address,Connection>  conns=new HashMap<>();         // keys: Addresses (peer address), values: Connection
     Receiver              receiver=null;
@@ -69,7 +69,7 @@ public abstract class BasicConnectionTable {
 
 
 
-    protected BasicConnectionTable() {        
+    protected AbstractBasicConnectionTable() {
         factory = new DefaultThreadFactory("Connection Table", false);
     }
 

--- a/src/org/jgroups/blocks/AbstractRequest.java
+++ b/src/org/jgroups/blocks/AbstractRequest.java
@@ -23,8 +23,8 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author Bela Ban
  */
-public abstract class Request implements NotifyingFuture, org.jgroups.util.Condition {
-    protected static final Log        log=LogFactory.getLog(Request.class);
+public abstract class AbstractRequest implements NotifyingFuture, org.jgroups.util.Condition {
+    protected static final Log        log=LogFactory.getLog(AbstractRequest.class);
 
     protected final Lock              lock=new ReentrantLock();
 
@@ -39,7 +39,7 @@ public abstract class Request implements NotifyingFuture, org.jgroups.util.Condi
 
 
     
-    public Request(Message request, RequestCorrelator corr, RequestOptions options) {
+    public AbstractRequest(Message request, RequestCorrelator corr, RequestOptions options) {
         this.request_msg=request;
         this.corr=corr;
         this.options=options;

--- a/src/org/jgroups/blocks/ConnectionTableNIO.java
+++ b/src/org/jgroups/blocks/ConnectionTableNIO.java
@@ -28,7 +28,7 @@ import java.util.concurrent.*;
  *
  * @author Bela Ban, Scott Marlow, Alex Fu
  */
-public class ConnectionTableNIO extends BasicConnectionTable implements Runnable {
+public class ConnectionTableNIO extends AbstractBasicConnectionTable implements Runnable {
 
    private ServerSocketChannel m_serverSocketChannel;
    private Selector m_acceptSelector;
@@ -216,7 +216,7 @@ public class ConnectionTableNIO extends BasicConnectionTable implements Runnable
     /**
     * Try to obtain correct Connection (or create one if not yet existent)
     */
-   BasicConnectionTable.Connection getConnection(Address dest) throws Exception
+   AbstractBasicConnectionTable.Connection getConnection(Address dest) throws Exception
    {
       Connection conn;
       SocketChannel sock_ch;
@@ -958,7 +958,7 @@ public class ConnectionTableNIO extends BasicConnectionTable implements Runnable
       }
    }
 
-   class Connection extends BasicConnectionTable.Connection {
+   class Connection extends AbstractBasicConnectionTable.Connection {
       private SocketChannel sock_ch = null;
       private WriteHandler m_writeHandler;
       private SelectorWriteHandler m_selectorWriteHandler;

--- a/src/org/jgroups/blocks/GroupRequest.java
+++ b/src/org/jgroups/blocks/GroupRequest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @author Bela Ban
  */
-public class GroupRequest<T> extends Request {
+public class GroupRequest<T> extends AbstractRequest {
 
     /** Correlates requests and responses */
     @GuardedBy("lock")

--- a/src/org/jgroups/blocks/ReplicatedHashMap.java
+++ b/src/org/jgroups/blocks/ReplicatedHashMap.java
@@ -79,7 +79,7 @@ public class ReplicatedHashMap<K, V> extends
         }
     }
 
-    private Channel channel;
+    private AbstractChannel channel;
     protected RpcDispatcher disp=null;
     private String cluster_name=null;
     // to be notified when mbrship changes
@@ -99,7 +99,7 @@ public class ReplicatedHashMap<K, V> extends
     /**
      * Constructs a new ReplicatedHashMap with channel. Call {@link #start(long)} to start this map.
      */
-    public ReplicatedHashMap(Channel channel) {
+    public ReplicatedHashMap(AbstractChannel channel) {
         this.channel=channel;
         this.map=new ConcurrentHashMap<>();
         init();
@@ -109,7 +109,7 @@ public class ReplicatedHashMap<K, V> extends
     /**
      * Constructs a new ReplicatedHashMap using provided map instance.
      */
-    public ReplicatedHashMap(ConcurrentMap<K,V> map, Channel channel) {
+    public ReplicatedHashMap(ConcurrentMap<K,V> map, AbstractChannel channel) {
         if(channel == null)
             throw new IllegalArgumentException("Cannot create ReplicatedHashMap with null channel");
         if(map == null)
@@ -176,7 +176,7 @@ public class ReplicatedHashMap<K, V> extends
         return cluster_name;
     }
 
-    public Channel getChannel() {
+    public AbstractChannel getChannel() {
         return channel;
     }
 

--- a/src/org/jgroups/blocks/ReplicatedTree.java
+++ b/src/org/jgroups/blocks/ReplicatedTree.java
@@ -412,7 +412,7 @@ public class ReplicatedTree extends ReceiverAdapter {
     * Returns the Channel the DistributedTree is connected to 
     * @return Channel
     */
-    public Channel getChannel()             {return channel;}
+    public AbstractChannel getChannel()             {return channel;}
 
    /**
     * Returns the number of current members joined to the group

--- a/src/org/jgroups/blocks/RpcDispatcher.java
+++ b/src/org/jgroups/blocks/RpcDispatcher.java
@@ -35,12 +35,12 @@ public class RpcDispatcher extends MessageDispatcher {
     }
 
 
-    public RpcDispatcher(Channel channel, MessageListener l, MembershipListener l2, Object server_obj) {
+    public RpcDispatcher(AbstractChannel channel, MessageListener l, MembershipListener l2, Object server_obj) {
         super(channel, l, l2);
         this.server_obj=server_obj;
     }
 
-    public RpcDispatcher(Channel channel, Object server_obj) {
+    public RpcDispatcher(AbstractChannel channel, Object server_obj) {
         this(channel, null, null, server_obj);
     }
 

--- a/src/org/jgroups/blocks/UnicastRequest.java
+++ b/src/org/jgroups/blocks/UnicastRequest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @author Bela Ban
  */
-public class UnicastRequest<T> extends Request {
+public class UnicastRequest<T> extends AbstractRequest {
     protected final Rsp<T>     result;
     protected final Address    target;
     protected int              num_received=0;

--- a/src/org/jgroups/blocks/atomic/CounterService.java
+++ b/src/org/jgroups/blocks/atomic/CounterService.java
@@ -1,6 +1,6 @@
 package org.jgroups.blocks.atomic;
 
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.protocols.COUNTER;
 
 /**
@@ -9,14 +9,14 @@ import org.jgroups.protocols.COUNTER;
  * @since 3.0.0
  */
 public class CounterService {
-    protected Channel ch;
+    protected AbstractChannel ch;
     protected COUNTER  counter_prot;
 
-    public CounterService(Channel ch) {
+    public CounterService(AbstractChannel ch) {
         setChannel(ch);
     }
 
-    public void setChannel(Channel ch) {
+    public void setChannel(AbstractChannel ch) {
         this.ch=ch;
         counter_prot=(COUNTER)ch.getProtocolStack().findProtocol(COUNTER.class);
         if(counter_prot == null)

--- a/src/org/jgroups/blocks/cs/AbstractBaseServer.java
+++ b/src/org/jgroups/blocks/cs/AbstractBaseServer.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 3.6.5
  */
 @MBean(description="Server used to accept connections from other servers (or clients) and send data to servers")
-public abstract class BaseServer implements Closeable, ConnectionListener {
+public abstract class AbstractBaseServer implements Closeable, ConnectionListener {
     protected Address                         local_addr; // typically the address of the server socket or channel
     protected final List<ConnectionListener>  conn_listeners=new CopyOnWriteArrayList<>();
     protected final Map<Address,Connection>   conns=new HashMap<>();
@@ -59,41 +59,41 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
     protected TimeService                     time_service;
 
 
-    protected BaseServer(ThreadFactory f) {
+    protected AbstractBaseServer(ThreadFactory f) {
         this.factory=f;
     }
 
 
 
     public Receiver         receiver()                              {return receiver;}
-    public BaseServer       receiver(Receiver r)                    {this.receiver=r; return this;}
+    public AbstractBaseServer receiver(Receiver r)                    {this.receiver=r; return this;}
     public long             reaperInterval()                        {return reaperInterval;}
-    public BaseServer       reaperInterval(long interval)           {this.reaperInterval=interval; return this;}
+    public AbstractBaseServer reaperInterval(long interval)           {this.reaperInterval=interval; return this;}
     public Log              log()                                   {return log;}
-    public BaseServer       log(Log the_log)                        {this.log=the_log; return this;}
+    public AbstractBaseServer log(Log the_log)                        {this.log=the_log; return this;}
     public Address          localAddress()                          {return local_addr;}
     public InetAddress      clientBindAddress()                     {return client_bind_addr;}
-    public BaseServer       clientBindAddress(InetAddress addr)     {this.client_bind_addr=addr; return this;}
+    public AbstractBaseServer clientBindAddress(InetAddress addr)     {this.client_bind_addr=addr; return this;}
     public int              clientBindPort()                        {return client_bind_port;}
-    public BaseServer       clientBindPort(int port)                {this.client_bind_port=port; return this;}
+    public AbstractBaseServer clientBindPort(int port)                {this.client_bind_port=port; return this;}
     public boolean          deferClientBinding()                    {return defer_client_binding;}
-    public BaseServer       deferClientBinding(boolean defer)       {this.defer_client_binding=defer; return this;}
+    public AbstractBaseServer deferClientBinding(boolean defer)       {this.defer_client_binding=defer; return this;}
     public boolean          usePeerConnections()                    {return use_peer_connections;}
-    public BaseServer       usePeerConnections(boolean flag)        {this.use_peer_connections=flag; return this;}
+    public AbstractBaseServer usePeerConnections(boolean flag)        {this.use_peer_connections=flag; return this;}
     public int              socketConnectionTimeout()               {return sock_conn_timeout;}
-    public BaseServer       socketConnectionTimeout(int timeout)    {this.sock_conn_timeout = timeout; return this;}
+    public AbstractBaseServer socketConnectionTimeout(int timeout)    {this.sock_conn_timeout = timeout; return this;}
     public long             connExpireTime()                        {return conn_expire_time;}
-    public BaseServer       connExpireTimeout(long t)               {conn_expire_time=TimeUnit.NANOSECONDS.convert(t, TimeUnit.MILLISECONDS); return this;}
+    public AbstractBaseServer connExpireTimeout(long t)               {conn_expire_time=TimeUnit.NANOSECONDS.convert(t, TimeUnit.MILLISECONDS); return this;}
     public TimeService      timeService()                           {return time_service;}
-    public BaseServer       timeService(TimeService ts)             {this.time_service=ts; return this;}
+    public AbstractBaseServer timeService(TimeService ts)             {this.time_service=ts; return this;}
     public int              receiveBufferSize()                     {return recv_buf_size;}
-    public BaseServer       receiveBufferSize(int recv_buf_size)    {this.recv_buf_size = recv_buf_size; return this;}
+    public AbstractBaseServer receiveBufferSize(int recv_buf_size)    {this.recv_buf_size = recv_buf_size; return this;}
     public int              sendBufferSize()                        {return send_buf_size;}
-    public BaseServer       sendBufferSize(int send_buf_size)       {this.send_buf_size = send_buf_size; return this;}
+    public AbstractBaseServer sendBufferSize(int send_buf_size)       {this.send_buf_size = send_buf_size; return this;}
     public int              linger()                                {return linger;}
-    public BaseServer       linger(int linger)                      {this.linger=linger; return this;}
+    public AbstractBaseServer linger(int linger)                      {this.linger=linger; return this;}
     public boolean          tcpNodelay()                            {return tcp_nodelay;}
-    public BaseServer       tcpNodelay(boolean tcp_nodelay)         {this.tcp_nodelay = tcp_nodelay; return this;}
+    public AbstractBaseServer tcpNodelay(boolean tcp_nodelay)         {this.tcp_nodelay = tcp_nodelay; return this;}
     @ManagedAttribute(description="True if the server is running, else false")
     public boolean          running()                               {return running.get();}
 
@@ -510,7 +510,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
 
         public void run() {
             while(!Thread.currentThread().isInterrupted()) {
-                synchronized(BaseServer.this) {
+                synchronized(AbstractBaseServer.this) {
                     for(Iterator<Entry<Address,Connection>> it=conns.entrySet().iterator();it.hasNext();) {
                         Entry<Address,Connection> entry=it.next();
                         Connection c=entry.getValue();

--- a/src/org/jgroups/blocks/cs/AbstractNioBaseServer.java
+++ b/src/org/jgroups/blocks/cs/AbstractNioBaseServer.java
@@ -15,7 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  * @since  3.6.5
  */
-public abstract class NioBaseServer extends BaseServer {
+public abstract class AbstractNioBaseServer extends AbstractBaseServer {
     protected Selector          selector; // get notified about accepts, data ready to read/write etc
     protected Thread            acceptor; // the thread which calls select() in a loop
     protected final Lock        reg_lock=new ReentrantLock(); // for OP_CONNECT registrations
@@ -33,22 +33,22 @@ public abstract class NioBaseServer extends BaseServer {
 
 
 
-    protected NioBaseServer(ThreadFactory f) {
+    protected AbstractNioBaseServer(ThreadFactory f) {
         super(f);
     }
 
 
 
     public int            maxSendBuffers()              {return max_send_buffers;}
-    public NioBaseServer  maxSendBuffers(int num)       {this.max_send_buffers=num; return this;}
+    public AbstractNioBaseServer maxSendBuffers(int num)       {this.max_send_buffers=num; return this;}
     public boolean        selectorOpen()                {return selector != null && selector.isOpen();}
     public boolean        acceptorRunning()             {return acceptor != null && acceptor.isAlive();}
     public int            numSelects()                  {return num_selects;}
     public boolean        copyOnPartialWrite()          {return copy_on_partial_write;}
     public long           readerIdleTime()              {return reader_idle_time;}
-    public NioBaseServer  readerIdleTime(long t)        {reader_idle_time=t; return this;}
+    public AbstractNioBaseServer readerIdleTime(long t)        {reader_idle_time=t; return this;}
 
-    public NioBaseServer  copyOnPartialWrite(boolean b) {
+    public AbstractNioBaseServer copyOnPartialWrite(boolean b) {
         this.copy_on_partial_write=b;
         synchronized(this) {
             for(Connection c: conns.values()) {

--- a/src/org/jgroups/blocks/cs/AbstractTcpBaseServer.java
+++ b/src/org/jgroups/blocks/cs/AbstractTcpBaseServer.java
@@ -10,13 +10,13 @@ import org.jgroups.util.ThreadFactory;
  * @author Bela Ban
  * @since  3.6.5
  */
-public abstract class TcpBaseServer extends BaseServer {
+public abstract class AbstractTcpBaseServer extends AbstractBaseServer {
     protected SocketFactory     socket_factory=new DefaultSocketFactory();
     protected volatile boolean  use_send_queues=true;
     protected int               send_queue_size=2000;
     protected int               peer_addr_read_timeout=2000; // max time in milliseconds to block on reading peer address
 
-    protected TcpBaseServer(ThreadFactory f) {
+    protected AbstractTcpBaseServer(ThreadFactory f) {
         super(f);
     }
 
@@ -27,11 +27,11 @@ public abstract class TcpBaseServer extends BaseServer {
 
 
     public int           peerAddressReadTimeout()                {return peer_addr_read_timeout;}
-    public TcpBaseServer peerAddressReadTimeout(int timeout)     {this.peer_addr_read_timeout=timeout; return this;}
+    public AbstractTcpBaseServer peerAddressReadTimeout(int timeout)     {this.peer_addr_read_timeout=timeout; return this;}
     public int           sendQueueSize()                         {return send_queue_size;}
-    public TcpBaseServer sendQueueSize(int send_queue_size)      {this.send_queue_size=send_queue_size; return this;}
+    public AbstractTcpBaseServer sendQueueSize(int send_queue_size)      {this.send_queue_size=send_queue_size; return this;}
     public boolean       useSendQueues()                         {return use_send_queues;}
-    public TcpBaseServer useSendQueues(boolean flag)             {this.use_send_queues=flag; return this;}
+    public AbstractTcpBaseServer useSendQueues(boolean flag)             {this.use_send_queues=flag; return this;}
     public SocketFactory socketFactory()                         {return socket_factory;}
-    public TcpBaseServer socketFactory(SocketFactory factory)    {this.socket_factory=factory; return this;}
+    public AbstractTcpBaseServer socketFactory(SocketFactory factory)    {this.socket_factory=factory; return this;}
 }

--- a/src/org/jgroups/blocks/cs/NioClient.java
+++ b/src/org/jgroups/blocks/cs/NioClient.java
@@ -14,7 +14,7 @@ import java.nio.channels.Selector;
  * @author Bela Ban
  * @since  3.6.5
  */
-public class NioClient extends NioBaseServer implements Client {
+public class NioClient extends AbstractNioBaseServer implements Client {
     protected Address       remote_addr; // the address of the server (needs to be set before connecting)
     protected NioConnection conn;        // connection to the server
 

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -30,7 +30,7 @@ public class NioConnection implements Connection {
     protected SelectionKey        key;
     protected Address             peer_addr;    // address of the 'other end' of the connection
     protected long                last_access;  // timestamp of the last access to this connection (read or write)
-    protected final NioBaseServer server;
+    protected final AbstractNioBaseServer server;
 
     protected final Buffers       send_buf;     // send messages via gathering writes
     protected boolean             write_interest_set; // set when a send() didn't manage to send all data
@@ -46,7 +46,7 @@ public class NioConnection implements Connection {
 
 
      /** Creates a connection stub and binds it, use {@link #connect(Address)} to connect */
-    public NioConnection(Address peer_addr, NioBaseServer server) throws Exception {
+    public NioConnection(Address peer_addr, AbstractNioBaseServer server) throws Exception {
         this.server=server;
         if(peer_addr == null)
             throw new IllegalArgumentException("Invalid parameter peer_addr="+ peer_addr);
@@ -58,7 +58,7 @@ public class NioConnection implements Connection {
         last_access=getTimestamp(); // last time a message was sent or received (ns)
     }
 
-    public NioConnection(SocketChannel channel, NioBaseServer server) throws Exception {
+    public NioConnection(SocketChannel channel, AbstractNioBaseServer server) throws Exception {
         this.channel=channel;
         this.server=server;
         setSocketParameters(this.channel.socket());

--- a/src/org/jgroups/blocks/cs/NioServer.java
+++ b/src/org/jgroups/blocks/cs/NioServer.java
@@ -22,7 +22,7 @@ import java.nio.channels.SocketChannel;
  * @author Bela Ban
  * @since  3.6.5
  */
-public class NioServer extends NioBaseServer {
+public class NioServer extends AbstractNioBaseServer {
     protected ServerSocketChannel channel;  // used to accept connections from peers
 
 

--- a/src/org/jgroups/blocks/cs/Receiver.java
+++ b/src/org/jgroups/blocks/cs/Receiver.java
@@ -5,7 +5,7 @@ import org.jgroups.Address;
 import java.nio.ByteBuffer;
 
 /**
- * Receiver interface to be used with {@link BaseServer} instances
+ * Receiver interface to be used with {@link AbstractBaseServer} instances
  * @author Bela Ban
  * @since  3.6.5
  */

--- a/src/org/jgroups/blocks/cs/TcpClient.java
+++ b/src/org/jgroups/blocks/cs/TcpClient.java
@@ -11,7 +11,7 @@ import java.nio.ByteBuffer;
  * @author Bela Ban
  * @since  3.6.5
  */
-public class TcpClient extends TcpBaseServer implements Client, ConnectionListener {
+public class TcpClient extends AbstractTcpBaseServer implements Client, ConnectionListener {
     protected Address       remote_addr; // the address of the server (needs to be set before connecting)
     protected TcpConnection conn;        // connection to the server
 

--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -32,10 +32,10 @@ public class TcpConnection implements Connection {
     protected long                   last_access;
     protected volatile Sender        sender;
     protected volatile Receiver      receiver;
-    protected final TcpBaseServer    server;
+    protected final AbstractTcpBaseServer server;
 
     /** Creates a connection stub and binds it, use {@link #connect(Address)} to connect */
-    public TcpConnection(Address peer_addr, TcpBaseServer server) throws Exception {
+    public TcpConnection(Address peer_addr, AbstractTcpBaseServer server) throws Exception {
         this.server=server;
         if(peer_addr == null)
             throw new IllegalArgumentException("Invalid parameter peer_addr="+ peer_addr);

--- a/src/org/jgroups/blocks/cs/TcpServer.java
+++ b/src/org/jgroups/blocks/cs/TcpServer.java
@@ -14,7 +14,7 @@ import java.net.SocketException;
  * @author Vladimir Blagojevic
  * @author Bela Ban
  */
-public class TcpServer extends TcpBaseServer {
+public class TcpServer extends AbstractTcpBaseServer {
     protected ServerSocket srv_sock;
     protected Thread       acceptor;
 

--- a/src/org/jgroups/blocks/executor/ExecutionRunner.java
+++ b/src/org/jgroups/blocks/executor/ExecutionRunner.java
@@ -11,7 +11,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.jgroups.JChannel;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
-import org.jgroups.protocols.Executing;
+import org.jgroups.protocols.AbstractExecuting;
 
 /**
  * This class is to be used to pick up execution requests and actually run
@@ -21,7 +21,7 @@ import org.jgroups.protocols.Executing;
  */
 public class ExecutionRunner implements Runnable {
     protected JChannel ch;
-    protected Executing _execProt;
+    protected AbstractExecuting _execProt;
     
     public ExecutionRunner(JChannel channel) {
         setChannel(channel);
@@ -29,10 +29,10 @@ public class ExecutionRunner implements Runnable {
     
     public void setChannel(JChannel ch) {
         this.ch=ch;
-        _execProt=(Executing)ch.getProtocolStack().findProtocol(Executing.class);
+        _execProt=(AbstractExecuting)ch.getProtocolStack().findProtocol(AbstractExecuting.class);
         if(_execProt == null)
             throw new IllegalStateException("Channel configuration must include a executing protocol " +
-                                              "(subclass of " + Executing.class.getName() + ")");
+                                              "(subclass of " + AbstractExecuting.class.getName() + ")");
     }
     
     protected static class Holder<T> {

--- a/src/org/jgroups/blocks/executor/ExecutionService.java
+++ b/src/org/jgroups/blocks/executor/ExecutionService.java
@@ -24,8 +24,8 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.jgroups.Channel;
-import org.jgroups.protocols.Executing;
+import org.jgroups.AbstractChannel;
+import org.jgroups.protocols.AbstractExecuting;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.NotifyingFuture;
 import org.jgroups.util.Streamable;
@@ -50,8 +50,8 @@ import org.jgroups.util.Util;
  * @since 2.12.0
  */
 public class ExecutionService extends AbstractExecutorService {
-    protected Channel ch;
-    protected Executing _execProt;
+    protected AbstractChannel ch;
+    protected AbstractExecuting _execProt;
     
     protected Lock _unfinishedLock = new ReentrantLock();
     protected Condition _unfinishedCondition = _unfinishedLock.newCondition();
@@ -64,16 +64,16 @@ public class ExecutionService extends AbstractExecutorService {
         
     }
 
-    public ExecutionService(Channel ch) {
+    public ExecutionService(AbstractChannel ch) {
         setChannel(ch);
     }
 
-    public void setChannel(Channel ch) {
+    public void setChannel(AbstractChannel ch) {
         this.ch=ch;
-        _execProt=(Executing)ch.getProtocolStack().findProtocol(Executing.class);
+        _execProt=(AbstractExecuting)ch.getProtocolStack().findProtocol(AbstractExecuting.class);
         if(_execProt == null)
             throw new IllegalStateException("Channel configuration must include a executing protocol " +
-                                              "(subclass of " + Executing.class.getName() + ")");
+                                              "(subclass of " + AbstractExecuting.class.getName() + ")");
     }
     
     // @see java.util.concurrent.AbstractExecutorService#submit(java.lang.Runnable, java.lang.Object)
@@ -110,7 +110,7 @@ public class ExecutionService extends AbstractExecutorService {
         protected final Sync<V> sync;
         
         /** The following values are only used on the client side */
-        private final Channel channel;
+        private final AbstractChannel channel;
         private final Set<Future<?>> _unfinishedFutures;
         private final Lock _unfinishedLock;
         private final Condition _unfinishedCondition;
@@ -128,10 +128,10 @@ public class ExecutionService extends AbstractExecutorService {
          *        it is finished. 
          * @param callable The callable to actually run on the server side
          */
-        public DistributedFuture(Channel channel, Lock unfinishedLock,
-                          Condition condition,
-                          Set<Future<?>> futuresToFinish, 
-                          Callable<V> callable) {
+        public DistributedFuture(AbstractChannel channel, Lock unfinishedLock,
+                                 Condition condition,
+                                 Set<Future<?>> futuresToFinish,
+                                 Callable<V> callable) {
             if (callable == null)
                 throw new NullPointerException();
             sync = new Sync<>(this, callable);
@@ -160,9 +160,9 @@ public class ExecutionService extends AbstractExecutorService {
          * <tt>Future&lt;?&gt; f = new FutureTask&lt;Object&gt;(runnable, null)</tt>
          * @throws NullPointerException if runnable is null
          */
-        public DistributedFuture(Channel channel, Lock unfinishedLock,
-                          Condition condition, Set<Future<?>> futuresToFinish, 
-                          Runnable runnable, V result) {
+        public DistributedFuture(AbstractChannel channel, Lock unfinishedLock,
+                                 Condition condition, Set<Future<?>> futuresToFinish,
+                                 Runnable runnable, V result) {
             sync = new Sync<>(this, new RunnableAdapter<>(runnable, result));
             this.channel = channel;
             // We keep the real copy to update the outside

--- a/src/org/jgroups/blocks/locking/LockService.java
+++ b/src/org/jgroups/blocks/locking/LockService.java
@@ -1,8 +1,8 @@
 package org.jgroups.blocks.locking;
 
 import org.jgroups.Event;
-import org.jgroups.Channel;
-import org.jgroups.protocols.Locking;
+import org.jgroups.AbstractChannel;
+import org.jgroups.protocols.AbstractLocking;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -12,7 +12,7 @@ import java.util.concurrent.locks.Lock;
 
 /**
  * LockService is the main class for to use for distributed locking functionality. LockService needs access to a
- * {@link Channel} and interacts with a locking protocol (e.g. {@link org.jgroups.protocols.CENTRAL_LOCK}) via events.<p/>
+ * {@link AbstractChannel} and interacts with a locking protocol (e.g. {@link org.jgroups.protocols.CENTRAL_LOCK}) via events.<p/>
  * When no locking protocol is seen on the channel's stack, LockService will throw an exception at startup. An example
  * of using LockService is:
  * <pre>
@@ -37,24 +37,24 @@ import java.util.concurrent.locks.Lock;
  * @since 2.12
  */
 public class LockService {
-    protected Channel ch;
-    protected Locking  lock_prot;
+    protected AbstractChannel ch;
+    protected AbstractLocking lock_prot;
 
 
     public LockService() {
         
     }
 
-    public LockService(Channel ch) {
+    public LockService(AbstractChannel ch) {
         setChannel(ch);
     }
 
-    public void setChannel(Channel ch) {
+    public void setChannel(AbstractChannel ch) {
         this.ch=ch;
-        lock_prot=(Locking)ch.getProtocolStack().findProtocol(Locking.class);
+        lock_prot=(AbstractLocking)ch.getProtocolStack().findProtocol(AbstractLocking.class);
         if(lock_prot == null)
             throw new IllegalStateException("Channel configuration must include a locking protocol " +
-                                              "(subclass of " + Locking.class.getName() + ")");
+                                              "(subclass of " + AbstractLocking.class.getName() + ")");
     }
 
     public Lock getLock(String lock_name) {

--- a/src/org/jgroups/blocks/mux/MuxHeader.java
+++ b/src/org/jgroups/blocks/mux/MuxHeader.java
@@ -4,14 +4,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 
 /**
  * Header that identifies the target handler for multiplexed dispatches.
  * @author Bela Ban
  * @author Paul Ferraro
  */
-public class MuxHeader extends Header {
+public class MuxHeader extends AbstractHeader {
 
     private short id;
 

--- a/src/org/jgroups/blocks/mux/MuxMessageDispatcher.java
+++ b/src/org/jgroups/blocks/mux/MuxMessageDispatcher.java
@@ -2,7 +2,7 @@ package org.jgroups.blocks.mux;
 
 import org.jgroups.*;
 import org.jgroups.blocks.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.RspList;
 
@@ -32,7 +32,7 @@ public class MuxMessageDispatcher extends MessageDispatcher {
         this.scope_id = scopeId;
     }
 
-    public MuxMessageDispatcher(short scopeId, Channel channel, MessageListener messageListener, MembershipListener membershipListener, RequestHandler handler) {
+    public MuxMessageDispatcher(short scopeId, AbstractChannel channel, MessageListener messageListener, MembershipListener membershipListener, RequestHandler handler) {
         this(scopeId);
         
         setMessageListener(messageListener);
@@ -48,7 +48,7 @@ public class MuxMessageDispatcher extends MessageDispatcher {
     }
 
     @Override
-    protected RequestCorrelator createRequestCorrelator(Protocol transport, RequestHandler handler, Address localAddr) {
+    protected RequestCorrelator createRequestCorrelator(AbstractProtocol transport, RequestHandler handler, Address localAddr) {
         // We can't set the scope of the request correlator here since this method is called from start()
         // triggered in the MessageDispatcher constructor, when this.scope is not yet defined
         return new MuxRequestCorrelator(scope_id, transport, handler, localAddr);

--- a/src/org/jgroups/blocks/mux/MuxRequestCorrelator.java
+++ b/src/org/jgroups/blocks/mux/MuxRequestCorrelator.java
@@ -1,10 +1,11 @@
 package org.jgroups.blocks.mux;
 
+import org.jgroups.AbstractHeader;
 import org.jgroups.Address;
 import org.jgroups.Message;
 import org.jgroups.blocks.*;
 import org.jgroups.conf.ClassConfigurator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import java.util.Collection;
 
@@ -17,21 +18,21 @@ import java.util.Collection;
 public class MuxRequestCorrelator extends RequestCorrelator {
 
     protected final static short MUX_ID = ClassConfigurator.getProtocolId(MuxRequestCorrelator.class);
-    private final org.jgroups.Header header;
+    private final AbstractHeader header;
     
-    public MuxRequestCorrelator(short id, Protocol transport, RequestHandler handler, Address localAddr) {
+    public MuxRequestCorrelator(short id, AbstractProtocol transport, RequestHandler handler, Address localAddr) {
         super(ClassConfigurator.getProtocolId(RequestCorrelator.class), transport, handler, localAddr);
         this.header = new MuxHeader(id);
     }
 
     @Override
-    public void sendRequest(Collection<Address> dest_mbrs, Message msg, Request req, RequestOptions options) throws Exception {
+    public void sendRequest(Collection<Address> dest_mbrs, Message msg, AbstractRequest req, RequestOptions options) throws Exception {
         msg.putHeader(MUX_ID, header);
         super.sendRequest(dest_mbrs, msg, req, options);
     }
 
     @Override
-    public void sendUnicastRequest(Address target, Message msg, Request req) throws Exception {
+    public void sendUnicastRequest(Address target, Message msg, AbstractRequest req) throws Exception {
         msg.putHeader(MUX_ID, header);
         super.sendUnicastRequest(target, msg, req);
     }

--- a/src/org/jgroups/blocks/mux/MuxRpcDispatcher.java
+++ b/src/org/jgroups/blocks/mux/MuxRpcDispatcher.java
@@ -2,7 +2,7 @@ package org.jgroups.blocks.mux;
 
 import org.jgroups.*;
 import org.jgroups.blocks.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.RspList;
 
@@ -34,7 +34,7 @@ public class MuxRpcDispatcher extends RpcDispatcher {
         this.scope_id = scopeId;
     }
 
-    public MuxRpcDispatcher(short scopeId, Channel channel, MessageListener messageListener, MembershipListener membershipListener, Object serverObject) {
+    public MuxRpcDispatcher(short scopeId, AbstractChannel channel, MessageListener messageListener, MembershipListener membershipListener, Object serverObject) {
         this(scopeId);
         
         setMessageListener(messageListener);
@@ -45,7 +45,7 @@ public class MuxRpcDispatcher extends RpcDispatcher {
         start();
     }
 
-    public MuxRpcDispatcher(short scopeId, Channel channel, MessageListener messageListener, MembershipListener membershipListener, Object serverObject, MethodLookup method_lookup) {
+    public MuxRpcDispatcher(short scopeId, AbstractChannel channel, MessageListener messageListener, MembershipListener membershipListener, Object serverObject, MethodLookup method_lookup) {
         this(scopeId);
         
         setMethodLookup(method_lookup);
@@ -63,7 +63,7 @@ public class MuxRpcDispatcher extends RpcDispatcher {
     }
 
     @Override
-    protected RequestCorrelator createRequestCorrelator(Protocol transport, RequestHandler handler, Address localAddr) {
+    protected RequestCorrelator createRequestCorrelator(AbstractProtocol transport, RequestHandler handler, Address localAddr) {
         // We can't set the scope of the request correlator here
         // since this method is called from start() triggered in the
         // MessageDispatcher constructor, when this.scope is not yet defined

--- a/src/org/jgroups/conf/PropertyConverters.java
+++ b/src/org/jgroups/conf/PropertyConverters.java
@@ -4,7 +4,7 @@ import org.jgroups.Global;
 import org.jgroups.View;
 import org.jgroups.stack.Configurator;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.StackType;
 import org.jgroups.util.Util;
 
@@ -63,7 +63,7 @@ public class PropertyConverters {
     public static class InitialHosts implements PropertyConverter {
 
         public Object convert(Object obj, Class<?> propertyFieldType, String propertyName, String prop_val, boolean check_scope) throws Exception {
-            int port_range = getPortRange((Protocol)obj) ;
+            int port_range = getPortRange((AbstractProtocol)obj) ;
             return Util.parseCommaDelimitedHosts(prop_val, port_range);
         }
 
@@ -85,7 +85,7 @@ public class PropertyConverters {
                 return value.getClass().getName();
 		}
 
-        private static int getPortRange(Protocol protocol) throws Exception {
+        private static int getPortRange(AbstractProtocol protocol) throws Exception {
             Field f = protocol.getClass().getDeclaredField("port_range") ;
             return ((Integer) Util.getField(f,protocol)).intValue();
 		}
@@ -122,13 +122,13 @@ public class PropertyConverters {
         public Object convert(Object obj, Class<?> propertyFieldType, String propertyName, String propertyValue, boolean check_scope) throws Exception {
 
         	// get the existing bind address - possibly null
-        	InetAddress	old_bind_addr = (InetAddress)Configurator.getValueFromProtocol((Protocol)obj, "bind_addr");
+        	InetAddress	old_bind_addr = (InetAddress)Configurator.getValueFromProtocol((AbstractProtocol)obj, "bind_addr");
 
         	// apply a bind interface constraint
             InetAddress new_bind_addr = Util.validateBindAddressFromInterface(old_bind_addr, propertyValue);
 
             if (new_bind_addr != null)
-            	setBindAddress((Protocol)obj, new_bind_addr) ;
+            	setBindAddress((AbstractProtocol)obj, new_bind_addr) ;
 
             // if no bind_interface specified, set it to the empty string to avoid exception
             // from @Property processing
@@ -139,7 +139,7 @@ public class PropertyConverters {
         }
 
 
-        private static void setBindAddress(Protocol protocol, InetAddress bind_addr) throws Exception {
+        private static void setBindAddress(AbstractProtocol protocol, InetAddress bind_addr) throws Exception {
             Field f=Util.getField(protocol.getClass(), "bind_addr");
 			Util.setField(f, protocol, bind_addr) ;
 		}

--- a/src/org/jgroups/conf/PropertyHelper.java
+++ b/src/org/jgroups/conf/PropertyHelper.java
@@ -4,7 +4,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
 import org.jgroups.stack.Configurator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 
 import java.lang.reflect.Field;
@@ -68,7 +68,7 @@ import java.util.Map;
     					field.getName() + " which is not annotated with @Property") ;
     		}
 			String propertyName = getPropertyName(field, props) ;
-			String name = obj instanceof Protocol? ((Protocol)obj).getName() : obj.getClass().getName();
+			String name = obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() : obj.getClass().getName();
 
     		PropertyConverter propertyConverter=(PropertyConverter)annotation.converter().newInstance();
     		if(propertyConverter == null) {    				
@@ -77,7 +77,7 @@ import java.util.Map;
     		}
     		Object converted = null ;
 			try {
-                String tmp=obj instanceof Protocol? ((Protocol)obj).getName() + "." + propertyName : propertyName;
+                String tmp=obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() + "." + propertyName : propertyName;
 				converted=propertyConverter.convert(obj, field.getType(), tmp, prop, check_scope);
 			}
 			catch(Exception e) {
@@ -100,7 +100,7 @@ import java.util.Map;
                         field.getName() + " which is not annotated with @Property");
             }
             String propertyName=field.getName();
-            String name=obj instanceof Protocol? ((Protocol)obj).getName() : obj.getClass().getName();
+            String name=obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() : obj.getClass().getName();
 
             PropertyConverter propertyConverter=(PropertyConverter)annotation.converter().newInstance();
             if(propertyConverter == null) {
@@ -109,7 +109,7 @@ import java.util.Map;
             }
             Object converted=null;
             try {
-                String tmp=obj instanceof Protocol? ((Protocol)obj).getName() + "." + propertyName : propertyName;
+                String tmp=obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() + "." + propertyName : propertyName;
                 converted=propertyConverter.convert(obj, field.getType(), tmp, value, check_scope);
             }
             catch(Exception e) {
@@ -139,7 +139,7 @@ import java.util.Map;
     					method.getName() + " which is not annotated with @Property") ;
     		}
     		String propertyName = getPropertyName(method) ;
-    		String name = obj instanceof Protocol? ((Protocol)obj).getName() : obj.getClass().getName();
+    		String name = obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() : obj.getClass().getName();
     		PropertyConverter propertyConverter=(PropertyConverter)annotation.converter().newInstance();
     		if(propertyConverter == null) {    				
     			throw new Exception("Could not find property converter for method " + propertyName
@@ -147,7 +147,7 @@ import java.util.Map;
     		}
     		Object converted = null ;
     		try {
-                String tmp=obj instanceof Protocol? ((Protocol)obj).getName() + "." + propertyName : propertyName;
+                String tmp=obj instanceof AbstractProtocol ? ((AbstractProtocol)obj).getName() + "." + propertyName : propertyName;
     			converted=propertyConverter.convert(obj, method.getParameterTypes()[0], tmp, prop, check_scope);
     		}
     		catch(Exception e) {

--- a/src/org/jgroups/demos/Draw.java
+++ b/src/org/jgroups/demos/Draw.java
@@ -411,13 +411,13 @@ public class Draw extends ReceiverAdapter implements ActionListener, ChannelList
 
     /* ------------------------------ ChannelListener interface -------------------------- */
 
-    public void channelConnected(Channel channel) {
+    public void channelConnected(AbstractChannel channel) {
         if(jmx) {
             Util.registerChannel((JChannel)channel, "jgroups");
         }
     }
 
-    public void channelDisconnected(Channel channel) {
+    public void channelDisconnected(AbstractChannel channel) {
         if(jmx) {
             MBeanServer server=Util.getMBeanServer();
             if(server != null) {
@@ -431,7 +431,7 @@ public class Draw extends ReceiverAdapter implements ActionListener, ChannelList
         }
     }
 
-    public void channelClosed(Channel channel) {
+    public void channelClosed(AbstractChannel channel) {
 
     }
 

--- a/src/org/jgroups/demos/ProgrammaticChat.java
+++ b/src/org/jgroups/demos/ProgrammaticChat.java
@@ -8,7 +8,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 
 import java.net.InetAddress;
@@ -19,7 +19,7 @@ import java.net.InetAddress;
 public class ProgrammaticChat {
 
     public static void main(String[] args) throws Exception {
-        Protocol[] prot_stack={
+        AbstractProtocol[] prot_stack={
           new UDP().setValue("bind_addr", InetAddress.getByName("127.0.0.1")),
           new PING(),
           new MERGE3(),

--- a/src/org/jgroups/demos/PubClient.java
+++ b/src/org/jgroups/demos/PubClient.java
@@ -16,7 +16,7 @@ import java.nio.ByteBuffer;
  * @since  3.6.5
  */
 public class PubClient extends ReceiverAdapter implements ConnectionListener {
-    protected BaseServer       client;
+    protected AbstractBaseServer client;
     protected final String     name;
     protected volatile boolean running=true;
     protected InputStream      in;

--- a/src/org/jgroups/demos/PubServer.java
+++ b/src/org/jgroups/demos/PubServer.java
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer;
  * @since  3.6.5
  */
 public class PubServer extends ReceiverAdapter {
-    protected BaseServer server;
+    protected AbstractBaseServer server;
     protected final Log  log=LogFactory.getLog(PubServer.class);
 
 

--- a/src/org/jgroups/demos/QuoteClient.java
+++ b/src/org/jgroups/demos/QuoteClient.java
@@ -29,7 +29,7 @@ public class QuoteClient extends Frame implements WindowListener, ActionListener
         MembershipListener {
     static final String channel_name="Quotes";
     RpcDispatcher disp;
-    Channel channel;
+    AbstractChannel channel;
     final Button get=new Button("Get");
     final Button set=new Button("Set");
     final Button quit=new Button("Quit");

--- a/src/org/jgroups/demos/QuoteServer.java
+++ b/src/org/jgroups/demos/QuoteServer.java
@@ -30,7 +30,7 @@ import java.util.Hashtable;
 
 public class QuoteServer extends ReceiverAdapter {
     final Hashtable stocks=new Hashtable();
-    Channel channel;
+    AbstractChannel channel;
     RpcDispatcher disp;
     static final String channel_name="Quotes";
     final int num_members=1;

--- a/src/org/jgroups/demos/TotalOrder.java
+++ b/src/org/jgroups/demos/TotalOrder.java
@@ -43,7 +43,7 @@ public class TotalOrder extends Frame {
     final Button quit=new Button("Quit");
     final Panel button_panel=new Panel();
     SenderThread sender=null;
-    Channel channel;
+    AbstractChannel channel;
     long timeout=0;
     int field_size=0;
     int num_fields=0;

--- a/src/org/jgroups/demos/ViewDemo.java
+++ b/src/org/jgroups/demos/ViewDemo.java
@@ -11,7 +11,7 @@ import org.jgroups.util.Util;
  * randomly. The view should always be correct.
  */
 public class ViewDemo extends ReceiverAdapter {
-    private Channel channel;
+    private AbstractChannel channel;
 
 
     public void viewAccepted(View new_view) {

--- a/src/org/jgroups/demos/applets/DrawApplet.java
+++ b/src/org/jgroups/demos/applets/DrawApplet.java
@@ -30,7 +30,7 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
     private Label mbr_label;
     private final Font default_font=new Font("Helvetica", Font.PLAIN, 12);
     private static final String groupname="DrawGroup";
-    private Channel channel=null;
+    private AbstractChannel channel=null;
     private int member_size=1;
     private int red=0, green=0, blue=0;
     private Color default_color=null;

--- a/src/org/jgroups/demos/wb/Whiteboard.java
+++ b/src/org/jgroups/demos/wb/Whiteboard.java
@@ -21,7 +21,7 @@ import java.io.OutputStream;
  */
 public class Whiteboard extends Applet implements MessageListener, MembershipListener, ActionListener, ComponentListener, FocusListener {
     public RpcDispatcher           disp;
-    Channel                        channel;
+    AbstractChannel channel;
     GraphPanel                     panel;
     private Button                 leave_button;
     private Label                  mbr_label;

--- a/src/org/jgroups/fork/ForkChannel.java
+++ b/src/org/jgroups/fork/ForkChannel.java
@@ -3,7 +3,7 @@ package org.jgroups.fork;
 import org.jgroups.*;
 import org.jgroups.protocols.FORK;
 import org.jgroups.stack.AddressGenerator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 
@@ -19,7 +19,7 @@ import java.util.List;
  * @since  3.4
  */
 public class ForkChannel extends JChannel implements ChannelListener {
-    protected final Channel           main_channel;
+    protected final AbstractChannel main_channel;
     protected final String            fork_channel_id;
     protected static final Field[]    copied_fields;
 
@@ -57,9 +57,9 @@ public class ForkChannel extends JChannel implements ChannelListener {
      *
      * @throws Exception
      */
-    public ForkChannel(final Channel main_channel, String fork_stack_id, String fork_channel_id,
-                       boolean create_fork_if_absent, int position, Class<? extends Protocol> neighbor,
-                       Protocol ... protocols) throws Exception {
+    public ForkChannel(final AbstractChannel main_channel, String fork_stack_id, String fork_channel_id,
+                       boolean create_fork_if_absent, int position, Class<? extends AbstractProtocol> neighbor,
+                       AbstractProtocol... protocols) throws Exception {
 
         super(false);
         if(main_channel == null)    throw new IllegalArgumentException("main channel cannot be null");
@@ -95,8 +95,8 @@ public class ForkChannel extends JChannel implements ChannelListener {
      *                  a ForkChannel to mux/demux messages, but doesn't need a different protocol stack.
      * @throws Exception
      */
-    public ForkChannel(final Channel main_channel, String fork_stack_id, String fork_channel_id,
-                       Protocol ... protocols) throws Exception {
+    public ForkChannel(final AbstractChannel main_channel, String fork_stack_id, String fork_channel_id,
+                       AbstractProtocol... protocols) throws Exception {
         this(main_channel, fork_stack_id, fork_channel_id, false, 0, null, protocols);
     }
 
@@ -111,7 +111,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
         return this;
     }
 
-    public void channelConnected(Channel channel) {
+    public void channelConnected(AbstractChannel channel) {
         copyFields();
         if(local_addr == null) return;
         Event evt=new Event(Event.SET_LOCAL_ADDRESS, local_addr);
@@ -119,11 +119,11 @@ public class ForkChannel extends JChannel implements ChannelListener {
             up_handler.up(evt);
     }
 
-    public void channelDisconnected(Channel channel) {
+    public void channelDisconnected(AbstractChannel channel) {
         copyFields();
     }
 
-    public void channelClosed(Channel channel) {
+    public void channelClosed(AbstractChannel channel) {
         copyFields();
     }
 
@@ -148,7 +148,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
         state=State.CONNECTING;
         this.main_channel.addChannelListener(this);
         copyFields();
-        Channel existing_ch=((ForkProtocolStack)prot_stack).putIfAbsent(fork_channel_id,this);
+        AbstractChannel existing_ch=((ForkProtocolStack)prot_stack).putIfAbsent(fork_channel_id,this);
         if(existing_ch != null && existing_ch != this)
             throw new IllegalArgumentException("fork-channel with id=" + fork_channel_id + " is already present");
         setLocalAddress(local_addr);
@@ -263,7 +263,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
     /**
      * Creates a new FORK protocol, or returns the existing one, or throws an exception. Never returns null.
      */
-    protected static FORK getFORK(Channel ch, int position, Class<? extends Protocol> neighbor,
+    protected static FORK getFORK(AbstractChannel ch, int position, Class<? extends AbstractProtocol> neighbor,
                                   boolean create_fork_if_absent) throws Exception {
         ProtocolStack stack=ch.getProtocolStack();
         FORK fork=(FORK)stack.findProtocol(FORK.class);

--- a/src/org/jgroups/fork/ForkProtocol.java
+++ b/src/org/jgroups/fork/ForkProtocol.java
@@ -3,7 +3,7 @@ package org.jgroups.fork;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.protocols.FORK;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import java.util.Map;
 
@@ -13,7 +13,7 @@ import java.util.Map;
  * @author Bela Ban
  * @since  3.4
  */
-public class ForkProtocol extends Protocol {
+public class ForkProtocol extends AbstractProtocol {
     protected final String       fork_stack_id;
 
     public ForkProtocol(String fork_stack_id) {

--- a/src/org/jgroups/fork/ForkProtocolStack.java
+++ b/src/org/jgroups/fork/ForkProtocolStack.java
@@ -2,7 +2,7 @@ package org.jgroups.fork;
 
 import org.jgroups.*;
 import org.jgroups.protocols.FORK;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
@@ -24,7 +24,7 @@ public class ForkProtocolStack extends ProtocolStack {
     protected final String                         fork_stack_id;
     protected final ConcurrentMap<String,JChannel> fork_channels=new ConcurrentHashMap<>();
     protected final UnknownForkHandler             unknownForkHandler;
-    protected final List<Protocol>                 protocols;
+    protected final List<AbstractProtocol>                 protocols;
 
     // init() increments and destroy() decrements
     // 1 -> 0: destroy the stack and remove it from FORK. Calls destroy() in all fork stack protocols before
@@ -36,7 +36,7 @@ public class ForkProtocolStack extends ProtocolStack {
     protected int                                  connects;
 
 
-    public ForkProtocolStack(UnknownForkHandler unknownForkHandler, List<Protocol> protocols, String fork_stack_id) {
+    public ForkProtocolStack(UnknownForkHandler unknownForkHandler, List<AbstractProtocol> protocols, String fork_stack_id) {
         this.unknownForkHandler = unknownForkHandler;
         this.fork_stack_id=fork_stack_id;
         this.protocols=new ArrayList<>(protocols != null? protocols.size() : 0);
@@ -64,7 +64,7 @@ public class ForkProtocolStack extends ProtocolStack {
     }
 
     @Override
-    public List<Protocol> getProtocols() {
+    public List<AbstractProtocol> getProtocols() {
         return new ArrayList<>(protocols); // copy because Collections.reverse() will be called on the return value
     }
 

--- a/src/org/jgroups/jmx/JmxConfigurator.java
+++ b/src/org/jgroups/jmx/JmxConfigurator.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 
@@ -47,8 +47,8 @@ public class JmxConfigurator {
 
         if (register_protocols) {
             ProtocolStack stack = channel.getProtocolStack();
-            List<Protocol> protocols = stack.getProtocols();
-            for (Protocol p : protocols) {
+            List<AbstractProtocol> protocols = stack.getProtocols();
+            for (AbstractProtocol p : protocols) {
                 if (p.getClass().isAnnotationPresent(MBean.class)) {
                     String jmx_name=getProtocolRegistrationName(cluster_name,domain,p);
                     register(p, server, jmx_name);
@@ -97,8 +97,8 @@ public class JmxConfigurator {
             clusterName=ObjectName.quote(clusterName);
 
         ProtocolStack stack = c.getProtocolStack();
-        List<Protocol> protocols = stack.getProtocols();
-        for (Protocol p : protocols) {
+        List<AbstractProtocol> protocols = stack.getProtocols();
+        for (AbstractProtocol p : protocols) {
             if (p.getClass().isAnnotationPresent(MBean.class)) {
                 try {
                     String obj_name=getProtocolRegistrationName(clusterName, domain, p);
@@ -148,7 +148,7 @@ public class JmxConfigurator {
      * @param p protocol to be wrapped
      * @return Protocol p as a DynamicMBean
      */
-    public static DynamicMBean wrap(Protocol p) {
+    public static DynamicMBean wrap(AbstractProtocol p) {
         return new ResourceDMBean(p);
     }
 
@@ -230,7 +230,7 @@ public class JmxConfigurator {
         return domain + ":type=channel,cluster=" + clusterName;
     }
 
-    private static String getProtocolRegistrationName(String clusterName, String domain, Protocol p) {
+    private static String getProtocolRegistrationName(String clusterName, String domain, AbstractProtocol p) {
         return domain + ":type=protocol,cluster=" + clusterName + ",protocol=" + p.getName();
     }
 

--- a/src/org/jgroups/protocols/ABP.java
+++ b/src/org/jgroups/protocols/ABP.java
@@ -5,7 +5,7 @@ import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
 import org.jgroups.annotations.Unsupported;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.ConcurrentLinkedBlockingQueue;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Experimental @Unsupported
 @MBean(description="Alternating Bit Protocol, for reliable p2p unicasts")
-public class ABP extends Protocol {
+public class ABP extends AbstractProtocol {
 
     @Property(description="Interval (in ms) at which a sent msg is resent")
     protected long resend_interval=1000;
@@ -173,7 +173,7 @@ public class ABP extends Protocol {
         }
     }
 
-    protected static class ABPHeader extends Header {
+    protected static class ABPHeader extends AbstractHeader {
         protected Type type;
         protected byte bit;  // either 1 or 0
 

--- a/src/org/jgroups/protocols/AUTH.java
+++ b/src/org/jgroups/protocols/AUTH.java
@@ -5,12 +5,12 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
 import org.jgroups.annotations.XmlAttribute;
-import org.jgroups.auth.AuthToken;
+import org.jgroups.auth.AbstractAuthToken;
 import org.jgroups.auth.X509Token;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.JoinRsp;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ import java.util.List;
   "cert_password", "keystore_password"                                  // X509Token
 })
 @MBean(description="Provides authentication of joiners, to prevent un-authorized joining of a cluster")
-public class AUTH extends Protocol {
+public class AUTH extends AbstractProtocol {
 
     /** Interface to provide callbacks for handling up events */
     public interface UpHandler {
@@ -48,7 +48,7 @@ public class AUTH extends Protocol {
 
 
     /** Used on the coordinator to authentication joining member requests against */
-    protected AuthToken             auth_token=null;
+    protected AbstractAuthToken auth_token=null;
 
     protected static final short    gms_id=ClassConfigurator.getProtocolId(GMS.class);
 
@@ -70,13 +70,13 @@ public class AUTH extends Protocol {
     @Property(name="auth_class")
     public void setAuthClass(String class_name) throws Exception {
         Object obj=Class.forName(class_name).newInstance();
-        auth_token=(AuthToken)obj;
+        auth_token=(AbstractAuthToken)obj;
         auth_token.setAuth(this);
     }
 
     public String    getAuthClass()                {return auth_token != null? auth_token.getClass().getName() : null;}
-    public AuthToken getAuthToken()                {return auth_token;}
-    public void      setAuthToken(AuthToken token) {this.auth_token=token;}
+    public AbstractAuthToken getAuthToken()                {return auth_token;}
+    public void      setAuthToken(AbstractAuthToken token) {this.auth_token=token;}
     public void      register(UpHandler handler)   {up_handlers.add(handler);}
     public void      unregister(UpHandler handler) {up_handlers.remove(handler);}
     public Address   getAddress()                  {return local_addr;}
@@ -282,7 +282,7 @@ public class AUTH extends Protocol {
     }
 
     protected static GMS.GmsHeader getGMSHeader(Message msg){
-        Header hdr = msg.getHeader(gms_id);
+        AbstractHeader hdr = msg.getHeader(gms_id);
         if(hdr instanceof GMS.GmsHeader)
             return (GMS.GmsHeader)hdr;
         return null;

--- a/src/org/jgroups/protocols/AbstractBasicTCP.java
+++ b/src/org/jgroups/protocols/AbstractBasicTCP.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * @author Scott Marlow
  * @author Bela Ban
  */
-public abstract class BasicTCP extends TP implements Receiver {
+public abstract class AbstractBasicTCP extends AbstractTP implements Receiver {
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
     
@@ -74,7 +74,7 @@ public abstract class BasicTCP extends TP implements Receiver {
     /* --------------------------------------------- Fields ------------------------------------------------------ */
     
 
-    protected BasicTCP() {
+    protected AbstractBasicTCP() {
         super();        
     }
 
@@ -88,7 +88,7 @@ public abstract class BasicTCP extends TP implements Receiver {
     public void init() throws Exception {
         super.init();
         if(!isSingleton() && bind_port <= 0) {
-            Discovery discovery_prot=(Discovery)stack.findProtocol(Discovery.class);
+            AbstractDiscovery discovery_prot=(AbstractDiscovery)stack.findProtocol(AbstractDiscovery.class);
             if(discovery_prot != null && !discovery_prot.isDynamic())
                 throw new IllegalArgumentException("bind_port cannot be set to " + bind_port +
                                                      ", as no dynamic discovery protocol (e.g. MPING or TCPGOSSIP) has been detected.");

--- a/src/org/jgroups/protocols/AbstractDiscovery.java
+++ b/src/org/jgroups/protocols/AbstractDiscovery.java
@@ -7,7 +7,7 @@ import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.ConfiguratorFactory;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
 
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  */
 @MBean
-public abstract class Discovery extends Protocol {
+public abstract class AbstractDiscovery extends AbstractProtocol {
 
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
@@ -154,22 +154,22 @@ public abstract class Discovery extends Protocol {
     public void      setNumInitialMembers(int num)      {}
     public int       getNumberOfDiscoveryRequestsSent() {return num_discovery_requests;}
     public long      timeout()                          {return timeout;}
-    public Discovery timeout(long timeout)              {this.timeout=timeout; return this;}
+    public AbstractDiscovery timeout(long timeout)              {this.timeout=timeout; return this;}
     @Deprecated
     public long      numInitialMembers()                {return -1;}
     @Deprecated
-    public Discovery numInitialMembers(int num)         {return this;}
+    public AbstractDiscovery numInitialMembers(int num)         {return this;}
     public boolean   breakOnCoordResponse()             {return break_on_coord_rsp;}
-    public Discovery breakOnCoordResponse(boolean flag) {break_on_coord_rsp=flag; return this;}
+    public AbstractDiscovery breakOnCoordResponse(boolean flag) {break_on_coord_rsp=flag; return this;}
     public boolean   returnEntireCache()                {return return_entire_cache;}
-    public Discovery returnEntireCache(boolean flag)    {return_entire_cache=flag; return this;}
+    public AbstractDiscovery returnEntireCache(boolean flag)    {return_entire_cache=flag; return this;}
     public long      staggerTimeout()                   {return stagger_timeout;}
-    public Discovery staggerTimeout(long timeout)       {stagger_timeout=timeout; return this;}
+    public AbstractDiscovery staggerTimeout(long timeout)       {stagger_timeout=timeout; return this;}
     public boolean   forceDiscoveryResponses()          {return force_sending_discovery_rsps;}
-    public Discovery forceDiscoveryResponses(boolean f) {force_sending_discovery_rsps=f; return this;}
+    public AbstractDiscovery forceDiscoveryResponses(boolean f) {force_sending_discovery_rsps=f; return this;}
     public boolean   useDiskCache()                     {return use_disk_cache;}
-    public Discovery useDiskCache(boolean flag)         {use_disk_cache=flag; return this;}
-    public Discovery discoveryRspExpiryTime(long t)     {this.discovery_rsp_expiry_time=t; return this;}
+    public AbstractDiscovery useDiskCache(boolean flag)         {use_disk_cache=flag; return this;}
+    public AbstractDiscovery discoveryRspExpiryTime(long t)     {this.discovery_rsp_expiry_time=t; return this;}
 
 
 

--- a/src/org/jgroups/protocols/AbstractExecuting.java
+++ b/src/org/jgroups/protocols/AbstractExecuting.java
@@ -7,7 +7,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.blocks.executor.ExecutionService.DistributedFuture;
 import org.jgroups.blocks.executor.ExecutorEvent;
 import org.jgroups.blocks.executor.ExecutorNotification;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Streamable;
 import org.jgroups.util.Util;
 
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @see org.jgroups.protocols.CENTRAL_EXECUTOR
  */
 @MBean(description="Based class for executor service functionality")
-abstract public class Executing extends Protocol {
+abstract public class AbstractExecuting extends AbstractProtocol {
 
     @Property(description="bypasses message bundling if set")
     protected boolean bypass_bundling=true;
@@ -87,8 +87,8 @@ abstract public class Executing extends Protocol {
      * This is a server side store of all the barriers for respective tasks 
      * requests.  When a consumer is starting up they should create a latch
      * place in map with its id and wait on it until a request comes in to
-     * wake it up it would only then touch the {@link Executing#_tasks} map.  A requestor
-     * should first place in the {@link Executing#_tasks} map and then create a latch
+     * wake it up it would only then touch the {@link AbstractExecuting#_tasks} map.  A requestor
+     * should first place in the {@link AbstractExecuting#_tasks} map and then create a latch
      * and notify the consumer
      */
     protected ConcurrentMap<Long, CyclicBarrier> _taskBarriers = 
@@ -137,7 +137,7 @@ abstract public class Executing extends Protocol {
         DELETE_CONSUMER_READY   // request to backups from coordinator to delete a consumer ready. Used by CENTRAL_LOCKING
     }
     
-    public Executing() {
+    public AbstractExecuting() {
         _awaitingReturn = Collections.synchronizedMap(new HashMap<Owner, Runnable>());
         _running = Collections.synchronizedMap(new HashMap<Runnable, Owner>());
     }
@@ -1033,7 +1033,7 @@ abstract public class Executing extends Protocol {
     }
 
 
-    public static class ExecutorHeader extends Header {
+    public static class ExecutorHeader extends AbstractHeader {
 
         public ExecutorHeader() {
         }

--- a/src/org/jgroups/protocols/AbstractFlowControl.java
+++ b/src/org/jgroups/protocols/AbstractFlowControl.java
@@ -8,7 +8,7 @@ import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Average;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  */
 @MBean(description="Simple flow control protocol based on a credit system")
-public abstract class FlowControl extends Protocol {
+public abstract class AbstractFlowControl extends AbstractProtocol {
 
     protected final static FcHeader REPLENISH_HDR=new FcHeader(FcHeader.REPLENISH);
     protected final static FcHeader CREDIT_REQUEST_HDR=new FcHeader(FcHeader.CREDIT_REQUEST);  

--- a/src/org/jgroups/protocols/AbstractLocking.java
+++ b/src/org/jgroups/protocols/AbstractLocking.java
@@ -8,7 +8,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.blocks.locking.AwaitInfo;
 import org.jgroups.blocks.locking.LockInfo;
 import org.jgroups.blocks.locking.LockNotification;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Bits;
 import org.jgroups.util.Owner;
 import org.jgroups.util.Streamable;
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @see org.jgroups.protocols.CENTRAL_LOCK
  */
 @MBean(description="Based class for locking functionality")
-abstract public class Locking extends Protocol {
+abstract public class AbstractLocking extends AbstractProtocol {
 
     @Property(description="bypasses message bundling if set")
     protected boolean bypass_bundling=true;
@@ -84,7 +84,7 @@ abstract public class Locking extends Protocol {
 
 
 
-    public Locking() {
+    public AbstractLocking() {
     }
 
 
@@ -1396,7 +1396,7 @@ abstract public class Locking extends Protocol {
     }
 
 
-    public static class LockingHeader extends Header {
+    public static class LockingHeader extends AbstractHeader {
 
         public LockingHeader() {
         }

--- a/src/org/jgroups/protocols/AuthHeader.java
+++ b/src/org/jgroups/protocols/AuthHeader.java
@@ -1,8 +1,8 @@
 package org.jgroups.protocols;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
-import org.jgroups.auth.AuthToken;
+import org.jgroups.AbstractHeader;
+import org.jgroups.auth.AbstractAuthToken;
 import org.jgroups.conf.ClassConfigurator;
 
 import java.io.DataInput;
@@ -12,22 +12,22 @@ import java.io.DataOutput;
  * @author Chris Mills
  * @author Bela Ban
  */
-public class AuthHeader extends Header {
-    protected AuthToken token=null;
+public class AuthHeader extends AbstractHeader {
+    protected AbstractAuthToken token=null;
 
 
     public AuthHeader() {
     }
 
-    public AuthHeader(AuthToken token) {
+    public AuthHeader(AbstractAuthToken token) {
         this.token=token;
     }
 
 
-    public void       setToken(AuthToken token) {this.token = token;}
-    public AuthToken  getToken()                {return this.token;}
-    public AuthHeader token(AuthToken token)    {this.token=token; return this;}
-    public AuthToken  token()                   {return this.token;}
+    public void       setToken(AbstractAuthToken token) {this.token = token;}
+    public AbstractAuthToken getToken()                {return this.token;}
+    public AuthHeader token(AbstractAuthToken token)    {this.token=token; return this;}
+    public AbstractAuthToken token()                   {return this.token;}
 
 
     public void writeTo(DataOutput out) throws Exception {
@@ -47,7 +47,7 @@ public class AuthHeader extends Header {
     }
 
 
-    protected static void writeAuthToken(DataOutput out, AuthToken tok) throws Exception {
+    protected static void writeAuthToken(DataOutput out, AbstractAuthToken tok) throws Exception {
         out.writeByte(tok == null? 0 : 1);
         if(tok == null) return;
         short id=ClassConfigurator.getMagicNumber(tok.getClass());
@@ -59,7 +59,7 @@ public class AuthHeader extends Header {
         tok.writeTo(out);
     }
 
-    protected static AuthToken readAuthToken(DataInput in) throws Exception {
+    protected static AbstractAuthToken readAuthToken(DataInput in) throws Exception {
         if(in.readByte() == 0) return null;
         short id=in.readShort();
         Class<?> clazz;
@@ -70,12 +70,12 @@ public class AuthHeader extends Header {
             String classname=in.readUTF();
             clazz=Class.forName(classname);
         }
-        AuthToken retval=(AuthToken)clazz.newInstance();
+        AbstractAuthToken retval=(AbstractAuthToken)clazz.newInstance();
         retval.readFrom(in);
         return retval;
     }
 
-    protected static int sizeOf(AuthToken tok) {
+    protected static int sizeOf(AbstractAuthToken tok) {
         int retval=Global.BYTE_SIZE; // null token ?
         if(tok == null) return retval;
 

--- a/src/org/jgroups/protocols/BARRIER.java
+++ b/src/org/jgroups/protocols/BARRIER.java
@@ -8,7 +8,7 @@ import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
@@ -36,7 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Blocks all multicast threads when closed")
-public class BARRIER extends Protocol {
+public class BARRIER extends AbstractProtocol {
     
     @Property(description="Max time barrier can be closed. Default is 60000 ms")
     protected long                       max_close_time=60000; // how long can the barrier stay closed (in ms) ? 0 means forever
@@ -65,7 +65,7 @@ public class BARRIER extends Protocol {
     // queues unicast messages or message batches (dest != null)
     protected final Map<Address,Message> ucast_queue=new ConcurrentHashMap<>();
 
-    protected TP                         transport;
+    protected AbstractTP transport;
 
     protected static final Object        NULL=new Object();
 

--- a/src/org/jgroups/protocols/CENTRAL_EXECUTOR.java
+++ b/src/org/jgroups/protocols/CENTRAL_EXECUTOR.java
@@ -19,7 +19,7 @@ import java.util.Set;
  * @author wburns
  * @since 2.12.0
  */
-public class CENTRAL_EXECUTOR extends Executing {
+public class CENTRAL_EXECUTOR extends AbstractExecuting {
 
     @Property(description="Number of backups to the coordinator.  Queue State gets replicated to these nodes as well")
     protected int num_backups=1;

--- a/src/org/jgroups/protocols/CENTRAL_LOCK.java
+++ b/src/org/jgroups/protocols/CENTRAL_LOCK.java
@@ -27,10 +27,10 @@ import java.util.*;
  * An alternative is also the {@link org.jgroups.protocols.PEER_LOCK} protocol.
  * @author Bela Ban
  * @since 2.12
- * @see Locking
+ * @see AbstractLocking
  * @see PEER_LOCK
  */
-public class CENTRAL_LOCK extends Locking implements LockNotification {
+public class CENTRAL_LOCK extends AbstractLocking implements LockNotification {
 
     @Property(description="Number of backups to the coordinator. Server locks get replicated to these nodes as well")
     protected int                 num_backups=1;

--- a/src/org/jgroups/protocols/COMPRESS.java
+++ b/src/org/jgroups/protocols/COMPRESS.java
@@ -2,11 +2,11 @@ package org.jgroups.protocols;
 
 import org.jgroups.Event;
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.Message;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 
@@ -26,7 +26,7 @@ import java.util.zip.Inflater;
  * @author Bela Ban
  */
 @MBean(description="Compresses messages to send and uncompresses received messages")
-public class COMPRESS extends Protocol {   
+public class COMPRESS extends AbstractProtocol {
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
     
@@ -191,7 +191,7 @@ public class COMPRESS extends Protocol {
 
 
 
-    public static class CompressHeader extends Header {
+    public static class CompressHeader extends AbstractHeader {
         int original_size=0;
 
         public CompressHeader() {

--- a/src/org/jgroups/protocols/DAISYCHAIN.java
+++ b/src/org/jgroups/protocols/DAISYCHAIN.java
@@ -5,7 +5,7 @@ import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 
@@ -26,7 +26,7 @@ import java.util.concurrent.Executor;
  */
 @Experimental
 @MBean(description="Protocol just above the transport which disseminates multicasts via daisy chaining")
-public class DAISYCHAIN extends Protocol {
+public class DAISYCHAIN extends AbstractProtocol {
 
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
@@ -194,7 +194,7 @@ public class DAISYCHAIN extends Protocol {
     }
 
 
-    public static class DaisyHeader extends Header {
+    public static class DaisyHeader extends AbstractHeader {
         private short   ttl;
 
         public DaisyHeader() {

--- a/src/org/jgroups/protocols/DELAY.java
+++ b/src/org/jgroups/protocols/DELAY.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.Event;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * @author Matej Cimbora
  */
 @MBean(description="Written by Sanne")
-public class DELAY extends Protocol {
+public class DELAY extends AbstractProtocol {
 
     private static final Random randomNumberGenerator = new Random();
 

--- a/src/org/jgroups/protocols/DISCARD.java
+++ b/src/org/jgroups/protocols/DISCARD.java
@@ -6,7 +6,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.View;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 import javax.swing.*;
@@ -23,7 +23,7 @@ import java.util.List;
  */
 @Unsupported
 @MBean(description="Discards messages")
-public class DISCARD extends Protocol {
+public class DISCARD extends AbstractProtocol {
     @Property
     protected double                    up=0.0;    // probability of dropping up   msgs
 

--- a/src/org/jgroups/protocols/DISCARD_PAYLOAD.java
+++ b/src/org/jgroups/protocols/DISCARD_PAYLOAD.java
@@ -4,7 +4,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.Property;
 import org.jgroups.annotations.Unsupported;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 /**
  * Discards a message whose sequence number (in the payload, as a Long) matches seqno 2 times,
@@ -13,7 +13,7 @@ import org.jgroups.stack.Protocol;
  * @author Bela Ban
  */
 @Unsupported
-public class DISCARD_PAYLOAD extends Protocol {
+public class DISCARD_PAYLOAD extends AbstractProtocol {
     @Property protected long seqno=3; // drop 3
     @Property protected long duplicate=4; // duplicate 4 (one time)
     protected int            num_discards=0;

--- a/src/org/jgroups/protocols/DUPL.java
+++ b/src/org/jgroups/protocols/DUPL.java
@@ -4,7 +4,7 @@ import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 import java.util.ArrayList;
@@ -13,7 +13,7 @@ import java.util.List;
 /** Duplicates outgoing or incoming messages by copying them
  * @author Bela Ban
  */
-public class DUPL extends Protocol {
+public class DUPL extends AbstractProtocol {
     protected static enum Direction {UP,DOWN};
 
     @Property(description="Number of copies of each incoming message (0=no copies)")

--- a/src/org/jgroups/protocols/ENCRYPT.java
+++ b/src/org/jgroups/protocols/ENCRYPT.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.AsciiString;
 import org.jgroups.util.Buffer;
 import org.jgroups.util.MessageBatch;
@@ -104,7 +104,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Protocol which encrypts and decrypts cluster traffic")
-public class ENCRYPT extends Protocol {
+public class ENCRYPT extends AbstractProtocol {
     private static final String DEFAULT_SYM_ALGO="AES";
     Address local_addr;
     Address keyServerAddr;
@@ -986,7 +986,7 @@ public class ENCRYPT extends Protocol {
     }
 
 
-    public static class EncryptHeader extends org.jgroups.Header {
+    public static class EncryptHeader extends AbstractHeader {
         public static final byte ENCRYPT            = 1 << 0;
         public static final byte KEY_REQUEST        = 1 << 1;
         public static final byte SECRETKEY          = 1 << 2;

--- a/src/org/jgroups/protocols/EXAMPLE.java
+++ b/src/org/jgroups/protocols/EXAMPLE.java
@@ -4,7 +4,7 @@ package org.jgroups.protocols;
 import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Unsupported;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 import java.io.DataInput;
@@ -21,7 +21,7 @@ import java.util.List;
  */
 @Unsupported
 @MBean(description="Sample protocol")
-public class EXAMPLE extends Protocol {
+public class EXAMPLE extends AbstractProtocol {
     final List<Address> members=new ArrayList<>();
 
 
@@ -78,7 +78,7 @@ public class EXAMPLE extends Protocol {
     }
 
 
-    public static class ExampleHeader extends Header {
+    public static class ExampleHeader extends AbstractHeader {
         // your variables
 
         public int size() {

--- a/src/org/jgroups/protocols/FC.java
+++ b/src/org/jgroups/protocols/FC.java
@@ -5,7 +5,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.View;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.BoundedList;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @MBean(description="Simple flow control protocol based on a credit system")
 @Deprecated
-public class FC extends Protocol {
+public class FC extends AbstractProtocol {
 
     private final static FcHeader REPLENISH_HDR=new FcHeader(FcHeader.REPLENISH);
     private final static FcHeader CREDIT_REQUEST_HDR=new FcHeader(FcHeader.CREDIT_REQUEST);

--- a/src/org/jgroups/protocols/FD.java
+++ b/src/org/jgroups/protocols/FD.java
@@ -4,7 +4,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.BoundedList;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.TimeScheduler;
@@ -41,7 +41,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Failure detection based on simple heartbeat protocol")
-public class FD extends Protocol {
+public class FD extends AbstractProtocol {
     
     /* -----------------------------------------    Properties     -------------------------------------------------- */
 
@@ -371,7 +371,7 @@ public class FD extends Protocol {
 
 
 
-    public static class FdHeader extends Header {
+    public static class FdHeader extends AbstractHeader {
         public static final byte HEARTBEAT     = 0;
         public static final byte HEARTBEAT_ACK = 1;
         public static final byte SUSPECT       = 2;

--- a/src/org/jgroups/protocols/FD_ALL.java
+++ b/src/org/jgroups/protocols/FD_ALL.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Failure detection based on simple heartbeat protocol")
-public class FD_ALL extends Protocol {
+public class FD_ALL extends AbstractProtocol {
     
     /* -----------------------------------------    Properties     -------------------------------------------------- */
 
@@ -182,7 +182,7 @@ public class FD_ALL extends Protocol {
                 Message msg=(Message)evt.getArg();
                 Address sender=msg.getSrc();
 
-                Header hdr=msg.getHeader(this.id);
+                AbstractHeader hdr=msg.getHeader(this.id);
                 if(hdr != null) {
                     update(sender); // updates the heartbeat entry for 'sender'
                     num_heartbeats_received++;
@@ -395,7 +395,7 @@ public class FD_ALL extends Protocol {
     }
 
 
-    public static class HeartbeatHeader extends Header {
+    public static class HeartbeatHeader extends AbstractHeader {
         public HeartbeatHeader() {}
         public String toString() {return "heartbeat";}
         public int size() {return 0;}

--- a/src/org/jgroups/protocols/FD_ALL2.java
+++ b/src/org/jgroups/protocols/FD_ALL2.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @Experimental
 @MBean(description="Failure detection based on simple heartbeat protocol")
-public class FD_ALL2 extends Protocol {
+public class FD_ALL2 extends AbstractProtocol {
     
     /* -----------------------------------------    Properties     -------------------------------------------------- */
 
@@ -170,7 +170,7 @@ public class FD_ALL2 extends Protocol {
                 Message msg=(Message)evt.getArg();
                 Address sender=msg.getSrc();
 
-                Header hdr=msg.getHeader(this.id);
+                AbstractHeader hdr=msg.getHeader(this.id);
                 if(hdr != null) {
                     update(sender); // updates the heartbeat entry for 'sender'
                     num_heartbeats_received++;
@@ -379,7 +379,7 @@ public class FD_ALL2 extends Protocol {
     }
 
 
-    public static class HeartbeatHeader extends Header {
+    public static class HeartbeatHeader extends AbstractHeader {
         public HeartbeatHeader() {}
         public String toString() {return "heartbeat";}
         public int size() {return 0;}

--- a/src/org/jgroups/protocols/FD_HOST.java
+++ b/src/org/jgroups/protocols/FD_HOST.java
@@ -9,7 +9,7 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  */
 @MBean(description="Failure detection protocol which detects crashes or hangs of entire hosts and suspects " +
   "all cluster members on those hosts")
-public class FD_HOST extends Protocol {
+public class FD_HOST extends AbstractProtocol {
 
     @Property(description="The command used to check a given host for liveness. Example: \"ping\". " +
       "If null, InetAddress.isReachable() will be used by default")

--- a/src/org/jgroups/protocols/FD_SOCK.java
+++ b/src/org/jgroups/protocols/FD_SOCK.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.*;
 import org.jgroups.conf.PropertyConverters;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.ThreadFactory;
 
@@ -32,7 +32,7 @@ import java.util.concurrent.*;
  * @author Bela Ban May 29 2001
  */
 @MBean(description="Failure detection protocol based on sockets connecting members")
-public class FD_SOCK extends Protocol implements Runnable {
+public class FD_SOCK extends AbstractProtocol implements Runnable {
     protected static final int NORMAL_TERMINATION=9;
     protected static final int ABNORMAL_TERMINATION=-1;
 
@@ -896,7 +896,7 @@ public class FD_SOCK extends Protocol implements Runnable {
     /* ------------------------------- End of Private Methods ------------------------------------ */
 
 
-    public static class FdHeader extends Header {
+    public static class FdHeader extends AbstractHeader {
         public static final byte SUSPECT       = 10;
         public static final byte UNSUSPECT     = 11;
         public static final byte WHO_HAS_SOCK  = 12;

--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
  * The design is at doc/design/FILE_PING.txt
  * @author Bela Ban
  */
-public class FILE_PING extends Discovery {
+public class FILE_PING extends AbstractDiscovery {
     protected static final String SUFFIX=".list";
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */

--- a/src/org/jgroups/protocols/FORWARD_TO_COORD.java
+++ b/src/org/jgroups/protocols/FORWARD_TO_COORD.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Bits;
 import org.jgroups.util.ForwardQueue;
 import org.jgroups.util.Util;
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 3.2
  */
 @MBean(description="Forwards unicast messages to the current coordinator")
-public class FORWARD_TO_COORD extends Protocol {
+public class FORWARD_TO_COORD extends AbstractProtocol {
 
     @Property(description="The delay (in ms) to wait until we resend a message to member P after P told us that " +
       "it isn't the coordinator. Thsi can happen when we see P as new coordinator, but P hasn't yet installed the view " +
@@ -188,7 +188,7 @@ public class FORWARD_TO_COORD extends Protocol {
 
 
 
-    protected static class ForwardHeader extends Header {
+    protected static class ForwardHeader extends AbstractHeader {
         protected static final byte MSG       = 1; // attached to the messages to the coord
         protected static final byte ACK       = 2; // sent back by the coord
         protected static final byte NOT_COORD = 3; // sent by the coord when it is *not* the coord

--- a/src/org/jgroups/protocols/FRAG.java
+++ b/src/org/jgroups/protocols/FRAG.java
@@ -8,7 +8,7 @@ import org.jgroups.View;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Filip Hanik
  */
 @MBean(description="Fragments messages larger than fragmentation size into smaller packets")
-public class FRAG extends Protocol {
+public class FRAG extends AbstractProtocol {
     
     /* -----------------------------------------    Properties     -------------------------------------------------- */
 

--- a/src/org/jgroups/protocols/FRAG2.java
+++ b/src/org/jgroups/protocols/FRAG2.java
@@ -5,7 +5,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.View;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Range;
 import org.jgroups.util.Util;
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Fragments messages larger than fragmentation size into smaller packets")
-public class FRAG2 extends Protocol {
+public class FRAG2 extends AbstractProtocol {
     
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
@@ -86,7 +86,7 @@ public class FRAG2 extends Protocol {
         if(frag_size <=0)
             throw new Exception("frag_size=" + old_frag_size + ", new frag_size=" + frag_size + ": new frag_size is invalid");
 
-        TP transport=getTransport();
+        AbstractTP transport=getTransport();
         if(transport != null) {
             int max_bundle_size=transport.getMaxBundleSize();
             if(frag_size >= max_bundle_size)

--- a/src/org/jgroups/protocols/FcHeader.java
+++ b/src/org/jgroups/protocols/FcHeader.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -10,7 +10,7 @@ import java.io.DataOutput;
  * Header used by various flow control protocols
  * @author Bela Ban
  */
-public class FcHeader extends Header {
+public class FcHeader extends AbstractHeader {
     public static final byte REPLENISH=1;
     public static final byte CREDIT_REQUEST=2; // the sender of the message is the requester
 

--- a/src/org/jgroups/protocols/FragHeader.java
+++ b/src/org/jgroups/protocols/FragHeader.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Bits;
 
 import java.io.DataInput;
@@ -11,7 +11,7 @@ import java.io.DataOutput;
 /**
  * @author Bela Ban
  */
-public class FragHeader extends Header {
+public class FragHeader extends AbstractHeader {
     public long id;
     public int  frag_id;
     public int  num_frags;

--- a/src/org/jgroups/protocols/HDRS.java
+++ b/src/org/jgroups/protocols/HDRS.java
@@ -5,7 +5,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 
@@ -13,7 +13,7 @@ import org.jgroups.util.MessageBatch;
  * Prints the headers of all sent or received messages
  */
 @MBean(description="Prints the headers of all sent and/or received messages")
-public class HDRS extends Protocol {
+public class HDRS extends AbstractProtocol {
     @Property(description="Enables printing of down messages")
     protected volatile boolean print_down=true;
 

--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Future;
  * @author Sanne Grinovero
  * @since 2.12
  */
-public class JDBC_PING extends Discovery {
+public class JDBC_PING extends AbstractDiscovery {
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
 

--- a/src/org/jgroups/protocols/MAKE_BATCH.java
+++ b/src/org/jgroups/protocols/MAKE_BATCH.java
@@ -5,7 +5,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.AsciiString;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.TimeScheduler;
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  * @since  3.5
  */
 @MBean(description="Intercepts single messages and passes them up as batches")
-public class MAKE_BATCH extends Protocol {
+public class MAKE_BATCH extends AbstractProtocol {
     @Property(description="handle multicast messages")
     protected boolean multicasts=false;
 

--- a/src/org/jgroups/protocols/MERGE2.java
+++ b/src/org/jgroups/protocols/MERGE2.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -44,7 +44,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @MBean(description="Protocol to discover subgroups existing due to a network partition")
 @Deprecated
-public class MERGE2 extends Protocol {
+public class MERGE2 extends AbstractProtocol {
     
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
@@ -475,7 +475,7 @@ public class MERGE2 extends Protocol {
     }
 
 
-    protected static class MergeHeader extends Header {
+    protected static class MergeHeader extends AbstractHeader {
         protected byte    type=1; // 1 == req, 2 == rsp
         protected View    view;
         protected static final byte REQ=1;

--- a/src/org/jgroups/protocols/MERGE3.java
+++ b/src/org/jgroups/protocols/MERGE3.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
 
@@ -34,7 +34,7 @@ import java.util.concurrent.Future;
  * @since 3.1
  */
 @MBean(description="Protocol to discover subgroups existing due to a network partition")
-public class MERGE3 extends Protocol {
+public class MERGE3 extends AbstractProtocol {
     
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
@@ -513,7 +513,7 @@ public class MERGE3 extends Protocol {
     }
 
 
-    public static class MergeHeader extends Header {
+    public static class MergeHeader extends AbstractHeader {
         protected Type                        type=Type.INFO;
         protected ViewId                      view_id;
         protected String                      logical_name;

--- a/src/org/jgroups/protocols/MFC.java
+++ b/src/org/jgroups/protocols/MFC.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  */
 @MBean(description="Simple flow control protocol based on a credit system")
-public class MFC extends FlowControl {
+public class MFC extends AbstractFlowControl {
 
     
     

--- a/src/org/jgroups/protocols/PDC.java
+++ b/src/org/jgroups/protocols/PDC.java
@@ -7,7 +7,7 @@ import org.jgroups.View;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
 
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since  3.3
  */
 @MBean(description="Persistent Discovery Cache. Caches discovery information on disk.")
-public class PDC extends Protocol {
+public class PDC extends AbstractProtocol {
     protected final ConcurrentMap<Address,PhysicalAddress> cache=new ConcurrentHashMap<>();
 
     /* -----------------------------------------    Properties     ----------------------------------------------- */

--- a/src/org/jgroups/protocols/PEER_LOCK.java
+++ b/src/org/jgroups/protocols/PEER_LOCK.java
@@ -29,11 +29,11 @@ import java.util.Map;
  * An alternative is also the {@link org.jgroups.protocols.CENTRAL_LOCK} protocol.
  * @author Bela Ban
  * @since 2.12
- * @see Locking
+ * @see AbstractLocking
  * @see CENTRAL_LOCK
  * @deprecated Use {@link org.jgroups.protocols.CENTRAL_LOCK} instead
  */
-public class PEER_LOCK extends Locking {
+public class PEER_LOCK extends AbstractLocking {
 
     public PEER_LOCK() {
         super();

--- a/src/org/jgroups/protocols/PERF.java
+++ b/src/org/jgroups/protocols/PERF.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Average;
 import org.jgroups.util.MessageBatch;
 
@@ -12,9 +12,9 @@ import java.io.DataInput;
 import java.io.DataOutput;
 
 /**
- * Protocol measuring latency between stacks. On {@link Protocol#down(org.jgroups.Event)}, a header is added to the
+ * Protocol measuring latency between stacks. On {@link AbstractProtocol#down(org.jgroups.Event)}, a header is added to the
  * message with the ID of the PERF protocol and the start time is set in the header.
- * On {@link Protocol#up(org.jgroups.Event)}, the time difference is computed and a rolling average is updated in PERF.<p/>
+ * On {@link AbstractProtocol#up(org.jgroups.Event)}, the time difference is computed and a rolling average is updated in PERF.<p/>
  * Note that we can have several measurements by inserting PERF protocols with different IDs (Protocol.id) into the stack.</p>
  * If PERF is used to measure latency between nodes running on different physical boxes, it is important that the clocks
  * are synchronized, or else latency cannot be computed correctly (may even be negative).
@@ -22,7 +22,7 @@ import java.io.DataOutput;
  * @since  3.5
  */
 @MBean(description="Measures latency between PERF instances")
-public class PERF extends Protocol {
+public class PERF extends AbstractProtocol {
     protected Average avg;
     protected Address local_addr;
 
@@ -92,7 +92,7 @@ public class PERF extends Protocol {
         super.up(batch);
     }
 
-    protected static class PerfHeader extends Header {
+    protected static class PerfHeader extends AbstractHeader {
         protected long start_time; // in ns
 
         public PerfHeader() {

--- a/src/org/jgroups/protocols/PING.java
+++ b/src/org/jgroups/protocols/PING.java
@@ -20,7 +20,7 @@ import java.util.List;
  * with a discovery response.
  * @author Bela Ban
  */
-public class PING extends Discovery {
+public class PING extends AbstractDiscovery {
 
     public boolean isDynamic() {
         return true;

--- a/src/org/jgroups/protocols/PRIO.java
+++ b/src/org/jgroups/protocols/PRIO.java
@@ -1,11 +1,12 @@
 package org.jgroups.protocols;
 
+import org.jgroups.AbstractChannel;
 import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 import java.util.Comparator;
@@ -32,7 +33,7 @@ import java.util.concurrent.PriorityBlockingQueue;
  * @author Michael Earl
  */
 @Experimental
-public class PRIO extends Protocol {
+public class PRIO extends AbstractProtocol {
 	private PriorityBlockingQueue<PriorityMessage> downMessageQueue;
 	private PriorityBlockingQueue<PriorityMessage> upMessageQueue;
     private DownMessageThread                      downMessageThread;
@@ -50,12 +51,12 @@ public class PRIO extends Protocol {
     private Address local_addr;
 
     /**
-     * This method is called on a {@link org.jgroups.Channel#connect(String)}. Starts work.
+     * This method is called on a {@link AbstractChannel#connect(String)}. Starts work.
      * Protocols are connected and queues are ready to receive events.
      * Will be called <em>from bottom to top</em>. This call will replace
      * the <b>START</b> and <b>START_OK</b> events.
      * @exception Exception Thrown if protocol cannot be started successfully. This will cause the ProtocolStack
-     *                      to fail, so {@link org.jgroups.Channel#connect(String)} will throw an exception
+     *                      to fail, so {@link AbstractChannel#connect(String)} will throw an exception
      */
     public void start() throws Exception {
 		if (prioritize_down) {
@@ -72,7 +73,7 @@ public class PRIO extends Protocol {
     }
 
     /**
-     * This method is called on a {@link org.jgroups.Channel#disconnect()}. Stops work (e.g. by closing multicast socket).
+     * This method is called on a {@link AbstractChannel#disconnect()}. Stops work (e.g. by closing multicast socket).
      * Will be called <em>from top to bottom</em>. This means that at the time of the method invocation the
      * neighbor protocol below is still working. This method will replace the
      * <b>STOP</b>, <b>STOP_OK</b>, <b>CLEANUP</b> and <b>CLEANUP_OK</b> events. The ProtocolStack guarantees that
@@ -188,7 +189,7 @@ public class PRIO extends Protocol {
 	 * <P>
 	 * The messageQueue contains the prioritized messages 
 	 */
-	private class DownMessageThread extends MessageThread {
+	private class DownMessageThread extends AbstractMessageThread {
 		private DownMessageThread( PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
 			super( prio, messageQueue );
 		}
@@ -204,7 +205,7 @@ public class PRIO extends Protocol {
 	 * <P>
 	 * The messageQueue contains the prioritized messages
 	 */
-	private class UpMessageThread extends MessageThread {
+	private class UpMessageThread extends AbstractMessageThread {
 		private UpMessageThread( PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
 			super( prio, messageQueue );
 		}
@@ -219,13 +220,13 @@ public class PRIO extends Protocol {
      * This Thread class will process PriorityMessage's off of the queue and call the handleMessage method
 	 * to send the message
      */
-    private abstract class MessageThread extends Thread
+    private abstract class AbstractMessageThread extends Thread
     {
 		private PRIO prio;
 		private PriorityBlockingQueue<PriorityMessage> messageQueue;
         private volatile boolean running=true;
 
-        private MessageThread( PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
+        private AbstractMessageThread(PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
 			this.prio = prio;
 			this.messageQueue = messageQueue;
             setName( "PRIO " + (messageQueue == downMessageQueue ? "down" : "up") );

--- a/src/org/jgroups/protocols/PingHeader.java
+++ b/src/org/jgroups/protocols/PingHeader.java
@@ -2,7 +2,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Bits;
 
 import java.io.DataInput;
@@ -12,7 +12,7 @@ import java.io.DataOutput;
 /**
  * @author Bela Ban
  */
-public class PingHeader extends Header {
+public class PingHeader extends AbstractHeader {
     public static final byte GET_MBRS_REQ=1;
     public static final byte GET_MBRS_RSP=2;
 

--- a/src/org/jgroups/protocols/PrioHeader.java
+++ b/src/org/jgroups/protocols/PrioHeader.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -21,7 +21,7 @@ import java.io.DataOutput;
  * </code>
  * @author Michael Earl
  */
-public class PrioHeader extends Header {
+public class PrioHeader extends AbstractHeader {
 	private byte priority = 0;
 
 	public PrioHeader() {

--- a/src/org/jgroups/protocols/RATE_LIMITER.java
+++ b/src/org/jgroups/protocols/RATE_LIMITER.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 
 import java.util.Map;
@@ -19,7 +19,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @Experimental
 @MBean(description="Limits the sending rate to max_bytes per time_period")
-public class RATE_LIMITER extends Protocol {
+public class RATE_LIMITER extends AbstractProtocol {
 
     @Property(description="Max number of bytes to be sent in time_period ms. Blocks the sender if exceeded until a new " +
             "time period has started")

--- a/src/org/jgroups/protocols/RELAY.java
+++ b/src/org/jgroups/protocols/RELAY.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.*;
 import org.jgroups.stack.AddressGenerator;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
 
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  * @since 2.12
  */
 @MBean(description="RELAY protocol")
-public class RELAY extends Protocol {
+public class RELAY extends AbstractProtocol {
 
     /* ------------------------------------------    Properties     ---------------------------------------------- */
     @Property(description="Description of the local cluster, e.g. \"nyc\". This is added to every address, so it" +
@@ -621,7 +621,7 @@ public class RELAY extends Protocol {
     }
 
 
-    public static class RelayHeader extends Header {
+    public static class RelayHeader extends AbstractHeader {
         public static enum Type {DISSEMINATE, FORWARD, VIEW, BROADCAST_VIEW};
         protected Type                type;
         protected Address             original_sender; // with DISSEMINATE

--- a/src/org/jgroups/protocols/RSVP.java
+++ b/src/org/jgroups/protocols/RSVP.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.AckCollector;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.TimeScheduler;
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * @since  3.1
  */
 @MBean(description="Implements synchronous acks for messages which have their RSVP flag set)")
-public class RSVP extends Protocol {
+public class RSVP extends AbstractProtocol {
 
     /* -----------------------------------------    Properties     -------------------------------------------------- */
     @Property(description="Max time in milliseconds to block for an RSVP'ed message (0 blocks forever).")
@@ -368,7 +368,7 @@ public class RSVP extends Protocol {
     }
 
     
-    protected static class RsvpHeader extends Header {
+    protected static class RsvpHeader extends AbstractHeader {
         protected static final byte REQ      = 1;
         protected static final byte REQ_ONLY = 2;
         protected static final byte RSP      = 3;

--- a/src/org/jgroups/protocols/S3_PING.java
+++ b/src/org/jgroups/protocols/S3_PING.java
@@ -385,7 +385,7 @@ public class S3_PING extends FILE_PING {
         private boolean isSecure;
         private String server;
         private int port;
-        private CallingFormat callingFormat;
+        private AbstractCallingFormat callingFormat;
 
         public AWSAuthConnection(String awsAccessKeyId, String awsSecretAccessKey) {
             this(awsAccessKeyId, awsSecretAccessKey, true);
@@ -403,12 +403,12 @@ public class S3_PING extends FILE_PING {
 
         public AWSAuthConnection(String awsAccessKeyId, String awsSecretAccessKey, boolean isSecure,
                                  String server, int port) {
-            this(awsAccessKeyId, awsSecretAccessKey, isSecure, server, port, CallingFormat.getSubdomainCallingFormat());
+            this(awsAccessKeyId, awsSecretAccessKey, isSecure, server, port, AbstractCallingFormat.getSubdomainCallingFormat());
 
         }
 
         public AWSAuthConnection(String awsAccessKeyId, String awsSecretAccessKey, boolean isSecure,
-                                 String server, CallingFormat format) {
+                                 String server, AbstractCallingFormat format) {
             this(awsAccessKeyId, awsSecretAccessKey, isSecure, server,
                  isSecure? Utils.SECURE_PORT : Utils.INSECURE_PORT,
                  format);
@@ -425,7 +425,7 @@ public class S3_PING extends FILE_PING {
          * @param format             Type of request Regular/Vanity or Pure Vanity domain
          */
         public AWSAuthConnection(String awsAccessKeyId, String awsSecretAccessKey, boolean isSecure,
-                                 String server, int port, CallingFormat format) {
+                                 String server, int port, AbstractCallingFormat format) {
             this.awsAccessKeyId=awsAccessKeyId;
             this.awsSecretAccessKey=awsSecretAccessKey;
             this.isSecure=isSecure;
@@ -831,8 +831,8 @@ public class S3_PING extends FILE_PING {
         private HttpURLConnection makeRequest(String method, String bucket, String key, Map pathArgs, Map headers,
                                               S3Object object)
                 throws IOException {
-            CallingFormat format=Utils.getCallingFormatForBucket(this.callingFormat, bucket);
-            if(isSecure && format != CallingFormat.getPathCallingFormat() && bucket.contains(".")) {
+            AbstractCallingFormat format=Utils.getCallingFormatForBucket(this.callingFormat, bucket);
+            if(isSecure && format != AbstractCallingFormat.getPathCallingFormat() && bucket.contains(".")) {
                 System.err.println("You are making an SSL connection, however, the bucket contains periods and the wildcard certificate will not match by default.  Please consider using HTTP.");
             }
 
@@ -1477,11 +1477,11 @@ public class S3_PING extends FILE_PING {
     }
 
 
-    abstract static class CallingFormat {
+    abstract static class AbstractCallingFormat {
 
-        protected static CallingFormat pathCallingFormat=new PathCallingFormat();
-        protected static CallingFormat subdomainCallingFormat=new SubdomainCallingFormat();
-        protected static CallingFormat vanityCallingFormat=new VanityCallingFormat();
+        protected static AbstractCallingFormat pathCallingFormat=new PathCallingFormat();
+        protected static AbstractCallingFormat subdomainCallingFormat=new SubdomainCallingFormat();
+        protected static AbstractCallingFormat vanityCallingFormat=new VanityCallingFormat();
 
         public abstract boolean supportsLocatedBuckets();
 
@@ -1492,19 +1492,19 @@ public class S3_PING extends FILE_PING {
         public abstract URL getURL(boolean isSecure, String server, int port, String bucket, String key, Map pathArgs)
                 throws MalformedURLException;
 
-        public static CallingFormat getPathCallingFormat() {
+        public static AbstractCallingFormat getPathCallingFormat() {
             return pathCallingFormat;
         }
 
-        public static CallingFormat getSubdomainCallingFormat() {
+        public static AbstractCallingFormat getSubdomainCallingFormat() {
             return subdomainCallingFormat;
         }
 
-        public static CallingFormat getVanityCallingFormat() {
+        public static AbstractCallingFormat getVanityCallingFormat() {
             return vanityCallingFormat;
         }
 
-        private static class PathCallingFormat extends CallingFormat {
+        private static class PathCallingFormat extends AbstractCallingFormat {
             public boolean supportsLocatedBuckets() {
                 return false;
             }
@@ -1529,7 +1529,7 @@ public class S3_PING extends FILE_PING {
             }
         }
 
-        private static class SubdomainCallingFormat extends CallingFormat {
+        private static class SubdomainCallingFormat extends AbstractCallingFormat {
             public boolean supportsLocatedBuckets() {
                 return true;
             }
@@ -1825,8 +1825,8 @@ public class S3_PING extends FILE_PING {
         /**
          * Validate bucket-name
          */
-        static boolean validateBucketName(String bucketName, CallingFormat callingFormat) {
-            if(callingFormat == CallingFormat.getPathCallingFormat()) {
+        static boolean validateBucketName(String bucketName, AbstractCallingFormat callingFormat) {
+            if(callingFormat == AbstractCallingFormat.getPathCallingFormat()) {
                 final int MIN_BUCKET_LENGTH=3;
                 final int MAX_BUCKET_LENGTH=255;
                 final String BUCKET_NAME_REGEX="^[0-9A-Za-z\\.\\-_]*$";
@@ -1860,10 +1860,10 @@ public class S3_PING extends FILE_PING {
                     bucketName.matches(BUCKET_NAME_REGEX);
         }
 
-        static CallingFormat getCallingFormatForBucket(CallingFormat desiredFormat, String bucketName) {
-            CallingFormat callingFormat=desiredFormat;
-            if(callingFormat == CallingFormat.getSubdomainCallingFormat() && !Utils.isValidSubdomainBucketName(bucketName)) {
-                callingFormat=CallingFormat.getPathCallingFormat();
+        static AbstractCallingFormat getCallingFormatForBucket(AbstractCallingFormat desiredFormat, String bucketName) {
+            AbstractCallingFormat callingFormat=desiredFormat;
+            if(callingFormat == AbstractCallingFormat.getSubdomainCallingFormat() && !Utils.isValidSubdomainBucketName(bucketName)) {
+                callingFormat= AbstractCallingFormat.getPathCallingFormat();
             }
             return callingFormat;
         }

--- a/src/org/jgroups/protocols/SASL.java
+++ b/src/org/jgroups/protocols/SASL.java
@@ -25,7 +25,7 @@ import org.jgroups.conf.PropertyConverters;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.GMS.GmsHeader;
 import org.jgroups.protocols.pbcast.JoinRsp;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 /**
@@ -34,7 +34,7 @@ import org.jgroups.util.MessageBatch;
  * @author Tristan Tarrant
  */
 @MBean(description = "Provides SASL authentication")
-public class SASL extends Protocol {
+public class SASL extends AbstractProtocol {
     public static final short GMS_ID = ClassConfigurator.getProtocolId(GMS.class);
     public static final short SASL_ID = ClassConfigurator.getProtocolId(SASL.class);
     public static final String SASL_PROTOCOL_NAME = "jgroups";

--- a/src/org/jgroups/protocols/SCOPE.java
+++ b/src/org/jgroups/protocols/SCOPE.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.util.*;
 import org.jgroups.util.ThreadFactory;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 @MBean(description="Implementation of scopes (concurrent delivery of messages from the same sender)")
 @Deprecated
-public class SCOPE extends Protocol {
+public class SCOPE extends AbstractProtocol {
 
     protected int thread_pool_min_threads=2;
 
@@ -488,7 +488,7 @@ public class SCOPE extends Protocol {
     }
 
 
-    public static class ScopeHeader extends Header {
+    public static class ScopeHeader extends AbstractHeader {
         public static final byte MSG    = 1;
         public static final byte EXPIRE = 2;
 

--- a/src/org/jgroups/protocols/SEQUENCER.java
+++ b/src/org/jgroups/protocols/SEQUENCER.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Implementation of total order protocol using a sequencer")
-public class SEQUENCER extends Protocol {
+public class SEQUENCER extends AbstractProtocol {
     protected Address                           local_addr;
     protected volatile Address                  coord;
     protected volatile View                     view;
@@ -617,7 +617,7 @@ public class SEQUENCER extends Protocol {
 
 
 
-    public static class SequencerHeader extends Header {
+    public static class SequencerHeader extends AbstractHeader {
         protected static final byte FORWARD       = 1;
         protected static final byte FLUSH         = 2;
         protected static final byte BCAST         = 3;

--- a/src/org/jgroups/protocols/SEQUENCER2.java
+++ b/src/org/jgroups/protocols/SEQUENCER2.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Bits;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Table;
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 @Experimental
 @MBean(description="Implementation of total order protocol using a sequencer (unicast-unicast-multicast)")
-public class SEQUENCER2 extends Protocol {
+public class SEQUENCER2 extends AbstractProtocol {
     protected Address                           local_addr;
     protected volatile Address                  coord;
     protected volatile View                     view;
@@ -449,7 +449,7 @@ public class SEQUENCER2 extends Protocol {
     /* ----------------------------- End of Private Methods -------------------------------- */
     
 
-    public static class SequencerHeader extends Header {
+    public static class SequencerHeader extends AbstractHeader {
         protected static final byte REQUEST       = 1;
         protected static final byte BCAST         = 2;
         protected static final byte RESPONSE      = 3;

--- a/src/org/jgroups/protocols/SHARED_LOOPBACK.java
+++ b/src/org/jgroups/protocols/SHARED_LOOPBACK.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentMap;
  * us to test various protocols (with ProtocolTester) at maximum speed.
  * @author Bela Ban
  */
-public class SHARED_LOOPBACK extends TP {
+public class SHARED_LOOPBACK extends AbstractTP {
     protected PhysicalAddress  physical_addr;
 
     @ManagedAttribute(description="The current view",writable=false)

--- a/src/org/jgroups/protocols/SHARED_LOOPBACK_PING.java
+++ b/src/org/jgroups/protocols/SHARED_LOOPBACK_PING.java
@@ -13,11 +13,11 @@ import java.util.List;
  * @author Bela Ban
  * @since  3.5
  */
-public class SHARED_LOOPBACK_PING extends Discovery {
+public class SHARED_LOOPBACK_PING extends AbstractDiscovery {
 
     public void init() throws Exception {
         super.init();
-        TP tmp=getTransport();
+        AbstractTP tmp=getTransport();
         if(!(tmp instanceof SHARED_LOOPBACK))
             throw new IllegalStateException("the transport must be " + SHARED_LOOPBACK.class.getSimpleName());
         if(tmp.isSingleton())

--- a/src/org/jgroups/protocols/SHUFFLE.java
+++ b/src/org/jgroups/protocols/SHUFFLE.java
@@ -4,7 +4,7 @@ import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.TimeScheduler;
 
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  *
  */
 @Experimental
-public class SHUFFLE extends Protocol {
+public class SHUFFLE extends AbstractProtocol {
     protected TimeScheduler       timer=null;
     protected final List<Message> up_msgs=new LinkedList<>();
     protected final List<Message> down_msgs=new LinkedList<>();

--- a/src/org/jgroups/protocols/SIZE.java
+++ b/src/org/jgroups/protocols/SIZE.java
@@ -5,7 +5,7 @@ import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.annotations.Property;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 
@@ -19,7 +19,7 @@ import java.util.List;
  * 
  * @author Bela Ban June 13 2001
  */
-public class SIZE extends Protocol {
+public class SIZE extends AbstractProtocol {
     protected final List<Address> members=new ArrayList<>();
     @Property protected boolean   print_msg=false;
     @Property protected boolean   raw_buffer=false; // just print the payload size of the message

--- a/src/org/jgroups/protocols/STATS.java
+++ b/src/org/jgroups/protocols/STATS.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.annotations.MBean;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.Address;
@@ -16,7 +16,7 @@ import java.util.*;
  * @author Bela Ban
  */
 @MBean(description="Protocol which exposes various statistics")
-public class STATS extends Protocol {
+public class STATS extends AbstractProtocol {
     long sent_msgs, sent_bytes, sent_ucasts, sent_mcasts, received_ucasts, received_mcasts;
     long received_msgs, received_bytes, sent_ucast_bytes, sent_mcast_bytes, received_ucast_bytes, received_mcast_bytes;
 

--- a/src/org/jgroups/protocols/STOMP.java
+++ b/src/org/jgroups/protocols/STOMP.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.UUID;
 import org.jgroups.util.Util;
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since 2.11
  */
 @MBean(description="Server side STOPM protocol, STOMP clients can connect to it")
-public class STOMP extends Protocol implements Runnable {
+public class STOMP extends AbstractProtocol implements Runnable {
 
     /* -----------------------------------------    Properties     ----------------------------------------------- */
 
@@ -477,7 +477,7 @@ public class STOMP extends Protocol implements Runnable {
                     }
 
                     Message msg=new Message(null, frame.getBody());
-                    Header hdr=StompHeader.createHeader(StompHeader.Type.MESSAGE, headers);
+                    AbstractHeader hdr=StompHeader.createHeader(StompHeader.Type.MESSAGE, headers);
                     msg.putHeader(id, hdr);
                     down_prot.down(new Event(Event.MSG, msg));
                     String receipt=headers.get("receipt");
@@ -612,7 +612,7 @@ public class STOMP extends Protocol implements Runnable {
     }
 
 
-    public static class StompHeader extends org.jgroups.Header {
+    public static class StompHeader extends AbstractHeader {
         public static enum Type {MESSAGE, ENDPOINT}
 
         protected Type                      type;

--- a/src/org/jgroups/protocols/SaslHeader.java
+++ b/src/org/jgroups/protocols/SaslHeader.java
@@ -3,10 +3,10 @@ package org.jgroups.protocols;
 import java.io.DataInput;
 import java.io.DataOutput;
 
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Util;
 
-public class SaslHeader extends Header {
+public class SaslHeader extends AbstractHeader {
     public enum Type {
         CHALLENGE, RESPONSE
     };

--- a/src/org/jgroups/protocols/TCP.java
+++ b/src/org/jgroups/protocols/TCP.java
@@ -27,7 +27,7 @@ import java.util.Collection;
  * 
  * @author Bela Ban
  */
-public class TCP extends BasicTCP {
+public class TCP extends AbstractBasicTCP {
     
     private TcpServer server=null;
 

--- a/src/org/jgroups/protocols/TCPGOSSIP.java
+++ b/src/org/jgroups/protocols/TCPGOSSIP.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * 
  * @author Bela Ban
  */
-public class TCPGOSSIP extends Discovery implements RouterStub.MembersNotification {
+public class TCPGOSSIP extends AbstractDiscovery implements RouterStub.MembersNotification {
     
     /* -----------------------------------------    Properties     -------------------------------------------------- */
     
@@ -86,7 +86,7 @@ public class TCPGOSSIP extends Discovery implements RouterStub.MembersNotificati
         super.init();
         stubManager = RouterStubManager.emptyGossipClientStubManager(this).useNio(this.use_nio);
         // we cannot use TCPGOSSIP together with TUNNEL (https://jira.jboss.org/jira/browse/JGRP-1101)
-        TP transport=getTransport();
+        AbstractTP transport=getTransport();
         if(transport instanceof TUNNEL)
             throw new IllegalStateException("TCPGOSSIP cannot be used with TUNNEL; use either TUNNEL:PING or " +
                     "TCP:TCPGOSSIP as valid configurations");

--- a/src/org/jgroups/protocols/TCPPING.java
+++ b/src/org/jgroups/protocols/TCPPING.java
@@ -23,7 +23,7 @@ import java.util.*;
  *
  * @author Bela Ban
  */
-public class TCPPING extends Discovery {
+public class TCPPING extends AbstractDiscovery {
 
     /* -----------------------------------------    Properties     --------------------------------------- */
 

--- a/src/org/jgroups/protocols/TCP_NIO.java
+++ b/src/org/jgroups/protocols/TCP_NIO.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
 import org.jgroups.annotations.Unsupported;
-import org.jgroups.blocks.BasicConnectionTable;
+import org.jgroups.blocks.AbstractBasicConnectionTable;
 import org.jgroups.blocks.ConnectionTableNIO;
 
 import java.net.InetAddress;
@@ -19,7 +19,7 @@ import java.util.Collection;
  * @author Bela Ban
  */
 @Experimental @Unsupported @Deprecated
-public class TCP_NIO extends BasicTCP implements BasicConnectionTable.Receiver
+public class TCP_NIO extends AbstractBasicTCP implements AbstractBasicConnectionTable.Receiver
 {
 
     /*

--- a/src/org/jgroups/protocols/TCP_NIO2.java
+++ b/src/org/jgroups/protocols/TCP_NIO2.java
@@ -23,7 +23,7 @@ import java.util.Collection;
  * @author Bela Ban
  * @since 3.6.5
  */
-public class TCP_NIO2 extends BasicTCP {
+public class TCP_NIO2 extends AbstractBasicTCP {
     protected NioServer server;
 
     @Property(description="The max number of outgoing messages that can get queued for a given peer connection " +

--- a/src/org/jgroups/protocols/TRACE.java
+++ b/src/org/jgroups/protocols/TRACE.java
@@ -1,11 +1,11 @@
 
 package org.jgroups.protocols;
 import org.jgroups.Event;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 
 
-public class TRACE extends Protocol {
+public class TRACE extends AbstractProtocol {
 
     public TRACE() {}
 

--- a/src/org/jgroups/protocols/TUNNEL.java
+++ b/src/org/jgroups/protocols/TUNNEL.java
@@ -38,7 +38,7 @@ import java.util.List;
  * @author Vladimir Blagojevic
  */
 @Experimental
-public class TUNNEL extends TP implements RouterStub.StubReceiver {
+public class TUNNEL extends AbstractTP implements RouterStub.StubReceiver {
 
     public interface TUNNELPolicy {
         void sendToAllMembers(String group, byte[] data, int offset, int length) throws Exception;

--- a/src/org/jgroups/protocols/TpHeader.java
+++ b/src/org/jgroups/protocols/TpHeader.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols;
 
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.AsciiString;
 
 import java.io.DataInput;
@@ -14,7 +14,7 @@ import java.io.DataOutput;
  * Generic transport header, used by TP.
  * @author Bela Ban
  */
-public class TpHeader extends Header {
+public class TpHeader extends AbstractHeader {
     protected byte[] cluster_name;
 
     public TpHeader() { // used for externalization

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * 
  * @author Bela Ban
  */
-public class UDP extends TP {
+public class UDP extends AbstractTP {
 
     /* ------------------------------------------ Properties  ------------------------------------------ */
 

--- a/src/org/jgroups/protocols/UFC.java
+++ b/src/org/jgroups/protocols/UFC.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * @author Bela Ban
  */
 @MBean(description="Simple flow control protocol based on a credit system")
-public class UFC extends FlowControl {
+public class UFC extends AbstractFlowControl {
     
     /**
      * Map<Address,Long>: keys are members, values are credits left. For each send,
@@ -91,8 +91,8 @@ public class UFC extends FlowControl {
 
     public void init() throws Exception {
         super.init();
-        TP transport=getTransport();
-        if(transport instanceof BasicTCP)
+        AbstractTP transport=getTransport();
+        if(transport instanceof AbstractBasicTCP)
             log.info(this.getClass().getSimpleName() + " is not needed (and can be removed) as we're running on a TCP transport");
     }
 

--- a/src/org/jgroups/protocols/UNICAST.java
+++ b/src/org/jgroups/protocols/UNICAST.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.PropertyConverters;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -42,7 +42,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @Deprecated
 @MBean(description="Reliable unicast layer")
-public class UNICAST extends Protocol implements AgeOutCache.Handler<Address> {
+public class UNICAST extends AbstractProtocol implements AgeOutCache.Handler<Address> {
     public static final long DEFAULT_FIRST_SEQNO=Global.DEFAULT_FIRST_UNICAST_SEQNO;
 
 
@@ -993,7 +993,7 @@ public class UNICAST extends Protocol implements AgeOutCache.Handler<Address> {
      * | SEND_FIRST_SEQNO |
      * </pre>
      */
-    public static class UnicastHeader extends Header {
+    public static class UnicastHeader extends AbstractHeader {
         public static final byte DATA             = 0;
         public static final byte ACK              = 1;
         public static final byte SEND_FIRST_SEQNO = 2;

--- a/src/org/jgroups/protocols/UNICAST2.java
+++ b/src/org/jgroups/protocols/UNICAST2.java
@@ -6,7 +6,7 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.PropertyConverters;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -35,7 +35,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @Deprecated
 @MBean(description="Reliable unicast layer")
-public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
+public class UNICAST2 extends AbstractProtocol implements AgeOutCache.Handler<Address> {
     public static final long DEFAULT_FIRST_SEQNO=Global.DEFAULT_FIRST_UNICAST_SEQNO;
 
 
@@ -1145,7 +1145,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
      * | SEND_FIRST_SEQNO | seqno |
      * </pre>
      */
-    public static class Unicast2Header extends Header {
+    public static class Unicast2Header extends AbstractHeader {
         public static final byte DATA             = 0;
         public static final byte XMIT_REQ         = 1;
         public static final byte SEND_FIRST_SEQNO = 2;

--- a/src/org/jgroups/protocols/VERIFY_SUSPECT.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT.java
@@ -8,7 +8,7 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.PropertyConverters;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 
 import java.io.*;
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  */
 @MBean(description="Double-checks suspicions reports")
-public class VERIFY_SUSPECT extends Protocol implements Runnable {
+public class VERIFY_SUSPECT extends AbstractProtocol implements Runnable {
 
     /* ------------------------------------------ Properties  ------------------------------------------ */
     
@@ -337,7 +337,7 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
 
 
 
-    public static class VerifyHeader extends Header {
+    public static class VerifyHeader extends AbstractHeader {
         static final short ARE_YOU_DEAD=1;  // 'from' is sender of verify msg
         static final short I_AM_NOT_DEAD=2;  // 'from' is suspected member
 

--- a/src/org/jgroups/protocols/pbcast/AbstractGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/AbstractGmsImpl.java
@@ -13,14 +13,14 @@ import java.util.Collection;
 import java.util.Map;
 
 
-public abstract class GmsImpl {
+public abstract class AbstractGmsImpl {
     protected final GMS    gms;
     protected final Merger merger;
     protected final Log    log;
     volatile boolean       leaving=false;
 
 
-    protected GmsImpl(GMS gms) {
+    protected AbstractGmsImpl(GMS gms) {
         this.gms=gms;
         merger=gms.merger;
         log=gms.getLog();

--- a/src/org/jgroups/protocols/pbcast/AbstractServerGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/AbstractServerGmsImpl.java
@@ -10,9 +10,9 @@ import java.util.Collection;
  * Common super class for CoordGmsImpl and ParticipantGmsImpl
  * @author Bela Ban
  */
-public abstract class ServerGmsImpl extends GmsImpl {
+public abstract class AbstractServerGmsImpl extends AbstractGmsImpl {
 
-    protected ServerGmsImpl(GMS gms) {
+    protected AbstractServerGmsImpl(GMS gms) {
         super(gms);
     }
 

--- a/src/org/jgroups/protocols/pbcast/AbstractStreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/AbstractStreamingStateTransfer.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols.pbcast;
 import org.jgroups.*;
 import org.jgroups.annotations.*;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.StateTransferInfo;
 import org.jgroups.util.*;
 
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 3.0
  */
 @MBean(description="Streaming state transfer protocol base class")
-public abstract class StreamingStateTransfer extends Protocol implements ProcessingQueue.Handler<Address> {
+public abstract class AbstractStreamingStateTransfer extends AbstractProtocol implements ProcessingQueue.Handler<Address> {
 
     /*
      * ----------------------------------------------Properties -----------------------------------
@@ -89,7 +89,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
 
 
     /** Thread pool (configured with {@link #max_pool} and {@link #pool_thread_keep_alive}) to run
-     * {@link StreamingStateTransfer.StateGetter} threads on */
+     * {@link AbstractStreamingStateTransfer.StateGetter} threads on */
     protected ThreadPoolExecutor  thread_pool;
 
     /** List of members requesting state. Only a single state request is handled at any time */
@@ -507,7 +507,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
 
 
     
-    public static class StateHeader extends Header {
+    public static class StateHeader extends AbstractHeader {
         public static final byte STATE_REQ  = 1;
         public static final byte STATE_RSP  = 2;
         public static final byte STATE_PART = 3;

--- a/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
@@ -24,7 +24,7 @@ import java.util.*;
  * @author Bela Ban
  * @version $Revision: 1.78 $
  */
-public class ClientGmsImpl extends GmsImpl {
+public class ClientGmsImpl extends AbstractGmsImpl {
     protected final Promise<JoinRsp> join_promise=new Promise<>();
 
 

--- a/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
@@ -16,7 +16,7 @@ import java.util.*;
  * accordingly.
  * @author Bela Ban
  */
-public class CoordGmsImpl extends ServerGmsImpl {
+public class CoordGmsImpl extends AbstractServerGmsImpl {
     protected static final Long  MAX_SUSPEND_TIMEOUT=30000L;
 
     public CoordGmsImpl(GMS g) {

--- a/src/org/jgroups/protocols/pbcast/FLUSH.java
+++ b/src/org/jgroups/protocols/pbcast/FLUSH.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols.pbcast;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.*;
@@ -37,7 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 2.4
  */
 @MBean(description = "Flushes the cluster")
-public class FLUSH extends Protocol {
+public class FLUSH extends AbstractProtocol {
 
     private static final FlushStartResult SUCCESS_START_FLUSH = new FlushStartResult(Boolean.TRUE,null);
 
@@ -989,7 +989,7 @@ public class FLUSH extends Protocol {
       }
     }
 
-    public static class FlushHeader extends Header {
+    public static class FlushHeader extends AbstractHeader {
         public static final byte START_FLUSH         = 0;
         public static final byte STOP_FLUSH          = 2;
         public static final byte FLUSH_COMPLETED     = 3;

--- a/src/org/jgroups/protocols/pbcast/NAKACK.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK.java
@@ -6,7 +6,7 @@ import org.jgroups.Message;
 import org.jgroups.View;
 import org.jgroups.annotations.*;
 import org.jgroups.conf.PropertyConverters;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.stack.*;
 import org.jgroups.util.*;
 
@@ -36,7 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 @Deprecated
 @MBean(description="Reliable transmission multipoint FIFO protocol")
-public class NAKACK extends Protocol implements Retransmitter.RetransmitCommand, DiagnosticsHandler.ProbeHandler {
+public class NAKACK extends AbstractProtocol implements AbstractRetransmitter.RetransmitCommand, DiagnosticsHandler.ProbeHandler {
     private static final int NUM_REBROADCAST_MSGS=3;
 
     /* -----------------------------------------------------    Properties     --------------------- ------------------------------------ */
@@ -317,7 +317,7 @@ public class NAKACK extends Protocol implements Retransmitter.RetransmitCommand,
             }
         }
 
-        TP transport=getTransport();
+        AbstractTP transport=getTransport();
         if(transport != null) {
             transport.registerProbeHandler(this);
             if(!transport.supportsMulticasting()) {
@@ -897,7 +897,7 @@ public class NAKACK extends Protocol implements Retransmitter.RetransmitCommand,
             if(log.isTraceEnabled())
                 log.trace(local_addr + ": flushing become_server_queue (" + become_server_queue.size() + " elements)");
 
-            TP transport=getTransport();
+            AbstractTP transport=getTransport();
             Executor thread_pool=transport.getDefaultThreadPool(), oob_thread_pool=transport.getOOBThreadPool();
 
             for(final Message msg: become_server_queue) {

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -2,9 +2,9 @@ package org.jgroups.protocols.pbcast;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.stack.DiagnosticsHandler;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.util.*;
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Reliable transmission multipoint FIFO protocol")
-public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler {
+public class NAKACK2 extends AbstractProtocol implements DiagnosticsHandler.ProbeHandler {
     protected static final int NUM_REBROADCAST_MSGS=3;
 
     /* -----------------------------------------------------    Properties     --------------------- ------------------------------------ */
@@ -415,7 +415,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
             }
         }
 
-        TP transport=getTransport();
+        AbstractTP transport=getTransport();
         transport.registerProbeHandler(this);
         if(!transport.supportsMulticasting()) {
             if(use_mcast_xmit) {
@@ -995,7 +995,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
         if(become_server_queue != null && !become_server_queue.isEmpty()) {
             log.trace("%s: flushing become_server_queue (%d elements)", local_addr, become_server_queue.size());
 
-            TP transport=getTransport();
+            AbstractTP transport=getTransport();
             Executor thread_pool=transport.getDefaultThreadPool(), oob_thread_pool=transport.getOOBThreadPool();
 
             for(final Message msg: become_server_queue) {

--- a/src/org/jgroups/protocols/pbcast/NakAckHeader.java
+++ b/src/org/jgroups/protocols/pbcast/NakAckHeader.java
@@ -4,7 +4,7 @@ package org.jgroups.protocols.pbcast;
 
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Bits;
 import org.jgroups.util.Range;
 import org.jgroups.util.Util;
@@ -16,7 +16,7 @@ import java.io.DataOutput;
 /**
  * @author Bela Ban
  */
-public class NakAckHeader extends Header {
+public class NakAckHeader extends AbstractHeader {
     public static final byte MSG=1;       // regular msg
     public static final byte XMIT_REQ=2;  // retransmit request
     public static final byte XMIT_RSP=3;  // retransmit response (contains one or more messages)

--- a/src/org/jgroups/protocols/pbcast/NakAckHeader2.java
+++ b/src/org/jgroups/protocols/pbcast/NakAckHeader2.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols.pbcast;
 
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Bits;
 import org.jgroups.util.Util;
 
@@ -15,7 +15,7 @@ import java.io.DataOutput;
  * Header used by {@link org.jgroups.protocols.pbcast.NAKACK2}
  * @author Bela Ban
  */
-public class NakAckHeader2 extends Header {
+public class NakAckHeader2 extends AbstractHeader {
     public static final byte MSG           = 1;  // regular msg
     public static final byte XMIT_REQ      = 2;  // retransmit request
     public static final byte XMIT_RSP      = 3;  // retransmit response (contains one or more messages)

--- a/src/org/jgroups/protocols/pbcast/ParticipantGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ParticipantGmsImpl.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * @author Bela Ban
  */
-public class ParticipantGmsImpl extends ServerGmsImpl {
+public class ParticipantGmsImpl extends AbstractServerGmsImpl {
     private final List<Address>     suspected_mbrs=new ArrayList<>(11);
     private final Promise<Boolean>  leave_promise=new Promise<>();
 

--- a/src/org/jgroups/protocols/pbcast/STABLE.java
+++ b/src/org/jgroups/protocols/pbcast/STABLE.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols.pbcast;
 
 import org.jgroups.*;
 import org.jgroups.annotations.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import java.io.DataInput;
@@ -32,7 +32,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 @MBean(description="Computes the broadcast messages that are stable")
-public class STABLE extends Protocol {
+public class STABLE extends AbstractProtocol {
     protected static final long MAX_SUSPEND_TIME=200000;
 
     /* ------------------------------------------ Properties  ------------------------------------------ */
@@ -736,7 +736,7 @@ public class STABLE extends Protocol {
 
 
 
-    public static class StableHeader extends Header {
+    public static class StableHeader extends AbstractHeader {
         public static final byte STABLE_GOSSIP=1;
         public static final byte STABILITY=2;
 

--- a/src/org/jgroups/protocols/pbcast/STATE.java
+++ b/src/org/jgroups/protocols/pbcast/STATE.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @since 2.4
  */
 @MBean(description="Streaming state transfer protocol")
-public class STATE extends StreamingStateTransfer {
+public class STATE extends AbstractStreamingStateTransfer {
 
 
     /*

--- a/src/org/jgroups/protocols/pbcast/STATE_SOCK.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_SOCK.java
@@ -40,7 +40,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @since 3.0
  */
 @MBean(description="State trasnfer protocol based on streaming state transfer")
-public class STATE_SOCK extends StreamingStateTransfer {
+public class STATE_SOCK extends AbstractStreamingStateTransfer {
 
     /*
      * ----------------------------------------------Properties -----------------------------------

--- a/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.StateTransferInfo;
 import org.jgroups.util.Digest;
 import org.jgroups.util.ProcessingQueue;
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @see STATE_SOCK
  */
 @MBean(description="State transfer protocol based on byte array transfer")
-public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<Address> {
+public class STATE_TRANSFER extends AbstractProtocol implements ProcessingQueue.Handler<Address> {
     protected long                           start, stop; // to measure state transfer time
     protected final AtomicInteger            num_state_reqs=new AtomicInteger(0);
     protected final AtomicLong               num_bytes_sent=new AtomicLong(0);
@@ -384,7 +384,7 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
      * be stored in the header itself, but in the message's buffer.
      *
      */
-    public static class StateHeader extends Header {
+    public static class StateHeader extends AbstractHeader {
         public static final byte STATE_REQ = 1;
         public static final byte STATE_RSP = 2;
         public static final byte STATE_EX  = 3;

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -6,7 +6,7 @@ import org.jgroups.conf.ConfiguratorFactory;
 import org.jgroups.protocols.FORWARD_TO_COORD;
 import org.jgroups.protocols.relay.config.RelayConfig;
 import org.jgroups.stack.AddressGenerator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.jgroups.util.UUID;
 import org.w3c.dom.Node;
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @XmlInclude(schema="relay.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:jgroups:relay:1.0",alias="relay")
 @XmlElement(name="RelayConfiguration",type="relay:RelayConfigurationType")
 @MBean(description="RELAY2 protocol")
-public class RELAY2 extends Protocol {
+public class RELAY2 extends AbstractProtocol {
 
     /* ------------------------------------------    Properties     ---------------------------------------------- */
     @Property(description="Name of the site (needs to be defined in the configuration)",writable=false)
@@ -715,7 +715,7 @@ public class RELAY2 extends Protocol {
 
 
 
-    public static class Relay2Header extends Header {
+    public static class Relay2Header extends AbstractHeader {
         public static final byte DATA             = 1;
         public static final byte SITE_UNREACHABLE = 2; // final_dest is a SiteMaster
         public static final byte HOST_UNREACHABLE = 3; // final_dest is a SiteUUID (not currently used)

--- a/src/org/jgroups/protocols/relay/Relayer.java
+++ b/src/org/jgroups/protocols/relay/Relayer.java
@@ -64,14 +64,14 @@ public class Relayer {
      * @param my_site_id The ID of this site
      * @throws Throwable
      */
-    public void start(List<RelayConfig.BridgeConfig> bridge_configs, String bridge_name, final String my_site_id)
+    public void start(List<RelayConfig.AbstractBridgeConfig> bridge_configs, String bridge_name, final String my_site_id)
       throws Throwable {
         if(done) {
             log.trace(relay.getLocalAddress() + ": will not start the Relayer as stop() has been called");
             return;
         }
         try {
-            for(RelayConfig.BridgeConfig bridge_config: bridge_configs) {
+            for(RelayConfig.AbstractBridgeConfig bridge_config: bridge_configs) {
                 Bridge bridge=new Bridge(bridge_config.createChannel(), bridge_config.getClusterName(), bridge_name,
                                          new AddressGenerator() {
                                              public Address generateAddress() {

--- a/src/org/jgroups/protocols/relay/config/RelayConfig.java
+++ b/src/org/jgroups/protocols/relay/config/RelayConfig.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols.relay.config;
 
 import org.jgroups.JChannel;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -123,7 +123,7 @@ public class RelayConfig {
             Attr config_attr=(Attr)attrs.getNamedItem("config");
             String name=name_attr != null? name_attr.getValue() : null;
             String config=config_attr.getValue();
-            BridgeConfig bridge_config=new PropertiesBridgeConfig(name, config);
+            AbstractBridgeConfig bridge_config=new PropertiesBridgeConfig(name, config);
             site_config.addBridge(bridge_config);
         }
     }
@@ -159,7 +159,7 @@ public class RelayConfig {
 
     public static class SiteConfig {
         protected final String              name;
-        protected final List<BridgeConfig>  bridges=new ArrayList<>();
+        protected final List<AbstractBridgeConfig>  bridges=new ArrayList<>();
         protected final List<ForwardConfig> forwards=new ArrayList<>();
 
         public SiteConfig(String name) {
@@ -168,16 +168,16 @@ public class RelayConfig {
 
         public String getName() {return name;}
 
-        public List<BridgeConfig>  getBridges()   {return bridges;}
+        public List<AbstractBridgeConfig>  getBridges()   {return bridges;}
         public List<ForwardConfig> getForwards()  {return forwards;}
 
-        public SiteConfig addBridge(BridgeConfig bridge_config)    {bridges.add(bridge_config);   return this;}
+        public SiteConfig addBridge(AbstractBridgeConfig bridge_config)    {bridges.add(bridge_config);   return this;}
         public SiteConfig addForward(ForwardConfig forward_config) {forwards.add(forward_config); return this;}
 
         public String toString() {
             StringBuilder sb=new StringBuilder("name=" + name + "\n");
             if(!bridges.isEmpty())
-                for(BridgeConfig bridge_config: bridges)
+                for(AbstractBridgeConfig bridge_config: bridges)
                     sb.append(bridge_config).append("\n");
             if(!forwards.isEmpty())
                 for(ForwardConfig forward_config: forwards)
@@ -186,10 +186,10 @@ public class RelayConfig {
         }
     }
 
-    public abstract static class BridgeConfig {
+    public abstract static class AbstractBridgeConfig {
         protected final String cluster_name;
 
-        protected BridgeConfig(String cluster_name) {this.cluster_name=cluster_name;}
+        protected AbstractBridgeConfig(String cluster_name) {this.cluster_name=cluster_name;}
 
         public String            getClusterName()  {return cluster_name;}
         public abstract JChannel  createChannel() throws Exception;
@@ -197,7 +197,7 @@ public class RelayConfig {
         public String toString() {return "cluster=" + cluster_name;}
     }
 
-    public static class PropertiesBridgeConfig extends BridgeConfig {
+    public static class PropertiesBridgeConfig extends AbstractBridgeConfig {
         protected final String config;
 
         public PropertiesBridgeConfig(String cluster_name, String config) {
@@ -210,10 +210,10 @@ public class RelayConfig {
     }
 
 
-    public static class ProgrammaticBridgeConfig extends BridgeConfig {
-        protected Protocol[] protocols;
+    public static class ProgrammaticBridgeConfig extends AbstractBridgeConfig {
+        protected AbstractProtocol[] protocols;
 
-        public ProgrammaticBridgeConfig(String cluster_name, Protocol[] prots) {
+        public ProgrammaticBridgeConfig(String cluster_name, AbstractProtocol[] prots) {
             super(cluster_name);
             this.protocols=prots;
         }
@@ -227,10 +227,10 @@ public class RelayConfig {
         }
 
 
-        protected static String printProtocols(Protocol[] protocols) {
+        protected static String printProtocols(AbstractProtocol[] protocols) {
             StringBuilder sb=new StringBuilder("[");
             boolean first=true;
-            for(Protocol prot: protocols) {
+            for(AbstractProtocol prot: protocols) {
                 if(first)
                     first=false;
                 else

--- a/src/org/jgroups/protocols/rules/AbstractRule.java
+++ b/src/org/jgroups/protocols/rules/AbstractRule.java
@@ -8,12 +8,12 @@ import org.jgroups.logging.Log;
  * @author Bela Ban
  * @since  3.3
  */
-public abstract class Rule implements Runnable {
+public abstract class AbstractRule implements Runnable {
     protected SUPERVISOR sv;  // set when rule is installed
     protected Log        log;         // set when rule is installed
 
-    public Rule supervisor(SUPERVISOR sv) {this.sv=sv;   return this;}
-    public Rule log(Log log)              {this.log=log; return this;}
+    public AbstractRule supervisor(SUPERVISOR sv) {this.sv=sv;   return this;}
+    public AbstractRule log(Log log)              {this.log=log; return this;}
 
     /** Returns the name of the rule. Should be unique if a rule needs to be uninstalled */
     public abstract String name();

--- a/src/org/jgroups/protocols/rules/CheckFDMonitor.java
+++ b/src/org/jgroups/protocols/rules/CheckFDMonitor.java
@@ -9,7 +9,7 @@ import org.jgroups.protocols.FD;
  * @author Bela Ban
  * @since  3.3
  */
-public class CheckFDMonitor extends Rule {
+public class CheckFDMonitor extends AbstractRule {
     protected FD fd;
 
     public String name() {

--- a/src/org/jgroups/protocols/rules/SampleRule.java
+++ b/src/org/jgroups/protocols/rules/SampleRule.java
@@ -4,7 +4,7 @@ package org.jgroups.protocols.rules;
  * @author Bela Ban
  * @since  3.3
  */
-public class SampleRule extends Rule {
+public class SampleRule extends AbstractRule {
     public String name() {
         return "SampleRule";
     }

--- a/src/org/jgroups/protocols/tom/TOA.java
+++ b/src/org/jgroups/protocols/tom/TOA.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 3.1
  */
 @MBean(description = "Implementation of Total Order Anycast based on Skeen's Algorithm")
-public class TOA extends Protocol implements DeliveryProtocol {
+public class TOA extends AbstractProtocol implements DeliveryProtocol {
     //managers
     private DeliveryManagerImpl deliverManager;
     private SenderManager senderManager;

--- a/src/org/jgroups/protocols/tom/ToaHeader.java
+++ b/src/org/jgroups/protocols/tom/ToaHeader.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols.tom;
 
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Bits;
 import org.jgroups.util.Util;
 
@@ -18,7 +18,7 @@ import java.util.Collections;
  * @author Pedro Ruivo
  * @since 3.1
  */
-public class ToaHeader extends Header {
+public class ToaHeader extends AbstractHeader {
 
     //type
     public static final byte DATA_MESSAGE = 1 << 0;

--- a/src/org/jgroups/stack/AbstractRetransmitter.java
+++ b/src/org/jgroups/stack/AbstractRetransmitter.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  */
 @Deprecated
-public abstract class Retransmitter {
+public abstract class AbstractRetransmitter {
 
     /** Default retransmit intervals (ms) - exponential approx. */
     protected Interval                       retransmit_timeouts=new ExponentialInterval(300);
@@ -33,7 +33,7 @@ public abstract class Retransmitter {
     protected final RetransmitCommand        cmd;
     protected final TimeScheduler            timer;
     protected long                           xmit_stagger_timeout=0;
-    protected static final Log log=LogFactory.getLog(Retransmitter.class);
+    protected static final Log log=LogFactory.getLog(AbstractRetransmitter.class);
 
 
     /** Retransmit command (see Gamma et al.) used to retrieve missing messages */
@@ -57,7 +57,7 @@ public abstract class Retransmitter {
      * @param cmd the retransmission callback reference
      * @param sched retransmissions scheduler
      */
-    public Retransmitter(Address sender, RetransmitCommand cmd, TimeScheduler sched) {
+    public AbstractRetransmitter(Address sender, RetransmitCommand cmd, TimeScheduler sched) {
         this.sender=sender;
         this.cmd=cmd;
         timer=sched;
@@ -105,14 +105,14 @@ public abstract class Retransmitter {
 
     /* ---------------------------- End of Private Methods ------------------------------------ */
 
-    protected abstract class Task implements TimeScheduler.Task {
+    protected abstract class AbstractTask implements TimeScheduler.Task {
         protected final Interval       intervals;
         protected volatile Future      future;
         protected Address              msg_sender=null;
         protected RetransmitCommand    command;
         protected volatile boolean     cancelled=false;
 
-        protected Task(Interval intervals, RetransmitCommand cmd, Address msg_sender) {
+        protected AbstractTask(Interval intervals, RetransmitCommand cmd, Address msg_sender) {
             this.intervals=intervals;
             this.command=cmd;
             this.msg_sender=msg_sender;

--- a/src/org/jgroups/stack/GossipRouter.java
+++ b/src/org/jgroups/stack/GossipRouter.java
@@ -5,7 +5,7 @@ import org.jgroups.PhysicalAddress;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.ManagedOperation;
 import org.jgroups.annotations.Property;
-import org.jgroups.blocks.cs.BaseServer;
+import org.jgroups.blocks.cs.AbstractBaseServer;
 import org.jgroups.blocks.cs.Connection;
 import org.jgroups.blocks.cs.ConnectionListener;
 import org.jgroups.blocks.cs.TcpServer;
@@ -77,7 +77,7 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
     protected boolean                                           emit_suspect_events=true;
 
 
-    protected BaseServer                                        server;
+    protected AbstractBaseServer server;
     protected final AtomicBoolean                               running=new AtomicBoolean(false);
     protected Timer                                             timer;
     protected final Log                                         log=LogFactory.getLog(this.getClass());

--- a/src/org/jgroups/stack/NakReceiverWindow.java
+++ b/src/org/jgroups/stack/NakReceiverWindow.java
@@ -77,7 +77,7 @@ public class NakReceiverWindow {
 
     /** if not set, no retransmitter thread will be started. Useful if
      * protocols do their own retransmission (e.g PBCAST) */
-    private Retransmitter retransmitter=null;
+    private AbstractRetransmitter retransmitter=null;
 
     private Listener listener=null;
 
@@ -96,14 +96,14 @@ public class NakReceiverWindow {
      * @param sched the external scheduler to use for retransmission
      * requests of missing msgs. If it's not provided or is null, an internal
      */
-    public NakReceiverWindow(Address sender, Retransmitter.RetransmitCommand cmd, long highest_delivered_seqno,
+    public NakReceiverWindow(Address sender, AbstractRetransmitter.RetransmitCommand cmd, long highest_delivered_seqno,
                              TimeScheduler sched) {
         this(sender, cmd, highest_delivered_seqno, sched, true);
     }
 
 
 
-    public NakReceiverWindow(Address sender, Retransmitter.RetransmitCommand cmd,
+    public NakReceiverWindow(Address sender, AbstractRetransmitter.RetransmitCommand cmd,
                              long highest_delivered_seqno, TimeScheduler sched,
                              boolean use_range_based_retransmitter) {
         this(sender, cmd, highest_delivered_seqno, sched, use_range_based_retransmitter,
@@ -111,7 +111,7 @@ public class NakReceiverWindow {
     }
 
 
-    public NakReceiverWindow(final Address sender, Retransmitter.RetransmitCommand cmd,
+    public NakReceiverWindow(final Address sender, AbstractRetransmitter.RetransmitCommand cmd,
                              long highest_delivered_seqno, TimeScheduler sched,
                              boolean use_range_based_retransmitter,
                              int num_rows, int msgs_per_row, double resize_factor, long max_compaction_time,

--- a/src/org/jgroups/stack/ProtocolHook.java
+++ b/src/org/jgroups/stack/ProtocolHook.java
@@ -8,9 +8,9 @@ package org.jgroups.stack;
 public interface ProtocolHook {
     /**
      * Called after all protocols have been created, connected and its attributes set, but
-     * before {@link Protocol#init()} is called. The order of calling the hooks is from bottom to top protocol.
+     * before {@link AbstractProtocol#init()} is called. The order of calling the hooks is from bottom to top protocol.
      * @param prot The protocol that was created.
      * @throws Exception Thrown is the method failed.
      */
-    void afterCreation(Protocol prot) throws Exception;
+    void afterCreation(AbstractProtocol prot) throws Exception;
 }

--- a/src/org/jgroups/stack/RouterStub.java
+++ b/src/org/jgroups/stack/RouterStub.java
@@ -25,7 +25,7 @@ public class RouterStub extends ReceiverAdapter implements Comparable<RouterStub
     public interface MembersNotification {void members(List<PingData> mbrs);}
     public interface CloseListener       {void closed(RouterStub stub);}
 
-    protected BaseServer                                  client;
+    protected AbstractBaseServer client;
     protected final IpAddress                             local;  // bind address
     protected final IpAddress                             remote; // address of remote GossipRouter
     protected final boolean                               use_nio;

--- a/src/org/jgroups/stack/RouterStubManager.java
+++ b/src/org/jgroups/stack/RouterStubManager.java
@@ -30,7 +30,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
     // List of destinations that the reconnect task needs to create and connect
     protected volatile Set<Target>                      reconnect_list;
 
-    protected final Protocol                            owner;
+    protected final AbstractProtocol owner;
     protected final TimeScheduler                       timer;
     protected final String                              cluster_name;
     protected final Address                             local_addr;
@@ -47,7 +47,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
     }
 
 
-    public RouterStubManager(Protocol owner, String cluster_name, Address local_addr,
+    public RouterStubManager(AbstractProtocol owner, String cluster_name, Address local_addr,
                              String logical_name, PhysicalAddress phys_addr, long interval) {
         this.owner = owner;
         this.stubs = new ArrayList<>();
@@ -61,7 +61,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
         this.interval = interval;
     }
 
-    public static RouterStubManager emptyGossipClientStubManager(Protocol p) {
+    public static RouterStubManager emptyGossipClientStubManager(AbstractProtocol p) {
         return new RouterStubManager(p,null,null,null, null,0L);
     }
     

--- a/src/org/jgroups/util/ForwardQueue.java
+++ b/src/org/jgroups/util/ForwardQueue.java
@@ -4,7 +4,7 @@ import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Message;
 import org.jgroups.logging.Log;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import java.util.List;
 import java.util.Map;
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 3.3
  */
 public class ForwardQueue {
-    protected Protocol                          up_prot, down_prot;
+    protected AbstractProtocol up_prot, down_prot;
 
     protected Address                           local_addr;
 
@@ -64,11 +64,11 @@ public class ForwardQueue {
         this.log=log;
     }
 
-    public Protocol getUpProt()                           {return up_prot;}
-    public void     setUpProt(Protocol up_prot)           {this.up_prot=up_prot;}
+    public AbstractProtocol getUpProt()                           {return up_prot;}
+    public void     setUpProt(AbstractProtocol up_prot)           {this.up_prot=up_prot;}
 
-    public Protocol getDownProt()                         {return down_prot;}
-    public void     setDownProt(Protocol down_prot)       {this.down_prot=down_prot;}
+    public AbstractProtocol getDownProt()                         {return down_prot;}
+    public void     setDownProt(AbstractProtocol down_prot)       {this.down_prot=down_prot;}
 
     public Address  getLocalAddr()                        {return local_addr;}
     public void     setLocalAddr(Address local_addr)      {this.local_addr=local_addr;}

--- a/src/org/jgroups/util/HashedTimingWheel.java
+++ b/src/org/jgroups/util/HashedTimingWheel.java
@@ -182,7 +182,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown() || !running)
             return null;
-        RecurringTask wrapper=new FixedIntervalTask(task, delay);
+        AbstractRecurringTask wrapper=new FixedIntervalTask(task, delay);
         wrapper.doSchedule(initial_delay);
         return wrapper;
     }
@@ -193,7 +193,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown() || !running)
             return null;
-        RecurringTask wrapper=new FixedRateTask(task, delay);
+        AbstractRecurringTask wrapper=new FixedRateTask(task, delay);
         wrapper.doSchedule(initial_delay);
         return wrapper;
     }
@@ -201,7 +201,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
 
     /**
      * Schedule a task for execution at varying intervals. After execution, the task will get rescheduled after
-     * {@link org.jgroups.util.HashedTimingWheel.RecurringTask#nextInterval()} milliseconds. The task is never done until nextInterval()
+     * {@link AbstractRecurringTask#nextInterval()} milliseconds. The task is never done until nextInterval()
      * return a value <= 0 or the task is cancelled.
      * @param task the task to execute
      * Task is rescheduled relative to the last time it <i>actually</i> started execution<p/>
@@ -214,7 +214,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown() || !running)
             return null;
-        RecurringTask task_wrapper=new DynamicIntervalTask(task);
+        AbstractRecurringTask task_wrapper=new DynamicIntervalTask(task);
         task_wrapper.doSchedule(); // calls schedule() in ScheduledThreadPoolExecutor
         return task_wrapper;
     }
@@ -429,13 +429,13 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
      * {@link #nextInterval()} method determines the time to wait until the next execution.
      * @param <V>
      */
-    private abstract class RecurringTask<V> implements Runnable, Future<V> {
+    private abstract class AbstractRecurringTask<V> implements Runnable, Future<V> {
         protected final Runnable      task;
         protected volatile Future<?>  future; // cannot be null !
         protected volatile boolean    cancelled=false;
 
 
-        public RecurringTask(Runnable task) {
+        public AbstractRecurringTask(Runnable task) {
             this.task=task;
         }
 
@@ -517,7 +517,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
     }
 
 
-    private class FixedIntervalTask<V> extends RecurringTask<V> {
+    private class FixedIntervalTask<V> extends AbstractRecurringTask<V> {
         final long interval;
 
         public FixedIntervalTask(Runnable task, long interval) {
@@ -530,7 +530,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
         }
     }
 
-    private class FixedRateTask<V> extends RecurringTask<V> {
+    private class FixedRateTask<V> extends AbstractRecurringTask<V> {
         final long interval;
         final long first_execution;
         int num_executions=0;
@@ -550,7 +550,7 @@ public class HashedTimingWheel implements TimeScheduler, Runnable  {
     }
 
 
-   private class DynamicIntervalTask<V> extends RecurringTask<V> {
+   private class DynamicIntervalTask<V> extends AbstractRecurringTask<V> {
 
        public DynamicIntervalTask(Task task) {
            super(task);

--- a/src/org/jgroups/util/Headers.java
+++ b/src/org/jgroups/util/Headers.java
@@ -1,7 +1,7 @@
 package org.jgroups.util;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.conf.ClassConfigurator;
 
 import java.util.HashMap;
@@ -32,10 +32,10 @@ public class Headers {
      * @param id The ID
      * @return
      */
-    public static Header getHeader(final Header[] hdrs, short id) {
+    public static AbstractHeader getHeader(final AbstractHeader[] hdrs, short id) {
         if(hdrs == null)
             return null;
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 return null;
             if(hdr.getProtId() == id)
@@ -45,11 +45,11 @@ public class Headers {
     }
 
 
-    public static Map<Short,Header> getHeaders(final Header[] hdrs) {
+    public static Map<Short,AbstractHeader> getHeaders(final AbstractHeader[] hdrs) {
         if(hdrs == null)
             return new HashMap<>();
-        Map<Short,Header> retval=new HashMap<>(hdrs.length);
-        for(Header hdr: hdrs) {
+        Map<Short,AbstractHeader> retval=new HashMap<>(hdrs.length);
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             retval.put(hdr.getProtId(), hdr);
@@ -57,12 +57,12 @@ public class Headers {
         return retval;
     }
 
-    public static String printHeaders(final Header[] hdrs) {
+    public static String printHeaders(final AbstractHeader[] hdrs) {
         if(hdrs == null)
             return "";
         StringBuilder sb=new StringBuilder();
         boolean first=true;
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             short id=hdr.getProtId();
@@ -87,9 +87,9 @@ public class Headers {
      * @param replace_if_present Whether or not to overwrite an existing header
      * @return A new copy of headers if the array needed to be expanded, or null otherwise
      */
-    public static Header[] putHeader(final Header[] headers, short id, Header hdr, boolean replace_if_present) {
+    public static AbstractHeader[] putHeader(final AbstractHeader[] headers, short id, AbstractHeader hdr, boolean replace_if_present) {
         int i=0;
-        Header[] hdrs=headers;
+        AbstractHeader[] hdrs=headers;
         boolean resized=false;
         while(i < hdrs.length) {
             if(hdrs[i] == null) {
@@ -114,26 +114,26 @@ public class Headers {
     /**
      * Increases the capacity of the array and copies the contents of the old into the new array
      */
-    public static Header[] resize(final Header[] headers) {
+    public static AbstractHeader[] resize(final AbstractHeader[] headers) {
         int new_capacity=headers.length + RESIZE_INCR;
-        Header[] new_hdrs=new Header[new_capacity];
+        AbstractHeader[] new_hdrs=new AbstractHeader[new_capacity];
         System.arraycopy(headers, 0, new_hdrs, 0, headers.length);
         return new_hdrs;
     }
 
-     public static Header[] copy(final Header[] headers) {
+     public static AbstractHeader[] copy(final AbstractHeader[] headers) {
          if(headers == null)
-             return new Header[0];
-         Header[] retval=new Header[headers.length];
+             return new AbstractHeader[0];
+         AbstractHeader[] retval=new AbstractHeader[headers.length];
          System.arraycopy(headers, 0, retval, 0, headers.length);
          return retval;
      }
 
-    public static String printObjectHeaders(final Header[] hdrs) {
+    public static String printObjectHeaders(final AbstractHeader[] hdrs) {
         if(hdrs == null)
             return "";
         StringBuilder sb=new StringBuilder();
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             sb.append(hdr.getProtId()).append(": ").append(hdr).append('\n');
@@ -141,11 +141,11 @@ public class Headers {
         return sb.toString();
     }
 
-    public static int marshalledSize(final Header[] hdrs) {
+    public static int marshalledSize(final AbstractHeader[] hdrs) {
         int retval=0;
         if(hdrs == null)
             return retval;
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             retval+=Global.SHORT_SIZE *2;    // for protocol ID and magic number
@@ -154,11 +154,11 @@ public class Headers {
         return retval;
     }
 
-    public static int size(Header[] hdrs) {
+    public static int size(AbstractHeader[] hdrs) {
         int retval=0;
         if(hdrs == null)
             return retval;
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             retval++;
@@ -166,11 +166,11 @@ public class Headers {
         return retval;
     }
 
-    public static int size(Header[] hdrs, short... excluded_ids) {
+    public static int size(AbstractHeader[] hdrs, short... excluded_ids) {
         int retval=0;
         if(hdrs == null)
             return retval;
-        for(Header hdr: hdrs) {
+        for(AbstractHeader hdr: hdrs) {
             if(hdr == null)
                 break;
             if(!Util.containsId(hdr.getProtId(), excluded_ids))

--- a/src/org/jgroups/util/PropertiesToAsciidoc.java
+++ b/src/org/jgroups/util/PropertiesToAsciidoc.java
@@ -3,7 +3,7 @@ package org.jgroups.util;
 import org.jgroups.annotations.Experimental;
 import org.jgroups.annotations.Property;
 import org.jgroups.annotations.Unsupported;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -45,13 +45,13 @@ public class PropertiesToAsciidoc {
             copy(new FileReader(new File(prot_file)), new FileWriter(f));
             String s = fileToString(f);
 
-            Set<Class<Protocol>> classes = Util.findClassesAssignableFrom("org.jgroups.protocols",Protocol.class);
-            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.pbcast",Protocol.class));
-            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.relay",Protocol.class));
-            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.rules",Protocol.class));
-            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.tom",Protocol.class));
+            Set<Class<AbstractProtocol>> classes = Util.findClassesAssignableFrom("org.jgroups.protocols",AbstractProtocol.class);
+            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.pbcast",AbstractProtocol.class));
+            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.relay",AbstractProtocol.class));
+            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.rules",AbstractProtocol.class));
+            classes.addAll(Util.findClassesAssignableFrom("org.jgroups.protocols.tom",AbstractProtocol.class));
             Properties props = new Properties();
-            for (Class<Protocol> clazz : classes)
+            for (Class<AbstractProtocol> clazz : classes)
                 convertProtocolToAsciidocTable(props,clazz);
             String result = Util.replaceProperties(s, props);
             FileWriter fw = new FileWriter(f, false);
@@ -120,7 +120,7 @@ public class PropertiesToAsciidoc {
     }
 
 
-    private static void convertProtocolToAsciidocTable(Properties props, Class<Protocol> clazz) throws Exception {
+    private static void convertProtocolToAsciidocTable(Properties props, Class<AbstractProtocol> clazz) throws Exception {
         boolean isUnsupported = clazz.isAnnotationPresent(Unsupported.class);
         if (isUnsupported)
             return;

--- a/src/org/jgroups/util/Responses.java
+++ b/src/org/jgroups/util/Responses.java
@@ -2,6 +2,7 @@ package org.jgroups.util;
 
 import org.jgroups.Address;
 import org.jgroups.annotations.GuardedBy;
+import org.jgroups.protocols.AbstractDiscovery;
 import org.jgroups.protocols.PingData;
 
 import java.util.*;
@@ -10,7 +11,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Manages responses for the discovery protocol. Moved from {@link org.jgroups.protocols.Discovery}
+ * Manages responses for the discovery protocol. Moved from {@link AbstractDiscovery}
  * into this standalone class. Responses are only added but never removed.
  * @author Bela Ban
  * @since  3.5

--- a/src/org/jgroups/util/TimeScheduler2.java
+++ b/src/org/jgroups/util/TimeScheduler2.java
@@ -147,7 +147,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown())
             return null;
-        RecurringTask wrapper=new FixedIntervalTask(task, delay);
+        AbstractRecurringTask wrapper=new FixedIntervalTask(task, delay);
         wrapper.doSchedule(initial_delay);
         return wrapper;
     }
@@ -158,7 +158,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown())
             return null;
-        RecurringTask wrapper=new FixedRateTask(task, delay);
+        AbstractRecurringTask wrapper=new FixedRateTask(task, delay);
         wrapper.doSchedule(initial_delay);
         return wrapper;
     }
@@ -166,7 +166,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
 
     /**
      * Schedule a task for execution at varying intervals. After execution, the task will get rescheduled after
-     * {@link org.jgroups.util.TimeScheduler2.RecurringTask#nextInterval()} milliseconds. The task is never done until nextInterval()
+     * {@link AbstractRecurringTask#nextInterval()} milliseconds. The task is never done until nextInterval()
      * return a value <= 0 or the task is cancelled.
      * @param task the task to execute
      * Task is rescheduled relative to the last time it <i>actually</i> started execution<p/>
@@ -179,7 +179,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
             throw new NullPointerException();
         if (isShutdown())
             return null;
-        RecurringTask task_wrapper=new DynamicIntervalTask(task);
+        AbstractRecurringTask task_wrapper=new DynamicIntervalTask(task);
         task_wrapper.doSchedule(); // calls schedule() in ScheduledThreadPoolExecutor
         return task_wrapper;
     }
@@ -514,13 +514,13 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
      * {@link #nextInterval()} method determines the time to wait until the next execution.
      * @param <V>
      */
-    private abstract class RecurringTask<V> implements Runnable, Future<V> {
+    private abstract class AbstractRecurringTask<V> implements Runnable, Future<V> {
         protected final Runnable      task;
         protected volatile Future<?>  future; // cannot be null !
         protected volatile boolean    cancelled=false;
 
 
-        private RecurringTask(Runnable task) {
+        private AbstractRecurringTask(Runnable task) {
             this.task=task;
         }
 
@@ -602,7 +602,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
     }
 
 
-    private class FixedIntervalTask<V> extends RecurringTask<V> {
+    private class FixedIntervalTask<V> extends AbstractRecurringTask<V> {
         final long interval;
 
         private FixedIntervalTask(Runnable task, long interval) {
@@ -615,7 +615,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
         }
     }
 
-    private class FixedRateTask<V> extends RecurringTask<V> {
+    private class FixedRateTask<V> extends AbstractRecurringTask<V> {
         final long interval;
         final long first_execution;
         int num_executions=0;
@@ -635,7 +635,7 @@ public class TimeScheduler2 implements TimeScheduler, Runnable  {
     }
 
 
-   private class DynamicIntervalTask<V> extends RecurringTask<V> {
+   private class DynamicIntervalTask<V> extends AbstractRecurringTask<V> {
 
        private DynamicIntervalTask(Task task) {
            super(task);

--- a/src/org/jgroups/util/XMLSchemaGenerator.java
+++ b/src/org/jgroups/util/XMLSchemaGenerator.java
@@ -5,7 +5,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.annotations.XmlAttribute;
 import org.jgroups.annotations.XmlElement;
 import org.jgroups.annotations.XmlInclude;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -103,7 +103,7 @@ public class XMLSchemaGenerator {
     protected static void generateProtocolSchema(Document xmldoc, Element parent, String... suffixes) throws Exception {
         for(String suffix: suffixes) {
             String package_name=PROT_PACKAGE + (suffix == null || suffix.isEmpty()? "" : "." + suffix);
-            Set<Class<?>> classes=getClasses(Protocol.class, package_name);
+            Set<Class<?>> classes=getClasses(AbstractProtocol.class, package_name);
             for (Class<?> clazz : classes)
                 classToXML(xmldoc, parent, clazz, package_name);
         }

--- a/tests/byteman/org/jgroups/tests/byteman/SequencerFailoverTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/SequencerFailoverTest.java
@@ -144,7 +144,7 @@ public class SequencerFailoverTest extends BMNGRunner {
         discard.setLocalAddress(a.getAddress());
         discard.setDiscardAll(true);
         ProtocolStack stack=a.getProtocolStack();
-        TP transport=stack.getTransport();
+        AbstractTP transport=stack.getTransport();
         stack.insertProtocol(discard,  ProtocolStack.ABOVE, transport.getClass());
         
         MySender[] senders=new MySender[num_senders];

--- a/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
@@ -4,7 +4,7 @@ import org.jboss.byteman.contrib.bmunit.BMNGRunner;
 import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.blocks.cs.BaseServer;
+import org.jgroups.blocks.cs.AbstractBaseServer;
 import org.jgroups.blocks.cs.TcpServer;
 import org.jgroups.blocks.cs.NioServer;
 import org.jgroups.blocks.cs.ReceiverAdapter;
@@ -25,7 +25,7 @@ import java.util.List;
  */
 @Test(groups=Global.BYTEMAN,singleThreaded=true,dataProvider="configProvider")
 public class ServerTest extends BMNGRunner {
-    protected BaseServer               a, b;
+    protected AbstractBaseServer a, b;
     protected static final InetAddress loopback;
     protected MyReceiver               receiver_a, receiver_b;
     protected static final int         PORT_A, PORT_B;
@@ -55,7 +55,7 @@ public class ServerTest extends BMNGRunner {
     }
 
 
-    protected void setup(BaseServer one, BaseServer two) throws Exception {
+    protected void setup(AbstractBaseServer one, AbstractBaseServer two) throws Exception {
         a=one;
         a.usePeerConnections(true);
         b=two;
@@ -75,13 +75,13 @@ public class ServerTest extends BMNGRunner {
     }
 
 
-    public void testStart(BaseServer a, BaseServer b) throws Exception {
+    public void testStart(AbstractBaseServer a, AbstractBaseServer b) throws Exception {
         setup(a, b);
         assert !a.hasConnection(B) && !b.hasConnection(A);
         assert a.getNumConnections() == 0 && b.getNumConnections() == 0;
     }
 
-    public void testSimpleSend(BaseServer a, BaseServer b) throws Exception {
+    public void testSimpleSend(AbstractBaseServer a, AbstractBaseServer b) throws Exception {
         setup(a,b);
         byte[] data=STRING_A.getBytes();
         a.send(B, data, 0, data.length);
@@ -93,7 +93,7 @@ public class ServerTest extends BMNGRunner {
      * Tests A connecting to B, and then B connecting to A; no concurrent connections
      */
     // @Test(dataProvider="configProvider",invocationCount=5)
-    public void testSimpleConnection(BaseServer first, BaseServer second) throws Exception {
+    public void testSimpleConnection(AbstractBaseServer first, AbstractBaseServer second) throws Exception {
         setup(first,second);
         byte[] buf="hello".getBytes();
         a.send(B, buf, 0, buf.length);
@@ -120,7 +120,7 @@ public class ServerTest extends BMNGRunner {
      */
     @BMScript(dir="scripts/ServerTest", value="testConcurrentConnect")
     // @Test(dataProvider="configProvider",invocationCount=5)
-    public void testConcurrentConnect(BaseServer first, BaseServer second) throws Exception {
+    public void testConcurrentConnect(AbstractBaseServer first, AbstractBaseServer second) throws Exception {
         setup(first, second);
         _testConcurrentConnect(1, 1, 0);
     }
@@ -166,10 +166,10 @@ public class ServerTest extends BMNGRunner {
     }
 
 
-    protected void waitForOpenConns(int expected, BaseServer... servers) {
+    protected void waitForOpenConns(int expected, AbstractBaseServer... servers) {
         for(int i=0; i < 10; i++) {
             boolean all_ok=true;
-            for(BaseServer server: servers) {
+            for(AbstractBaseServer server: servers) {
                 if(server.getNumOpenConnections() != expected) {
                     all_ok=false;
                     break;
@@ -182,7 +182,7 @@ public class ServerTest extends BMNGRunner {
     }
 
 
-    protected BaseServer create(boolean nio, int port) {
+    protected AbstractBaseServer create(boolean nio, int port) {
         try {
             return nio? new NioServer(loopback, port) : new TcpServer(loopback, port).useSendQueues(false);
         }
@@ -193,12 +193,12 @@ public class ServerTest extends BMNGRunner {
 
 
     protected static class Sender implements Runnable {
-        protected final BaseServer server;
+        protected final AbstractBaseServer server;
         protected final Address    dest;
         protected final String     req_to_send;
 
 
-        public Sender(BaseServer server, Address dest, String req_to_send) {
+        public Sender(AbstractBaseServer server, Address dest, String req_to_send) {
             this.server=server;
             this.dest=dest;
             this.req_to_send=req_to_send;

--- a/tests/byteman/org/jgroups/tests/helpers/ForwardToCoordFailoverTestHelper.java
+++ b/tests/byteman/org/jgroups/tests/helpers/ForwardToCoordFailoverTestHelper.java
@@ -4,7 +4,7 @@ import org.jboss.byteman.rule.Rule;
 import org.jboss.byteman.rule.helper.Helper;
 import org.jgroups.Event;
 import org.jgroups.Message;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 /**
  * @author Bela Ban
@@ -16,7 +16,7 @@ public class ForwardToCoordFailoverTestHelper extends Helper {
         super(rule);
     }
 
-    public void sendMessages(final Protocol prot, final int start, final int end) {
+    public void sendMessages(final AbstractProtocol prot, final int start, final int end) {
         final Thread sender=new Thread() {
             public void run() {
                 for(int i=start; i <= end; i++) {

--- a/tests/byteman/org/jgroups/tests/helpers/SequencerFailoverTestHelper.java
+++ b/tests/byteman/org/jgroups/tests/helpers/SequencerFailoverTestHelper.java
@@ -4,7 +4,7 @@ import org.jboss.byteman.rule.Rule;
 import org.jboss.byteman.rule.helper.Helper;
 import org.jgroups.Event;
 import org.jgroups.Message;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 /**
  * @author Bela Ban
@@ -16,7 +16,7 @@ public class SequencerFailoverTestHelper extends Helper {
         super(rule);
     }
 
-    public void sendMessages(final Protocol prot, final int start, final int end) {
+    public void sendMessages(final AbstractProtocol prot, final int start, final int end) {
         final Thread sender=new Thread() {
             public void run() {
                 for(int i=start; i <= end; i++) {

--- a/tests/junit-functional/org/jgroups/blocks/GroupRequestTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/GroupRequestTest.java
@@ -3,7 +3,7 @@ package org.jgroups.blocks;
 
 import org.jgroups.*;
 import org.jgroups.protocols.relay.SiteUUID;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.RspList;
 import org.jgroups.util.UUID;
 import org.jgroups.util.Util;
@@ -249,7 +249,7 @@ public class GroupRequestTest {
         checkComplete(req, true);
     }
 
-    protected static void checkComplete(Request req, boolean expect) {
+    protected static void checkComplete(AbstractRequest req, boolean expect) {
         System.out.println("req = " + req);
         assert req.getResponsesComplete() == expect;
     }
@@ -381,7 +381,7 @@ public class GroupRequestTest {
             this.async=async;
             this.responses=responses;
             this.delay=delay;
-            this.transport=new Protocol() {
+            this.transport=new AbstractProtocol() {
                 public Object down(Event evt) {
                     return null;
                 }
@@ -393,12 +393,12 @@ public class GroupRequestTest {
         }
 
         @Override
-        public void sendRequest(List<Address> dest_mbrs, Message msg, Request req) throws Exception {
+        public void sendRequest(List<Address> dest_mbrs, Message msg, AbstractRequest req) throws Exception {
             send();
         }
 
         @Override
-        public void sendRequest(Collection<Address> dest_mbrs, Message msg, Request req, RequestOptions options) throws Exception {
+        public void sendRequest(Collection<Address> dest_mbrs, Message msg, AbstractRequest req, RequestOptions options) throws Exception {
             send();
         }
 

--- a/tests/junit-functional/org/jgroups/blocks/LockServiceTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/LockServiceTest.java
@@ -4,7 +4,7 @@ import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.blocks.locking.LockService;
 import org.jgroups.protocols.CENTRAL_LOCK;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -310,13 +310,13 @@ public class LockServiceTest {
 
 
     protected JChannel createChannel(String name) throws Exception {
-        Protocol[] stack=Util.getTestStack(new CENTRAL_LOCK().level("trace"));
+        AbstractProtocol[] stack=Util.getTestStack(new CENTRAL_LOCK().level("trace"));
         return new JChannel(stack).name(name);
     }
 
     protected void setProp(Class<?> clazz, String prop_name, Object value, JChannel ... channels) {
         for(JChannel ch: channels) {
-            Protocol prot=ch.getProtocolStack().findProtocol(clazz);
+            AbstractProtocol prot=ch.getProtocolStack().findProtocol(clazz);
             prot.setValue(prop_name, value);
         }
     }

--- a/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
@@ -7,8 +7,8 @@ import org.jgroups.JChannel;
 import org.jgroups.View;
 import org.jgroups.protocols.FRAG;
 import org.jgroups.protocols.FRAG2;
-import org.jgroups.protocols.TP;
-import org.jgroups.stack.Protocol;
+import org.jgroups.protocols.AbstractTP;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.Rsp;
 import org.jgroups.util.RspList;
@@ -519,7 +519,7 @@ public class RpcDispatcherTest {
 
     protected static void setProps(JChannel... channels) {
         for(JChannel ch: channels) {
-            Protocol prot=ch.getProtocolStack().findProtocol(FRAG2.class);
+            AbstractProtocol prot=ch.getProtocolStack().findProtocol(FRAG2.class);
             if(prot != null) {
                 ((FRAG2)prot).setFragSize(12000);
             }
@@ -530,7 +530,7 @@ public class RpcDispatcherTest {
 
             prot=ch.getProtocolStack().getTransport();
             if(prot != null)
-                ((TP)prot).setMaxBundleSize(14000);
+                ((AbstractTP)prot).setMaxBundleSize(14000);
         }
     }
 

--- a/tests/junit-functional/org/jgroups/blocks/RpcLockingTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/RpcLockingTest.java
@@ -177,7 +177,7 @@ public class RpcLockingTest {
 
     protected void enableTracing() {
         for(JChannel ch: Arrays.asList(a,b))
-            ch.getProtocolStack().findProtocol(Locking.class).setLevel("TRACE");
+            ch.getProtocolStack().findProtocol(AbstractLocking.class).setLevel("TRACE");
     }
 
 

--- a/tests/junit-functional/org/jgroups/protocols/ENCRYPTAsymmetricTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/ENCRYPTAsymmetricTest.java
@@ -10,7 +10,7 @@ package org.jgroups.protocols;
 import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.ENCRYPT.EncryptHeader;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 import org.testng.Assert;
@@ -451,7 +451,7 @@ public class ENCRYPTAsymmetricTest {
 
 
     
-    static class MockProtocol extends Protocol {
+    static class MockProtocol extends AbstractProtocol {
         private final TreeMap<String, Event> upMessages=new TreeMap<>();
         private final TreeMap<String, Event> downMessages=new TreeMap<>();
         private int counter;

--- a/tests/junit-functional/org/jgroups/protocols/ENCRYPTKeystoreTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/ENCRYPTKeystoreTest.java
@@ -8,7 +8,7 @@ import org.jgroups.Event;
 import org.jgroups.Global;
 import org.jgroups.Message;
 import org.jgroups.conf.ClassConfigurator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.testng.annotations.Test;
 
@@ -182,7 +182,7 @@ public class ENCRYPTKeystoreTest {
     }
 
 
-    protected static class MockProtocol extends Protocol {
+    protected static class MockProtocol extends AbstractProtocol {
         private final Map<String,Event> upMessages=new HashMap<>();
         private final Map<String,Event> downMessages=new HashMap<>();
         private int                     counter;

--- a/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
@@ -8,7 +8,7 @@ import org.jgroups.protocols.pbcast.FLUSH;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Digest;
 import org.jgroups.util.MergeId;
@@ -30,16 +30,16 @@ public class GMS_MergeTest {
 
     static final short GMS_ID=ClassConfigurator.getProtocolId(GMS.class);
 
-    protected static Protocol[] getProps() {
+    protected static AbstractProtocol[] getProps() {
         return modify(Util.getTestStack());
     }
 
-    protected static Protocol[] getFlushProps() {
+    protected static AbstractProtocol[] getFlushProps() {
         return modify(Util.getTestStack(new FLUSH()));
     }
 
-    protected static Protocol[] modify(Protocol[] retval) {
-        for(Protocol prot: retval) {
+    protected static AbstractProtocol[] modify(AbstractProtocol[] retval) {
+        for(AbstractProtocol prot: retval) {
             if(prot instanceof GMS)
                 ((GMS)prot).setJoinTimeout(1000);
             if(prot instanceof STABLE)
@@ -513,7 +513,7 @@ public class GMS_MergeTest {
 
         for(int i=0; i < retval.length; i++) {
             JChannel ch;
-            Protocol[] props=use_flush_props? getFlushProps() : getProps();
+            AbstractProtocol[] props=use_flush_props? getFlushProps() : getProps();
             if(simple_ids) {
                 ch=new MyChannel(props);
                 ((MyChannel)ch).setId(i+1);
@@ -721,11 +721,11 @@ public class GMS_MergeTest {
             super(configurator);
         }
 
-        public MyChannel(Collection<Protocol> protocols) throws Exception {
+        public MyChannel(Collection<AbstractProtocol> protocols) throws Exception {
             super(protocols);
         }
 
-        public MyChannel(Protocol... protocols) throws Exception {
+        public MyChannel(AbstractProtocol... protocols) throws Exception {
             super(protocols);
         }
 

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.NakAckHeader2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.*;
 import org.testng.annotations.BeforeMethod;
@@ -122,7 +122,7 @@ public class NAKACK2_RetransmissionTest {
 
 
     /** Used to catch retransmit requests sent by NAKACK to the transport */
-    protected static class MockTransport extends TP {
+    protected static class MockTransport extends AbstractTP {
         protected final List<Long> xmit_requests=new LinkedList<>();
 
         public List<Long>         getXmitRequests() {return xmit_requests;}
@@ -155,7 +155,7 @@ public class NAKACK2_RetransmissionTest {
 
     }
 
-    protected static class MockProtocol extends Protocol {
+    protected static class MockProtocol extends AbstractProtocol {
         protected final List<Long> msgs=new LinkedList<>();
 
         public List<Long> getMsgs() {return msgs;}

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_Delivery_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_Delivery_Test.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.NakAckHeader2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -37,7 +37,7 @@ public class NAKACK_Delivery_Test {
         b=Util.createRandomAddress("B");
         nak=new NAKACK2();
 
-        TP transport=new TP() {
+        AbstractTP transport=new AbstractTP() {
             public boolean supportsMulticasting() {return false;}
             public void sendMulticast(AsciiString cluster_name, byte[] data, int offset, int length) throws Exception {}
             public void sendUnicast(PhysicalAddress dest, byte[] data, int offset, int length) throws Exception {}
@@ -163,7 +163,7 @@ public class NAKACK_Delivery_Test {
     }
 
 
-    static class MyReceiver extends Protocol {
+    static class MyReceiver extends AbstractProtocol {
         final ConcurrentMap<Address, Collection<Message>> msgs=new ConcurrentHashMap<>();
 
         public ConcurrentMap<Address, Collection<Message>> getMsgs() {

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_REBROADCAST_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_REBROADCAST_Test.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.NakAckHeader2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -29,7 +29,7 @@ public class NAKACK_REBROADCAST_Test {
         nak=new NAKACK2();
         interceptor = new MessageInterceptor();
         nak.setDownProtocol(interceptor);
-        TP transport=new TP() {
+        AbstractTP transport=new AbstractTP() {
             public boolean supportsMulticasting() {return false;}
             public void sendMulticast(AsciiString cluster_name, byte[] data, int offset, int length) throws Exception {}
             public void sendUnicast(PhysicalAddress dest, byte[] data, int offset, int length) throws Exception {}
@@ -73,7 +73,7 @@ public class NAKACK_REBROADCAST_Test {
         	Assert.assertTrue(i == 1);
     }
 
-    static class MessageInterceptor extends Protocol {
+    static class MessageInterceptor extends AbstractProtocol {
         private SeqnoList range;
 
         public MessageInterceptor () {

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_RetransmitTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_RetransmitTest.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.*;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -110,7 +110,7 @@ public class NAKACK_RetransmitTest {
 
     protected static void change(JChannel ... channels) {
         for(JChannel ch: channels) {
-            TP transport=ch.getProtocolStack().getTransport();
+            AbstractTP transport=ch.getProtocolStack().getTransport();
             transport.setMaxBundleSize(MAX_BUNDLE_SIZE);
             NAKACK2 nak=(NAKACK2)ch.getProtocolStack().findProtocol(NAKACK2.class);
             if(nak == null)
@@ -161,13 +161,13 @@ public class NAKACK_RetransmitTest {
 
     protected static void setLevel(String level, JChannel ... channels) {
         for(JChannel ch: channels) {
-            Protocol prot=ch.getProtocolStack().findProtocol(NAKACK2.class);
+            AbstractProtocol prot=ch.getProtocolStack().findProtocol(NAKACK2.class);
             prot.level(level);
         }
     }
 
 
-    protected static class DiscardEveryOtherMulticastMessage extends Protocol {
+    protected static class DiscardEveryOtherMulticastMessage extends AbstractProtocol {
         protected boolean discard=false;
 
         public Object down(Event evt) {

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_SET_DIGEST_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_SET_DIGEST_Test.java
@@ -18,7 +18,7 @@ public class NAKACK_SET_DIGEST_Test {
     private Address   a, b, c;
     private View      v1, v2;
 
-    private static final short TP_ID=101;
+    private static final short AbstractTP_ID=101;
 
     @BeforeMethod
     protected void setUp() throws Exception {
@@ -32,7 +32,7 @@ public class NAKACK_SET_DIGEST_Test {
         d1=new Digest(v1.getMembersRaw(), new long[]{11,11, 30,35});
         d2=new Digest(v2.getMembersRaw(), new long[]{10,10, 30,30, 50,50});
 
-        TP transport=new TP() {
+        AbstractTP transport=new AbstractTP() {
             public boolean supportsMulticasting() {return false;}
             public void sendMulticast(AsciiString cluster_name, byte[] data, int offset, int length) throws Exception {}
             public void sendUnicast(PhysicalAddress dest, byte[] data, int offset, int length) throws Exception {}
@@ -41,7 +41,7 @@ public class NAKACK_SET_DIGEST_Test {
             protected PhysicalAddress getPhysicalAddress() {return null;}
             public TimeScheduler getTimer() {return new DefaultTimeScheduler(1);}
         };
-        transport.setId(TP_ID);
+        transport.setId(AbstractTP_ID);
         nak.setDownProtocol(transport);
         nak.start();
     }

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_StressTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_StressTest.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.NakAckHeader2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.MutableDigest;
 import org.jgroups.util.Util;
@@ -54,9 +54,9 @@ public class NAKACK_StressTest {
         final Address sender=Util.createRandomAddress("B");
 
 
-        nak.setDownProtocol(new Protocol() {public Object down(Event evt) {return null;}});
+        nak.setDownProtocol(new AbstractProtocol() {public Object down(Event evt) {return null;}});
 
-        nak.setUpProtocol(new Protocol() {
+        nak.setUpProtocol(new AbstractProtocol() {
             public Object up(Event evt) {
                 if(evt.getType() == Event.MSG) {
                     delivered_msgs.incrementAndGet();

--- a/tests/junit-functional/org/jgroups/protocols/RATE_LIMITER_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/RATE_LIMITER_Test.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.Event;
 import org.jgroups.Global;
 import org.jgroups.Message;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.Test;
 
@@ -114,7 +114,7 @@ public class RATE_LIMITER_Test {
     }
 
 
-    protected static class Throughput extends Protocol implements Runnable {
+    protected static class Throughput extends AbstractProtocol implements Runnable {
         protected final AtomicInteger    bytes_in_period=new AtomicInteger(0);
         protected final Collection<Long> measurements=new ConcurrentLinkedQueue<>(); // measurement taken every second
         protected Thread                 runner;

--- a/tests/junit-functional/org/jgroups/protocols/SASLTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/SASLTest.java
@@ -23,7 +23,7 @@ import org.jgroups.View;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -45,7 +45,7 @@ public class SASLTest {
         sasl.setLevel("trace");
         GMS gms = new GMS();
         gms.setJoinTimeout(3000);
-        return new JChannel(new Protocol[] { new SHARED_LOOPBACK(), new PING(), new MERGE3(), new NAKACK2(),
+        return new JChannel(new AbstractProtocol[] { new SHARED_LOOPBACK(), new PING(), new MERGE3(), new NAKACK2(),
                 new UNICAST3(), new STABLE(), sasl, gms }).name(channelName);
     }
 
@@ -121,7 +121,7 @@ public class SASLTest {
         for (JChannel ch : channels) {
             DISCARD discard = new DISCARD();
             discard.setDiscardAll(true);
-            ch.getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE, TP.class);
+            ch.getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE, AbstractTP.class);
         }
 
         for (JChannel ch : channels) {

--- a/tests/junit-functional/org/jgroups/protocols/SASL_SimpleAuthorizingCallbackTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/SASL_SimpleAuthorizingCallbackTest.java
@@ -4,7 +4,6 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Properties;
 
 import org.jgroups.Global;
@@ -13,7 +12,7 @@ import org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -56,7 +55,7 @@ public class SASL_SimpleAuthorizingCallbackTest {
         sasl.setServerCallbackHandler(new SimpleAuthorizingCallbackHandler(properties));
         sasl.setTimeout(5000);
         sasl.sasl_props.put("com.sun.security.sasl.digest.realm", REALM);
-        return new JChannel(new Protocol[] { new SHARED_LOOPBACK(), new PING(), new NAKACK2(), new UNICAST3(),
+        return new JChannel(new AbstractProtocol[] { new SHARED_LOOPBACK(), new PING(), new NAKACK2(), new UNICAST3(),
                 new STABLE(), sasl, new GMS() }).name(channelName);
     }
 

--- a/tests/junit-functional/org/jgroups/protocols/SUPERVISOR_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/SUPERVISOR_Test.java
@@ -6,7 +6,7 @@ import org.jgroups.JChannel;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.protocols.rules.Rule;
+import org.jgroups.protocols.rules.AbstractRule;
 import org.jgroups.protocols.rules.SUPERVISOR;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -92,7 +92,7 @@ public class SUPERVISOR_Test {
     }
 
 
-    protected static class RestartFailureDetector extends Rule {
+    protected static class RestartFailureDetector extends AbstractRule {
         protected FD fd;
 
         public String name()        {return "MyRule";}

--- a/tests/junit-functional/org/jgroups/protocols/TOATest.java
+++ b/tests/junit-functional/org/jgroups/protocols/TOATest.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.tom.TOA;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -319,7 +319,7 @@ public class TOATest {
     }
 
     private TOANode createNewChannel(String name) throws Exception {
-        JChannel channel = new JChannel(new Protocol[]{
+        JChannel channel = new JChannel(new AbstractProtocol[]{
                 new SHARED_LOOPBACK(),
                 new SHARED_LOOPBACK_PING(),
                 new MERGE3(),

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_ContentionTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_ContentionTest.java
@@ -2,7 +2,7 @@ package org.jgroups.protocols;
 
 
 import org.jgroups.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
@@ -39,7 +39,7 @@ public class UNICAST_ContentionTest {
 
 
     @Test(dataProvider="provider")
-    public void testSimpleMessageReception(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testSimpleMessageReception(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         a=create(unicast_class, "A");
         b=create(unicast_class, "B");
         MyReceiver r1=new MyReceiver("A"), r2=new MyReceiver("B");
@@ -76,7 +76,7 @@ public class UNICAST_ContentionTest {
      * @throws Exception
      */
     @Test(dataProvider="provider")
-    public void testMessageReceptionUnderHighLoad(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testMessageReceptionUnderHighLoad(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         CountDownLatch latch=new CountDownLatch(1);
         a=create(unicast_class, "A");
         b=create(unicast_class, "B");
@@ -127,12 +127,12 @@ public class UNICAST_ContentionTest {
         assert r2.getNum() == NUM_EXPECTED_MSGS : "expected " + NUM_EXPECTED_MSGS + ", but got " + r2.getNum();
     }
 
-    protected JChannel create(Class<? extends Protocol> unicast_class, String name) throws Exception {
+    protected JChannel create(Class<? extends AbstractProtocol> unicast_class, String name) throws Exception {
         return new JChannel(new SHARED_LOOPBACK(), unicast_class.newInstance().setValue("xmit_interval", 500)).name(name);
     }
 
     private static long getNumberOfRetransmissions(JChannel ch) {
-        Protocol prot=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         if(prot instanceof UNICAST)
             return ((UNICAST)prot).getNumXmits();
         return 0;

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_DropFirstAndLastTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_DropFirstAndLastTest.java
@@ -6,7 +6,7 @@ import org.jgroups.JChannel;
 import org.jgroups.Message;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.MyReceiver;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -27,7 +27,7 @@ public class UNICAST_DropFirstAndLastTest {
     protected MyReceiver<Integer> rb;
     protected DISCARD             discard; // on A
 
-    protected void setup(Class<? extends Protocol> unicast_class) throws Exception {
+    protected void setup(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         a=createChannel(unicast_class, "A");
         discard=(DISCARD)a.getProtocolStack().findProtocol(DISCARD.class);
         assert discard != null;
@@ -56,7 +56,7 @@ public class UNICAST_DropFirstAndLastTest {
      * within a short time period, and we don't have to rely on the stable task to kick in.
      */
     @Test(dataProvider="configProvider")
-    public void testLastMessageDropped(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testLastMessageDropped(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         setup(unicast_class);
         setLevel("trace", a, b);
         Address dest=b.getAddress();
@@ -78,13 +78,13 @@ public class UNICAST_DropFirstAndLastTest {
      * within a short time period, and we don't have to rely on the stable task to kick in.
      */
     @Test(dataProvider="configProvider")
-    public void testFirstMessageDropped(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testFirstMessageDropped(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         setup(unicast_class);
 
         System.out.println("**** closing all connections ****");
         // close all connections, so we can start from scratch and send message A1 to B
         for(JChannel ch: Arrays.asList(a,b)) {
-            Protocol unicast=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+            AbstractProtocol unicast=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
             removeAllConnections(unicast);
         }
 
@@ -109,8 +109,8 @@ public class UNICAST_DropFirstAndLastTest {
     }
 
 
-    protected JChannel createChannel(Class<? extends Protocol> unicast_class, String name) throws Exception {
-        Protocol unicast=unicast_class.newInstance();
+    protected JChannel createChannel(Class<? extends AbstractProtocol> unicast_class, String name) throws Exception {
+        AbstractProtocol unicast=unicast_class.newInstance();
         if(unicast instanceof UNICAST2)
             unicast.setValue("stable_interval", 1000);
         return new JChannel(new SHARED_LOOPBACK().setValue("enable_batching", true),
@@ -125,7 +125,7 @@ public class UNICAST_DropFirstAndLastTest {
     protected void printConnectionTables(JChannel ... channels) {
         System.out.println("**** CONNECTIONS:");
         for(JChannel ch: channels) {
-            Protocol ucast=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+            AbstractProtocol ucast=ch.getProtocolStack().findProtocol(Util.getUnicastProtocols());
             System.out.println(ch.getName() + ":\n" + printConnections(ucast) + "\n");
         }
     }
@@ -135,7 +135,7 @@ public class UNICAST_DropFirstAndLastTest {
             ch.getProtocolStack().findProtocol(Util.getUnicastProtocols()).level(level);
     }
 
-    protected String printConnections(Protocol prot) {
+    protected String printConnections(AbstractProtocol prot) {
         if(prot instanceof UNICAST) {
             UNICAST unicast=(UNICAST)prot;
             return unicast.printConnections();
@@ -152,7 +152,7 @@ public class UNICAST_DropFirstAndLastTest {
             throw new IllegalArgumentException("prot (" + prot + ") needs to be UNICAST, UNICAST2 or UNICAST3");
     }
 
-    protected void removeAllConnections(Protocol prot) {
+    protected void removeAllConnections(AbstractProtocol prot) {
         if(prot instanceof UNICAST) {
             UNICAST unicast=(UNICAST)prot;
             unicast.removeAllConnections();

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_DroppedAckTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_DroppedAckTest.java
@@ -4,7 +4,7 @@ import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 public class UNICAST_DroppedAckTest {
     protected JChannel a, b;
 
-    protected void setup(Class<? extends Protocol> unicast_class) throws Exception {
+    protected void setup(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         a=createChannel(unicast_class, "A");
         b=createChannel(unicast_class, "B");
         a.connect("UNICAST_DroppedAckTest");
@@ -39,7 +39,7 @@ public class UNICAST_DroppedAckTest {
     }
 
     @Test(dataProvider="configProvider")
-    public void testNotEndlessXmits(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testNotEndlessXmits(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         setup(unicast_class);
 
         DISCARD discard_a=(DISCARD)a.getProtocolStack().findProtocol(DISCARD.class);
@@ -48,7 +48,7 @@ public class UNICAST_DroppedAckTest {
         for(int i=1; i <= 5; i++)
             b.send(a.getAddress(), i);
 
-        Protocol unicast_b=b.getProtocolStack().findProtocol(UNICAST.class, UNICAST3.class);
+        AbstractProtocol unicast_b=b.getProtocolStack().findProtocol(UNICAST.class, UNICAST3.class);
         for(int i=0; i < 10; i++) {
             int num_unacked_msgs=numUnackedMessages(unicast_b);
             System.out.println("num_unacked_msgs=" + num_unacked_msgs);
@@ -60,7 +60,7 @@ public class UNICAST_DroppedAckTest {
         assert numUnackedMessages(unicast_b) == 0 : "num_unacked_msgs on B should be 0 but is " + numUnackedMessages(unicast_b);
     }
 
-    protected int numUnackedMessages(Protocol unicast) {
+    protected int numUnackedMessages(AbstractProtocol unicast) {
         if(unicast instanceof UNICAST)
             return ((UNICAST)unicast).getNumUnackedMessages();
         if(unicast instanceof UNICAST3)
@@ -69,8 +69,8 @@ public class UNICAST_DroppedAckTest {
     }
 
 
-    protected JChannel createChannel(Class<? extends Protocol> unicast_class, String name) throws Exception {
-        return new JChannel(new Protocol[] {
+    protected JChannel createChannel(Class<? extends AbstractProtocol> unicast_class, String name) throws Exception {
+        return new JChannel(new AbstractProtocol[] {
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new MERGE3().setValue("max_interval", 3000).setValue("min_interval", 1000),

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_MessagesToSelfTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_MessagesToSelfTest.java
@@ -5,7 +5,7 @@ import org.jgroups.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -42,7 +42,7 @@ public class UNICAST_MessagesToSelfTest {
     }
 
     @Test(dataProvider="configProvider")
-    public void testReceptionOfAllMessages(Protocol prot) throws Throwable {
+    public void testReceptionOfAllMessages(AbstractProtocol prot) throws Throwable {
         System.out.println("prot=" + prot.getClass().getSimpleName());
         ch=createChannel(prot, null).name("A");
         ch.connect("UNICAST_Test.testReceptionOfAllMessages");
@@ -53,7 +53,7 @@ public class UNICAST_MessagesToSelfTest {
 
 
     @Test(dataProvider="configProvider")
-    public void testReceptionOfAllMessagesWithDISCARD(Protocol prot) throws Throwable {
+    public void testReceptionOfAllMessagesWithDISCARD(AbstractProtocol prot) throws Throwable {
         System.out.println("prot=" + prot.getClass().getSimpleName());
         DISCARD discard=new DISCARD();
         discard.setDownDiscardRate(0.1); // discard all down message with 10% probability
@@ -70,7 +70,7 @@ public class UNICAST_MessagesToSelfTest {
         return ByteBuffer.allocate(size).putInt(seqno).array();
     }
 
-    protected static JChannel createChannel(Protocol unicast, DISCARD discard) throws Exception {
+    protected static JChannel createChannel(AbstractProtocol unicast, DISCARD discard) throws Exception {
         JChannel ch=new JChannel(false);
         ProtocolStack stack=new ProtocolStack();
         ch.setProtocolStack(stack);

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
@@ -4,7 +4,7 @@ package org.jgroups.protocols;
 import org.jgroups.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -24,7 +24,7 @@ public class UNICAST_OOB_Test {
     JChannel a, b;
 
 
-    void setUp(Class<? extends Protocol> unicast_class) throws Exception {
+    void setUp(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         a=createChannel(unicast_class, "A");
         b=createChannel(unicast_class, "B");
     }
@@ -44,13 +44,13 @@ public class UNICAST_OOB_Test {
     }
 
     @Test(dataProvider="configProvider")
-    public void testRegularMessages(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testRegularMessages(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         setUp(unicast_class);
         sendMessages(false);
     }
 
     @Test(dataProvider="configProvider")
-    public void testOutOfBandMessages(Class<? extends Protocol> unicast_class) throws Exception {
+    public void testOutOfBandMessages(Class<? extends AbstractProtocol> unicast_class) throws Exception {
         setUp(unicast_class);
         sendMessages(true);
     }
@@ -66,7 +66,7 @@ public class UNICAST_OOB_Test {
 
         // the first channel will discard the unicast messages with seqno #3 two times, the let them pass down
         ProtocolStack stack=a.getProtocolStack();
-        Protocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
         System.out.println("Found unicast protocol " + neighbor.getClass().getSimpleName());
         stack.insertProtocolInStack(discard,neighbor,ProtocolStack.BELOW);
 
@@ -116,8 +116,8 @@ public class UNICAST_OOB_Test {
     }
 
 
-    protected JChannel createChannel(Class<? extends Protocol> unicast_class, String name) throws Exception {
-        Protocol unicast=unicast_class.newInstance().setValue("xmit_interval",500);
+    protected JChannel createChannel(Class<? extends AbstractProtocol> unicast_class, String name) throws Exception {
+        AbstractProtocol unicast=unicast_class.newInstance().setValue("xmit_interval",500);
         if(unicast instanceof UNICAST2)
             unicast.setValue("stable_interval", 1000);
         return new JChannel(

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_RetransmitTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_RetransmitTest.java
@@ -1,7 +1,7 @@
 package org.jgroups.protocols;
 
 import org.jgroups.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -76,7 +76,7 @@ public class UNICAST_RetransmitTest {
 
     protected static void change(JChannel ... channels) {
         for(JChannel ch: channels) {
-            TP transport=ch.getProtocolStack().getTransport();
+            AbstractTP transport=ch.getProtocolStack().getTransport();
             transport.setMaxBundleSize(MAX_BUNDLE_SIZE);
             UNICAST3 ucast=(UNICAST3)ch.getProtocolStack().findProtocol(UNICAST3.class);
             if(ucast == null)
@@ -124,13 +124,13 @@ public class UNICAST_RetransmitTest {
 
     protected static void setLevel(String level, JChannel ... channels) {
         for(JChannel ch: channels) {
-            Protocol prot=ch.getProtocolStack().findProtocol(UNICAST3.class);
+            AbstractProtocol prot=ch.getProtocolStack().findProtocol(UNICAST3.class);
             prot.level(level);
         }
     }
 
 
-    protected static class DiscardEveryOtherUnicastMessage extends Protocol {
+    protected static class DiscardEveryOtherUnicastMessage extends AbstractProtocol {
         protected boolean discard=false;
 
         public Object down(Event evt) {

--- a/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Global;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.DefaultThreadFactory;
 import org.jgroups.util.ThreadFactory;
 import org.jgroups.util.Util;
@@ -78,7 +78,7 @@ public class VERIFY_SUSPECT_Test {
         VERIFY_SUSPECT ver=new VERIFY_SUSPECT();
         ProtImpl impl=new ProtImpl();
         ver.setUpProtocol(impl);
-        ver.setDownProtocol(new Protocol() {
+        ver.setDownProtocol(new AbstractProtocol() {
             public Object down(Event evt) {
                 return null;
             }
@@ -101,7 +101,7 @@ public class VERIFY_SUSPECT_Test {
     }
 
 
-    protected class ProtImpl extends Protocol {
+    protected class ProtImpl extends AbstractProtocol {
         protected final Map<Address,Long> map=new HashMap<>();
 
         public Map<Address,Long> getMap() {
@@ -119,7 +119,7 @@ public class VERIFY_SUSPECT_Test {
         }
     }
 
-    protected static class NoopProtocol extends Protocol {
+    protected static class NoopProtocol extends AbstractProtocol {
         public Object down(Event evt) {return null;}
         public ThreadFactory getThreadFactory() {return new DefaultThreadFactory("y",false,true);}
     }

--- a/tests/junit-functional/org/jgroups/tests/BARRIERTest.java
+++ b/tests/junit-functional/org/jgroups/tests/BARRIERTest.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
 public class BARRIERTest {
     protected JChannel  ch;
-    protected Discovery discovery_prot;
+    protected AbstractDiscovery discovery_prot;
     protected BARRIER   barrier_prot;
-    protected TP        tp;
+    protected AbstractTP tp;
 
 
     @BeforeMethod void setUp() throws Exception {

--- a/tests/junit-functional/org/jgroups/tests/ConfiguratorTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ConfiguratorTest.java
@@ -5,7 +5,7 @@ import org.jgroups.JChannel;
 import org.jgroups.conf.ProtocolConfiguration;
 import org.jgroups.protocols.*;
 import org.jgroups.stack.Configurator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -37,9 +37,9 @@ public class ConfiguratorTest {
     
     public void testRemovalOfTop() throws Exception {
         stack.setup(Configurator.parseConfigurations(props));
-        Protocol prot=stack.removeProtocol("FC");
+        AbstractProtocol prot=stack.removeProtocol("FC");
         assert prot != null;
-        List<Protocol> protocols=stack.getProtocols();
+        List<AbstractProtocol> protocols=stack.getProtocols();
         Assert.assertEquals(5, protocols.size());
         assert protocols.get(0).getName().endsWith("UNICAST");
         assert  stack.getTopProtocol().getUpProtocol() != null;
@@ -50,18 +50,18 @@ public class ConfiguratorTest {
     
     public void testRemovalOfBottom() throws Exception {
         stack.setup(Configurator.parseConfigurations(props));
-        Protocol prot=stack.removeProtocol("UDP");
+        AbstractProtocol prot=stack.removeProtocol("UDP");
         assert prot != null;
-        List<Protocol> protocols=stack.getProtocols();
+        List<AbstractProtocol> protocols=stack.getProtocols();
         Assert.assertEquals(5, protocols.size());
         assert protocols.get(protocols.size() -1).getName().endsWith("PING");
     }
     
     public void testAddingAboveTop() throws Exception{
         stack.setup(Configurator.parseConfigurations(props));
-        Protocol new_prot=(Protocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
+        AbstractProtocol new_prot=(AbstractProtocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
         stack.insertProtocol(new_prot, ProtocolStack.ABOVE, FC.class);
-        List<Protocol> protocols=stack.getProtocols();
+        List<AbstractProtocol> protocols=stack.getProtocols();
         Assert.assertEquals(7, protocols.size());       
         assert protocols.get(0).getName().endsWith("TRACE");
         assert  stack.getTopProtocol().getUpProtocol() != null;
@@ -73,7 +73,7 @@ public class ConfiguratorTest {
     @Test(expectedExceptions={IllegalArgumentException.class})
     public void testAddingBelowBottom() throws Exception{
         stack.setup(Configurator.parseConfigurations(props));           
-        Protocol new_prot=(Protocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
+        AbstractProtocol new_prot=(AbstractProtocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
         stack.insertProtocol(new_prot, ProtocolStack.BELOW, UDP.class);
     }
     
@@ -81,46 +81,46 @@ public class ConfiguratorTest {
 
     public void testInsertion() throws Exception {
         stack.setup(Configurator.parseConfigurations(props));
-        List<Protocol> protocols=stack.getProtocols();
+        List<AbstractProtocol> protocols=stack.getProtocols();
         assert protocols != null;
         Assert.assertEquals(6, protocols.size());
 
         for(int i=0; i < names.length; i++) {
             String name=names[i];
-            Protocol p=protocols.get(i);
+            AbstractProtocol p=protocols.get(i);
             Assert.assertEquals(name, p.getName());
         }
 
         // insert below
-        Protocol new_prot=(Protocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
+        AbstractProtocol new_prot=(AbstractProtocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
         stack.insertProtocol(new_prot, ProtocolStack.BELOW, UNICAST.class);
         protocols=stack.getProtocols();
         Assert.assertEquals(7, protocols.size());
         for(int i=0; i < below.length; i++) {
             String name=below[i];
-            Protocol p=protocols.get(i);
+            AbstractProtocol p=protocols.get(i);
             Assert.assertEquals(name, p.getName());
         }
 
         // remove
-        Protocol prot=stack.removeProtocol("TRACE");
+        AbstractProtocol prot=stack.removeProtocol("TRACE");
         assert prot != null;
         protocols=stack.getProtocols();
         Assert.assertEquals(6, protocols.size());
         for(int i=0; i < names.length; i++) {
             String name=names[i];
-            Protocol p=protocols.get(i);
+            AbstractProtocol p=protocols.get(i);
             Assert.assertEquals(name, p.getName());
         }
 
         // insert above
-        new_prot=(Protocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
+        new_prot=(AbstractProtocol)Class.forName("org.jgroups.protocols.TRACE").newInstance();
         stack.insertProtocol(new_prot, ProtocolStack.ABOVE, UNICAST.class);
         protocols=stack.getProtocols();
         Assert.assertEquals(7, protocols.size());
         for(int i=0; i < above.length; i++) {
             String name=above[i];
-            Protocol p=protocols.get(i);
+            AbstractProtocol p=protocols.get(i);
             Assert.assertEquals(name, p.getName());
         }
     }
@@ -177,7 +177,7 @@ public class ConfiguratorTest {
           new SHARED_LOOPBACK() /* dummy stack */
         ).name("A");
 
-        TP tp=ch.getProtocolStack().getTransport();
+        AbstractTP tp=ch.getProtocolStack().getTransport();
         assert tp.getValue("external_port").equals(10000);
         assert tp.getValue("bind_addr").equals(InetAddress.getByName("127.0.0.1"));
 

--- a/tests/junit-functional/org/jgroups/tests/CustomProtocolTest.java
+++ b/tests/junit-functional/org/jgroups/tests/CustomProtocolTest.java
@@ -2,7 +2,7 @@ package org.jgroups.tests;
 
 import org.jgroups.JChannel;
 import org.jgroups.Global;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.testng.annotations.Test;
 
 /**
@@ -32,7 +32,7 @@ public class CustomProtocolTest {
     }
 
 
-    public static class MyProtocol extends Protocol {
+    public static class MyProtocol extends AbstractProtocol {
 
     }
 }

--- a/tests/junit-functional/org/jgroups/tests/DiscoveryTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DiscoveryTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.Event;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
-import org.jgroups.protocols.Discovery;
+import org.jgroups.protocols.AbstractDiscovery;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Responses;
 import org.jgroups.util.Util;
@@ -58,9 +58,9 @@ public class DiscoveryTest {
 
     protected void testLeak(JChannel discovery_initiator) throws Exception {
         ProtocolStack stack=discovery_initiator.getProtocolStack();
-        Discovery ping=(Discovery)stack.findProtocol(Discovery.class);
+        AbstractDiscovery ping=(AbstractDiscovery)stack.findProtocol(AbstractDiscovery.class);
         ping.discoveryRspExpiryTime(1000);
-        Field ping_rsps_field=Util.getField(Discovery.class, "ping_responses");
+        Field ping_rsps_field=Util.getField(AbstractDiscovery.class, "ping_responses");
         Map<Long,Responses> ping_rsps=(Map<Long,Responses>)Util.getField(ping_rsps_field, ping);
         for(int i=1; i <= 10; i++) {
             ping.down(Event.FIND_INITIAL_MBRS_EVT);

--- a/tests/junit-functional/org/jgroups/tests/DynamicDiscardTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DynamicDiscardTest.java
@@ -54,7 +54,7 @@ public class DynamicDiscardTest {
 
         // discard all messages (except those to self)
         DISCARD discard = new DISCARD();
-        channels[0].getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE, TP.class);
+        channels[0].getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE, AbstractTP.class);
         discard.setDiscardAll(true);
 
         // send a RSVP message

--- a/tests/junit-functional/org/jgroups/tests/ExecutingServiceTest2.java
+++ b/tests/junit-functional/org/jgroups/tests/ExecutingServiceTest2.java
@@ -1,6 +1,6 @@
 package org.jgroups.tests;
 
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.blocks.executor.ExecutionRunner;
@@ -26,13 +26,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ExecutingServiceTest2 {
 
     Set<Thread> threads=new HashSet<>();
-    Set<Channel> channels=new HashSet<>();
+    Set<AbstractChannel> channels=new HashSet<>();
 
     @AfterMethod
     public void tearDown() {
         for(Thread thread : threads)
             thread.interrupt();
-        for(Channel channel : channels)
+        for(AbstractChannel channel : channels)
             channel.close();
     }
 

--- a/tests/junit-functional/org/jgroups/tests/FCTest.java
+++ b/tests/junit-functional/org/jgroups/tests/FCTest.java
@@ -9,7 +9,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
@@ -36,8 +36,8 @@ public class FCTest {
         };
     }
 
-    protected void setUp(Class<? extends Protocol> flow_control_class) throws Exception {
-        Protocol flow_control_prot=flow_control_class.newInstance();
+    protected void setUp(Class<? extends AbstractProtocol> flow_control_class) throws Exception {
+        AbstractProtocol flow_control_prot=flow_control_class.newInstance();
         flow_control_prot.setValue("min_credits", 1000).setValue("max_credits", 10000).setValue("max_block_time", 1000);
 
         ch=new JChannel(new SHARED_LOOPBACK().setValue("thread_pool_rejection_policy", "run"),
@@ -55,7 +55,7 @@ public class FCTest {
 
 
     @Test(dataProvider="configProvider")
-    public void testReceptionOfAllMessages(Class<? extends Protocol> flow_control_class) throws Exception {
+    public void testReceptionOfAllMessages(Class<? extends AbstractProtocol> flow_control_class) throws Exception {
         int num_received=0;
         Receiver r=new Receiver();
         setUp(flow_control_class);

--- a/tests/junit-functional/org/jgroups/tests/ForkChannelTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ForkChannelTest.java
@@ -12,7 +12,7 @@ import org.jgroups.protocols.COUNTER;
 import org.jgroups.protocols.FORK;
 import org.jgroups.protocols.FRAG2;
 import org.jgroups.protocols.pbcast.STATE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.MyReceiver;
 import org.jgroups.util.Util;
@@ -33,7 +33,7 @@ public class ForkChannelTest {
     protected ForkChannel             fc1, fc2, fc3, fc4;
     protected static final String     CLUSTER="ForkChannelTest";
 
-    protected Protocol[] protocols() {return Util.getTestStack(new STATE(), new FORK());}
+    protected AbstractProtocol[] protocols() {return Util.getTestStack(new STATE(), new FORK());}
 
     @BeforeMethod protected void setup() throws Exception {
         a=new JChannel(protocols()).name("A");
@@ -117,7 +117,7 @@ public class ForkChannelTest {
 
     public void testRefcount() throws Exception {
         FORK fork=(FORK)a.getProtocolStack().findProtocol(FORK.class);
-        Protocol prot=fork.get("stack");
+        AbstractProtocol prot=fork.get("stack");
         assert prot == null;
         fc1=new ForkChannel(a, "stack", "fc1");
         prot=fork.get("stack");
@@ -176,7 +176,7 @@ public class ForkChannelTest {
         assert p1.inits == 1 && p2.inits == 1;
 
         FORK fork=(FORK)a.getProtocolStack().findProtocol(FORK.class);
-        Protocol prot=fork.get("stack");
+        AbstractProtocol prot=fork.get("stack");
         ForkProtocolStack fork_stack=(ForkProtocolStack)getProtStack(prot);
         int inits=fork_stack.getInits();
         assert inits == 3;
@@ -341,7 +341,7 @@ public class ForkChannelTest {
     }
 
 
-    protected static ProtocolStack getProtStack(Protocol prot) {
+    protected static ProtocolStack getProtStack(AbstractProtocol prot) {
         while(prot != null && !(prot instanceof ProtocolStack)) {
             prot=prot.getUpProtocol();
         }
@@ -365,7 +365,7 @@ public class ForkChannelTest {
         }
     }*/
 
-    protected static class Prot extends Protocol {
+    protected static class Prot extends AbstractProtocol {
         protected final String myname;
         protected int          inits, starts, stops, destroys;
 

--- a/tests/junit-functional/org/jgroups/tests/FragTest.java
+++ b/tests/junit-functional/org/jgroups/tests/FragTest.java
@@ -10,7 +10,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -105,7 +105,7 @@ public class FragTest {
     public void testMessageOrdering() throws Exception {
         OrderingReceiver receiver=new OrderingReceiver();
         ch.setReceiver(receiver);
-        Protocol frag=ch.getProtocolStack().findProtocol(FRAG2.class, FRAG.class);
+        AbstractProtocol frag=ch.getProtocolStack().findProtocol(FRAG2.class, FRAG.class);
         frag.setValue("frag_size", 5000);
 
         Message first=new Message(null, new Payload(1, 10));

--- a/tests/junit-functional/org/jgroups/tests/HeadersTest.java
+++ b/tests/junit-functional/org/jgroups/tests/HeadersTest.java
@@ -1,7 +1,7 @@
 package org.jgroups.tests;
 
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.util.Headers;
 import org.testng.annotations.Test;
 
@@ -21,7 +21,7 @@ public class HeadersTest {
 
 
     public void testGetHeader() {
-        Header[] hdrs=createHeaders(3);
+        AbstractHeader[] hdrs=createHeaders(3);
         assert null == Headers.getHeader(null, (short)400);
         assert null == Headers.getHeader(hdrs, (short)400);
         assert Headers.getHeader(hdrs, UDP_ID) == h3;
@@ -29,9 +29,9 @@ public class HeadersTest {
 
 
     public void testGetHeaders() {
-        Header[] hdrs=createHeaders(3);
+        AbstractHeader[] hdrs=createHeaders(3);
         System.out.printf("hdrs are: %s\n", Headers.printObjectHeaders(hdrs));
-        Map<Short, Header> map=Headers.getHeaders(hdrs);
+        Map<Short, AbstractHeader> map=Headers.getHeaders(hdrs);
         System.out.println("map = " + map);
         assert map != null && map.size() == 3;
         assert map.get(NAKACK_ID) == h1;
@@ -41,9 +41,9 @@ public class HeadersTest {
 
 
     public void testPutHeader() {
-        Header[] hdrs=createHeaders(3);
+        AbstractHeader[] hdrs=createHeaders(3);
         assert Headers.getHeader(hdrs, NAKACK_ID) == h1;
-        Header[] retval=Headers.putHeader(hdrs, NAKACK_ID, new MyHeader(NAKACK_ID), true);
+        AbstractHeader[] retval=Headers.putHeader(hdrs, NAKACK_ID, new MyHeader(NAKACK_ID), true);
         assert retval == null;
         assert Headers.size(hdrs) == 3;
         assert Headers.getHeader(hdrs, NAKACK_ID) != h1;
@@ -57,8 +57,8 @@ public class HeadersTest {
 
 
     public void testPutHeaderIfAbsent() {
-        Header[] hdrs=createHeaders(3);
-        Header[] retval=Headers.putHeader(hdrs, FRAG_ID, new MyHeader(FRAG_ID), false);
+        AbstractHeader[] hdrs=createHeaders(3);
+        AbstractHeader[] retval=Headers.putHeader(hdrs, FRAG_ID, new MyHeader(FRAG_ID), false);
         assert retval == null;
 
         assert Headers.getHeader(hdrs, FRAG_ID) == h2;
@@ -86,11 +86,11 @@ public class HeadersTest {
 
 
     public void testResize() {
-        Header[] hdrs=createHeaders(3);
+        AbstractHeader[] hdrs=createHeaders(3);
         int capacity=hdrs.length;
         System.out.println("hdrs = " + Headers.printHeaders(hdrs) + ", capacity=" + capacity);
 
-        Header[] retval=Headers.putHeader(hdrs, (short)400, new MyHeader((short)400), true);
+        AbstractHeader[] retval=Headers.putHeader(hdrs, (short)400, new MyHeader((short)400), true);
         assert retval != null;
         hdrs=retval;
         System.out.println("hdrs = " + Headers.printHeaders(hdrs) + ", capacity=" + hdrs.length);
@@ -108,24 +108,24 @@ public class HeadersTest {
 
 
     public void testCopy() {
-        Header[] hdrs=createHeaders(3);
-        Header[] retval=Headers.putHeader(hdrs, (short)400, new MyHeader((short)400), true);
+        AbstractHeader[] hdrs=createHeaders(3);
+        AbstractHeader[] retval=Headers.putHeader(hdrs, (short)400, new MyHeader((short)400), true);
         assert retval != null;
         hdrs=retval;
-        Header[] copy=Headers.copy(hdrs);
+        AbstractHeader[] copy=Headers.copy(hdrs);
         assert copy.length == hdrs.length;
         assert Headers.size(copy) == Headers.size(hdrs);
     }
 
 
     public void testSize() {
-        Header[] hdrs=createHeaders(3);
+        AbstractHeader[] hdrs=createHeaders(3);
         assert Headers.size(hdrs) == 3;
     }
 
 
-    private static Header[] createHeaders(int initial_capacity) {
-        Header[] hdrs=new Header[initial_capacity];
+    private static AbstractHeader[] createHeaders(int initial_capacity) {
+        AbstractHeader[] hdrs=new AbstractHeader[initial_capacity];
         hdrs[0]=h1;
         hdrs[1]=h2;
         hdrs[2]=h3;
@@ -134,7 +134,7 @@ public class HeadersTest {
 
 
 
-    public static class MyHeader extends Header {
+    public static class MyHeader extends AbstractHeader {
 
         public MyHeader(short prot_id) {
             this.prot_id=prot_id;

--- a/tests/junit-functional/org/jgroups/tests/InetAddressChecksTest.java
+++ b/tests/junit-functional/org/jgroups/tests/InetAddressChecksTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.Event;
 import org.jgroups.Global ;
 import org.jgroups.conf.ProtocolConfiguration;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.stack.Configurator ;
 import org.jgroups.stack.Configurator.InetAddressInfo;
@@ -23,7 +23,7 @@ import java.net.InetAddress ;
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
 public class InetAddressChecksTest {
 	ProtocolStack stack = null;
-	Protocol protocol = null ;
+	AbstractProtocol protocol = null ;
 	static final String ipCheckNoConsistentProps="org.jgroups.tests.InetAddressChecksTest$IPCHECK(" + 
 								"inetAddress1=127.0.0.1;inetAddress2=::1;inetAddress3=192.168.0.100;i=3)" ;
 	static final String ipCheckConsistentProps="org.jgroups.tests.InetAddressChecksTest$IPCHECK(" + 
@@ -43,7 +43,7 @@ public class InetAddressChecksTest {
 	public void testIPVersionCheckingNoConsistentVersion() throws Exception {
 
 		Vector<ProtocolConfiguration> protocol_configs = new Vector<>() ;
-		Vector<Protocol> protocols = new Vector<>() ;
+		Vector<AbstractProtocol> protocols = new Vector<>() ;
 		
 		// create the layer described by IPCHECK
 		protocol = Configurator.createProtocol(ipCheckNoConsistentProps, stack) ;
@@ -80,7 +80,7 @@ public class InetAddressChecksTest {
 	public void testIPVersionCheckingConsistentVersion() throws Exception {
 
 		Vector<ProtocolConfiguration> protocol_configs = new Vector<>() ;
-		Vector<Protocol> protocols = new Vector<>() ;
+		Vector<AbstractProtocol> protocols = new Vector<>() ;
 		
 		// create the layer described by IPCHECK
 		protocol = Configurator.createProtocol(ipCheckConsistentProps, stack) ;
@@ -118,7 +118,7 @@ public class InetAddressChecksTest {
 	}
 
 	
-	public static class IPCHECK extends Protocol {
+	public static class IPCHECK extends AbstractProtocol {
 
 		@Property(name="inetAddress1")
 		InetAddress inetAddress1 ;

--- a/tests/junit-functional/org/jgroups/tests/MergeTest4.java
+++ b/tests/junit-functional/org/jgroups/tests/MergeTest4.java
@@ -138,7 +138,7 @@ public class MergeTest4 {
         members.add(coord);
         View coord_view=new View(coord, 4, members);
         System.out.println("coord_view: " + coord_view);
-        Channel coord_channel = findChannel(coord);
+        AbstractChannel coord_channel = findChannel(coord);
         System.out.println("coord_channel: " + coord_channel.getAddress());
         
         MutableDigest digest=new MutableDigest(coord_view.getMembersRaw());

--- a/tests/junit-functional/org/jgroups/tests/MessageBatchTest.java
+++ b/tests/junit-functional/org/jgroups/tests/MessageBatchTest.java
@@ -297,7 +297,7 @@ public class MessageBatchTest {
         List<Message> msgs=createMessages();
         ByteArrayOutputStream output=new ByteArrayOutputStream();
         DataOutputStream out=new DataOutputStream(output);
-        TP.writeMessageList(b, a, "cluster".getBytes(), msgs, out, false, UDP_ID);
+        AbstractTP.writeMessageList(b, a, "cluster".getBytes(), msgs, out, false, UDP_ID);
         out.flush();
 
         byte[] buf=output.toByteArray();
@@ -306,7 +306,7 @@ public class MessageBatchTest {
         DataInputStream in=new DataInputStream(new ByteArrayInputStream(buf));
         in.readShort(); // version
         in.readByte(); // flags
-        List<Message> list=TP.readMessageList(in, UDP_ID);
+        List<Message> list= AbstractTP.readMessageList(in, UDP_ID);
         assert msgs.size() == list.size();
     }
 

--- a/tests/junit-functional/org/jgroups/tests/MessageTest.java
+++ b/tests/junit-functional/org/jgroups/tests/MessageTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.Header;
+import org.jgroups.AbstractHeader;
 import org.jgroups.Message;
 import org.jgroups.protocols.PingHeader;
 import org.jgroups.protocols.TpHeader;
@@ -261,7 +261,7 @@ public class MessageTest {
 
         Message m2=m1.copy(true, Global.BLOCKS_START_ID);
         System.out.println("Headers for m2: " + m2.printHeaders());
-        Map<Short,Header> hdrs=m2.getHeaders();
+        Map<Short,AbstractHeader> hdrs=m2.getHeaders();
         assert hdrs.size() == 2;
         assert hdrs.containsKey(Global.BLOCKS_START_ID);
 
@@ -477,7 +477,7 @@ public class MessageTest {
     }
 
 
-    protected static class DummyHeader extends Header {
+    protected static class DummyHeader extends AbstractHeader {
         protected final short num;
 
         public DummyHeader(short num) {

--- a/tests/junit-functional/org/jgroups/tests/NakReceiverWindowTest.java
+++ b/tests/junit-functional/org/jgroups/tests/NakReceiverWindowTest.java
@@ -6,7 +6,7 @@ import org.jgroups.Address;
 import org.jgroups.Global;
 import org.jgroups.Message;
 import org.jgroups.stack.NakReceiverWindow;
-import org.jgroups.stack.Retransmitter;
+import org.jgroups.stack.AbstractRetransmitter;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
 import org.testng.Assert;
@@ -771,7 +771,7 @@ public class NakReceiverWindowTest {
     }
 
 
-    private static class MyRetransmitCommand implements Retransmitter.RetransmitCommand {
+    private static class MyRetransmitCommand implements AbstractRetransmitter.RetransmitCommand {
 
         public void retransmit(long first_seqno, long last_seqno, Address sender) {
         }

--- a/tests/junit-functional/org/jgroups/tests/NakReceiverWindowTest2.java
+++ b/tests/junit-functional/org/jgroups/tests/NakReceiverWindowTest2.java
@@ -5,7 +5,7 @@ import org.jgroups.Global;
 import org.jgroups.Message;
 import org.jgroups.protocols.pbcast.NakAckHeader;
 import org.jgroups.stack.NakReceiverWindow;
-import org.jgroups.stack.Retransmitter;
+import org.jgroups.stack.AbstractRetransmitter;
 import org.jgroups.util.DefaultTimeScheduler;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -39,7 +39,7 @@ public class NakReceiverWindowTest2 {
     @BeforeMethod
     void init() {
         latch=new CountDownLatch(1);
-        win=new NakReceiverWindow(self, new Retransmitter.RetransmitCommand() {
+        win=new NakReceiverWindow(self, new AbstractRetransmitter.RetransmitCommand() {
             public void retransmit(long first_seqno, long last_seqno, Address sender) {
             }
         }, 0, new DefaultTimeScheduler(2));

--- a/tests/junit-functional/org/jgroups/tests/NakackTest.java
+++ b/tests/junit-functional/org/jgroups/tests/NakackTest.java
@@ -6,7 +6,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -114,7 +114,7 @@ public class NakackTest {
     }
 
     protected static JChannel createChannel() throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new MERGE3().setValue("min_interval", 1000).setValue("max_interval", 3000),

--- a/tests/junit-functional/org/jgroups/tests/NakackUnitTest.java
+++ b/tests/junit-functional/org/jgroups/tests/NakackUnitTest.java
@@ -5,7 +5,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -93,7 +93,7 @@ public class NakackUnitTest {
     protected Message msg() {return new Message(null);}
 
     protected JChannel create(String name, boolean use_batching) throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING().timeout(1000),
           new MAKE_BATCH().sleepTime(100).multicasts(use_batching),

--- a/tests/junit-functional/org/jgroups/tests/NioServerTest2.java
+++ b/tests/junit-functional/org/jgroups/tests/NioServerTest2.java
@@ -11,7 +11,7 @@ import org.jgroups.protocols.UNICAST3;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -81,7 +81,7 @@ public class NioServerTest2 {
 
 
     protected static JChannel create(String name) throws Exception {
-        return new JChannel(new Protocol[] {
+        return new JChannel(new AbstractProtocol[] {
           new TCP_NIO2()
             .setValue("bind_addr", Util.getLocalhost())
             .setValue("recv_buf_size", recv_buf_size).setValue("send_buf_size", send_buf_size),

--- a/tests/junit-functional/org/jgroups/tests/ProgrammaticApiTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ProgrammaticApiTest.java
@@ -5,7 +5,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -37,7 +37,7 @@ public class ProgrammaticApiTest {
         stack.init();
         c1.connect("demo");
 
-        Protocol transport=stack.getTransport();
+        AbstractProtocol transport=stack.getTransport();
         transport.up(new Event(Event.MSG, new Message(null, Util.createRandomAddress(), "hello world")));
         assert receiver.getNumMsgsReceived() == 1;
     }
@@ -81,16 +81,16 @@ public class ProgrammaticApiTest {
 
 
 
-    protected static class MockProtocol1 extends Protocol {
+    protected static class MockProtocol1 extends AbstractProtocol {
 
     }
 
-    protected static class MockProtocol2 extends Protocol {
+    protected static class MockProtocol2 extends AbstractProtocol {
         
     }
 
-    static Protocol[] createProtocols() {
-        return new Protocol[] {
+    static AbstractProtocol[] createProtocols() {
+        return new AbstractProtocol[] {
                 new PING(),
                 new MERGE3(),
                 new FD_SOCK(),

--- a/tests/junit-functional/org/jgroups/tests/PropertyConvertersTest.java
+++ b/tests/junit-functional/org/jgroups/tests/PropertyConvertersTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.Global;
 import org.jgroups.conf.PropertyConverter;
 import org.jgroups.conf.PropertyConverters;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.testng.annotations.Test;
 
 import java.net.NetworkInterface;
@@ -70,7 +70,7 @@ public class PropertyConvertersTest {
         assert map.get("com.sun.security.sasl.digest.realm").equals("MyRealm");
     }
 
-    private static void check(Protocol protocol, Class<?> type, String prop, Object result, PropertyConverter converter) throws Exception {
+    private static void check(AbstractProtocol protocol, Class<?> type, String prop, Object result, PropertyConverter converter) throws Exception {
         Object tmp=converter.convert(protocol, type, "bela", prop, false);
         assert tmp.equals(result) : " conversion result: " + tmp + " (" + tmp.getClass() + ")" +
                 ", expected result: " + result + " (" + result.getClass() + ")";
@@ -79,7 +79,7 @@ public class PropertyConvertersTest {
         assert output.equals(prop) : "output=" + output + ", prop=" + prop;
     }
 
-    private static void checkArray(Protocol protocol, Class<?> type, String prop, Object result, PropertyConverter converter) throws Exception {
+    private static void checkArray(AbstractProtocol protocol, Class<?> type, String prop, Object result, PropertyConverter converter) throws Exception {
         Object tmp=converter.convert(protocol, type, "bela", prop, false);
         assert Arrays.equals((long[])tmp, (long[])result) : " conversion result: " + tmp + " (" + tmp.getClass() + ")" +
                 ", expected result: " + result + " (" + result.getClass() + ")";

--- a/tests/junit-functional/org/jgroups/tests/ProtocolConfigurationTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ProtocolConfigurationTest.java
@@ -8,7 +8,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.conf.PropertyConverters;
 import org.jgroups.stack.Configurator;
 import org.jgroups.stack.IpAddress;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -25,7 +25,7 @@ import java.util.Vector;
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
 public class ProtocolConfigurationTest {
 	ProtocolStack stack = null;
-	Protocol protocol = null ;
+	AbstractProtocol protocol = null ;
 	static final String orderProps="org.jgroups.tests.ProtocolConfigurationTest$ORDERING(a=1;b=2;c=3)";
 	static final String refsProps="org.jgroups.tests.ProtocolConfigurationTest$REFS(a=1;b=2;c=3)";
 	static final String defaultProps="org.jgroups.tests.ProtocolConfigurationTest$DEFAULTS(b=333)";
@@ -86,7 +86,7 @@ public class ProtocolConfigurationTest {
 	public void testDefaultAssignment() throws Exception {
 
 		Vector<ProtocolConfiguration> protocol_configs = new Vector<>() ;
-		Vector<Protocol> protocols = new Vector<>() ;
+		Vector<AbstractProtocol> protocols = new Vector<>() ;
 		
 		// create the layer described by DEFAULTS
 		protocol = Configurator.createProtocol(defaultProps, stack) ;
@@ -119,7 +119,7 @@ public class ProtocolConfigurationTest {
 	public void testAssignmentInetAddresses() throws Exception {
 
 		Vector<ProtocolConfiguration> protocol_configs = new Vector<>() ;
-		Vector<Protocol> protocols = new Vector<>() ;
+		Vector<AbstractProtocol> protocols = new Vector<>() ;
 		
 		// create the layer described by INETADDRESSES
 		protocol = Configurator.createProtocol(addressProps, stack) ;
@@ -148,7 +148,7 @@ public class ProtocolConfigurationTest {
 	public void testConfigurableObject() throws Exception {
 
 		Vector<ProtocolConfiguration> protocol_configs = new Vector<>() ;
-		Vector<Protocol> protocols = new Vector<>() ;
+		Vector<AbstractProtocol> protocols = new Vector<>() ;
 		
 		// create the layer described by INETADDRESSES
 		protocol = Configurator.createProtocol(configurableObjectsProps, stack) ;
@@ -167,7 +167,7 @@ public class ProtocolConfigurationTest {
 	}
 
 	
-	public static class ORDERING extends Protocol {
+	public static class ORDERING extends AbstractProtocol {
 		List<String> list = new LinkedList<>() ;
 		
 		@Property(name="a", dependsUpon="b") 
@@ -197,7 +197,7 @@ public class ProtocolConfigurationTest {
 			return up_prot.up(evt);
 		}
 	}
-	public static class REFS extends Protocol {
+	public static class REFS extends AbstractProtocol {
 
 		@Property(name="a", dependsUpon="b") 
 		public void setA(int a) {
@@ -220,7 +220,7 @@ public class ProtocolConfigurationTest {
 			return up_prot.up(evt);
 		}
 	}
-	public static class DEFAULTS extends Protocol {
+	public static class DEFAULTS extends AbstractProtocol {
 		int a ;
 		int b ;
 		InetAddress c ;
@@ -258,7 +258,7 @@ public class ProtocolConfigurationTest {
 			return up_prot.up(evt);
 		}
 	}
-	public static class INETADDRESSES extends Protocol {
+	public static class INETADDRESSES extends AbstractProtocol {
 		InetAddress inetAddressMethod ;
 		
 		@Property(name="inetAddressField")
@@ -307,7 +307,7 @@ public class ProtocolConfigurationTest {
 			return up_prot.up(evt);
 		}
 	}
-	public static class CONFIGOBJPROTOCOL extends Protocol {
+	public static class CONFIGOBJPROTOCOL extends AbstractProtocol {
 
 	    private Object configObjInstance=null;
 		

--- a/tests/junit-functional/org/jgroups/tests/Relay2RpcDispatcherTest.java
+++ b/tests/junit-functional/org/jgroups/tests/Relay2RpcDispatcherTest.java
@@ -12,7 +12,7 @@ import org.jgroups.protocols.relay.RELAY2;
 import org.jgroups.protocols.relay.Relayer;
 import org.jgroups.protocols.relay.SiteMaster;
 import org.jgroups.protocols.relay.config.RelayConfig;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.RspList;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -180,8 +180,8 @@ public class Relay2RpcDispatcherTest {
     
     public static class ServerObject {
     	int i;
-    	Channel ch;
-    	public ServerObject(Channel ch, int i) {
+    	AbstractChannel ch;
+    	public ServerObject(AbstractChannel ch, int i) {
     		this.ch = ch;
     		this.i=i;
     	}
@@ -210,8 +210,8 @@ public class Relay2RpcDispatcherTest {
         return relay;
     }
 
-    protected static Protocol[] createBridgeStack() {
-        return new Protocol[]{
+    protected static AbstractProtocol[] createBridgeStack() {
+        return new AbstractProtocol[]{
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new NAKACK2(),

--- a/tests/junit-functional/org/jgroups/tests/Relay2Test.java
+++ b/tests/junit-functional/org/jgroups/tests/Relay2Test.java
@@ -7,7 +7,7 @@ import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.relay.RELAY2;
 import org.jgroups.protocols.relay.Relayer;
 import org.jgroups.protocols.relay.config.RelayConfig;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -279,8 +279,8 @@ public class Relay2Test {
         return relay;
     }
 
-    protected static Protocol[] createBridgeStack() {
-        return new Protocol[]{
+    protected static AbstractProtocol[] createBridgeStack() {
+        return new AbstractProtocol[]{
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new MERGE3().setValue("max_interval", 3000).setValue("min_interval", 1000),

--- a/tests/junit-functional/org/jgroups/tests/RetransmitterTest.java
+++ b/tests/junit-functional/org/jgroups/tests/RetransmitterTest.java
@@ -7,7 +7,7 @@ import org.jgroups.Global;
 import org.jgroups.stack.DefaultRetransmitter;
 import org.jgroups.stack.ExponentialInterval;
 import org.jgroups.stack.RangeBasedRetransmitter;
-import org.jgroups.stack.Retransmitter;
+import org.jgroups.stack.AbstractRetransmitter;
 import org.jgroups.util.*;
 import org.testng.Assert;
 import org.testng.annotations.*;
@@ -34,16 +34,16 @@ public class RetransmitterTest {
 
 
     @DataProvider(name="createRetransmitter")
-    protected Retransmitter[][] createRetransmitter() {
-        Retransmitter range_based_retransmitter=new RangeBasedRetransmitter(sender, new MyXmitter(), timer);
-        Retransmitter old_retransmitter=new DefaultRetransmitter(sender, new MyXmitter(), timer);
+    protected AbstractRetransmitter[][] createRetransmitter() {
+        AbstractRetransmitter range_based_retransmitter=new RangeBasedRetransmitter(sender, new MyXmitter(), timer);
+        AbstractRetransmitter old_retransmitter=new DefaultRetransmitter(sender, new MyXmitter(), timer);
 
         range_based_retransmitter.setRetransmitTimeouts(new ExponentialInterval(1000));
         range_based_retransmitter.reset();
         old_retransmitter.setRetransmitTimeouts(new ExponentialInterval(1000));
         old_retransmitter.reset();
 
-        return new Retransmitter[][] {
+        return new AbstractRetransmitter[][] {
           {old_retransmitter},
           {range_based_retransmitter}
         };
@@ -53,7 +53,7 @@ public class RetransmitterTest {
 
 
     @Test(dataProvider="createRetransmitter")
-    public void testNoEntry(Retransmitter xmitter) {
+    public void testNoEntry(AbstractRetransmitter xmitter) {
         int size=xmitter.size();
         System.out.println("xmitter: " + xmitter);
         Assert.assertEquals(0, size);
@@ -61,7 +61,7 @@ public class RetransmitterTest {
 
 
     @Test(dataProvider="createRetransmitter")
-    public void testSingleEntry(Retransmitter xmitter) {
+    public void testSingleEntry(AbstractRetransmitter xmitter) {
         xmitter.add(1, 1);
         int size=xmitter.size();
         System.out.println("xmitter: " + xmitter);
@@ -70,7 +70,7 @@ public class RetransmitterTest {
 
 
     @Test(dataProvider="createRetransmitter")
-    public void testEntry(Retransmitter xmitter) {
+    public void testEntry(AbstractRetransmitter xmitter) {
         xmitter.add(1, 10);
         int size=xmitter.size();
         System.out.println("xmitter: " + xmitter);
@@ -79,7 +79,7 @@ public class RetransmitterTest {
 
 
     @Test(dataProvider="createRetransmitter")
-    public void testMultipleEntries(Retransmitter xmitter) {
+    public void testMultipleEntries(AbstractRetransmitter xmitter) {
         xmitter.add(1, 10);
         int size=xmitter.size();
         System.out.println("xmitter: " + xmitter);
@@ -138,7 +138,7 @@ public class RetransmitterTest {
      * @param xmitter
      */
     @Test(dataProvider="createRetransmitter")
-    public void testRanges(Retransmitter xmitter) {
+    public void testRanges(AbstractRetransmitter xmitter) {
         xmitter.add(100, 200);
         xmitter.add(300, 400);
         System.out.println("xmitter (" + xmitter.getClass().getCanonicalName() + "): " + xmitter);
@@ -146,7 +146,7 @@ public class RetransmitterTest {
     }
 
     @Test(dataProvider="createRetransmitter")
-    public void testAddAndRemoveIndividualSeqnos(Retransmitter xmitter) {
+    public void testAddAndRemoveIndividualSeqnos(AbstractRetransmitter xmitter) {
         int NUM=100;
         List<Long> seqnos=new ArrayList<>(NUM);
         for(long i=1; i <= NUM; i++) {
@@ -167,7 +167,7 @@ public class RetransmitterTest {
 
 
     @Test(dataProvider="createRetransmitter")
-    public void testAddAndRemoveRanges(Retransmitter xmitter) {
+    public void testAddAndRemoveRanges(AbstractRetransmitter xmitter) {
         int NUM=100;
         List<Long> seqnos=new ArrayList<>(NUM);
         for(long i=1; i <= NUM; i++)
@@ -187,7 +187,7 @@ public class RetransmitterTest {
     }
 
 
-    static class MyXmitter implements Retransmitter.RetransmitCommand {
+    static class MyXmitter implements AbstractRetransmitter.RetransmitCommand {
 
         public void retransmit(long first_seqno, long last_seqno, Address sender) {
         }

--- a/tests/junit-functional/org/jgroups/tests/RpcDispatcherAsyncInvocationTest.java
+++ b/tests/junit-functional/org/jgroups/tests/RpcDispatcherAsyncInvocationTest.java
@@ -7,7 +7,7 @@ import org.jgroups.blocks.*;
 import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -122,11 +122,11 @@ public class RpcDispatcherAsyncInvocationTest {
 
 
     protected static JChannel createChannel(String name) throws Exception {
-        TP transport=new SHARED_LOOPBACK();
+        AbstractTP transport=new SHARED_LOOPBACK();
         transport.setOOBThreadPoolMinThreads(10);
         transport.setOOBThreadPoolMaxThreads(20);
         transport.setOOBThreadPoolQueueEnabled(false);
-        return new JChannel(new Protocol[]{
+        return new JChannel(new AbstractProtocol[]{
           transport,
           new SHARED_LOOPBACK_PING(),
           new NAKACK2(),

--- a/tests/junit-functional/org/jgroups/tests/ServerUnitTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ServerUnitTest.java
@@ -4,7 +4,7 @@ package org.jgroups.tests;
 
 import org.jgroups.Address;
 import org.jgroups.Global;
-import org.jgroups.blocks.cs.BaseServer;
+import org.jgroups.blocks.cs.AbstractBaseServer;
 import org.jgroups.blocks.cs.NioServer;
 import org.jgroups.blocks.cs.ReceiverAdapter;
 import org.jgroups.blocks.cs.TcpServer;
@@ -38,8 +38,8 @@ public class ServerUnitTest {
 
     public void testSetup() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
                 Assert.assertNotSame(a.localAddress(), b.localAddress());
             }
         }
@@ -48,7 +48,7 @@ public class ServerUnitTest {
 
     public void testSendEmptyData() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0)) {
                 byte[] data=new byte[0];
                 Address myself=a.localAddress();
                 a.receiver(new ReceiverAdapter() {});
@@ -59,7 +59,7 @@ public class ServerUnitTest {
 
     public void testSendNullData() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0)) {
                 Address myself=a.localAddress();
                 a.send(myself, null, 0, 0); // the test passes if send() doesn't throw an exception
             }
@@ -69,7 +69,7 @@ public class ServerUnitTest {
 
     public void testSendToSelf() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0)) {
                 long NUM=1000, total_time;
                 Address myself=a.localAddress();
                 MyReceiver r=new MyReceiver(a, NUM, false);
@@ -90,8 +90,8 @@ public class ServerUnitTest {
 
     public void testSendToAll() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
                 long NUM=1000, total_time;
                 MyReceiver r1=new MyReceiver(a, NUM, false);
                 MyReceiver r2=new MyReceiver(b, NUM, false);
@@ -120,8 +120,8 @@ public class ServerUnitTest {
 
     public void testSendToOther() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
                 long NUM=1000, total_time;
                 Address other=b.localAddress();
                 MyReceiver r=new MyReceiver(b, NUM, false);
@@ -145,8 +145,8 @@ public class ServerUnitTest {
 
     public void testSendToOtherGetResponse() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
                 long NUM=1000, total_time;
                 Address other=b.localAddress();
                 MyReceiver r1=new MyReceiver(a, NUM, false);
@@ -179,8 +179,8 @@ public class ServerUnitTest {
      */
     public void testReuseOfConnection() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
 
                 int num_conns;
                 num_conns=a.getNumConnections();
@@ -213,8 +213,8 @@ public class ServerUnitTest {
 
     public void testConnectionCountOnStop() throws Exception {
         for(boolean nio : new boolean[]{false, true}) {
-            try(BaseServer a=create(nio, 0);
-                BaseServer b=create(nio, 0)) {
+            try(AbstractBaseServer a=create(nio, 0);
+                AbstractBaseServer b=create(nio, 0)) {
                 Address addr1=a.localAddress(), addr2=b.localAddress();
                 byte[] data="hello world".getBytes();
                 a.send(addr1, data, 0, data.length); // send to self
@@ -265,9 +265,9 @@ public class ServerUnitTest {
         System.out.println("-- [" + Thread.currentThread() + "]: " + msg);
     }
 
-    protected static BaseServer create(boolean nio, int port) {
+    protected static AbstractBaseServer create(boolean nio, int port) {
         try {
-            BaseServer retval=nio? new NioServer(bind_addr, port).maxSendBuffers(1024)
+            AbstractBaseServer retval=nio? new NioServer(bind_addr, port).maxSendBuffers(1024)
               : new TcpServer(bind_addr, port).useSendQueues(false);
             retval.usePeerConnections(true);
             retval.start();
@@ -278,10 +278,10 @@ public class ServerUnitTest {
         }
     }
 
-    protected void waitForOpenConns(int expected, BaseServer... servers) {
+    protected void waitForOpenConns(int expected, AbstractBaseServer... servers) {
         for(int i=0; i < 10; i++) {
             boolean all_ok=true;
-            for(BaseServer server: servers) {
+            for(AbstractBaseServer server: servers) {
                 if(server.getNumOpenConnections() != expected) {
                     all_ok=false;
                     break;
@@ -294,7 +294,7 @@ public class ServerUnitTest {
     }
 
 
-    protected void connectionEstablished(BaseServer server, Address dest) {
+    protected void connectionEstablished(AbstractBaseServer server, Address dest) {
         for(int i=0; i < 10; i++) {
             if(server.connectionEstablishedTo(dest))
                 break;
@@ -313,9 +313,9 @@ public class ServerUnitTest {
         protected final  CondVar   done=new CondVar();
         protected boolean          send_response=false;
         protected final long       modulo;
-        protected final BaseServer server;
+        protected final AbstractBaseServer server;
 
-        MyReceiver(BaseServer server, long num_expected, boolean send_response) {
+        MyReceiver(AbstractBaseServer server, long num_expected, boolean send_response) {
             this.server=server;
             this.num_expected=num_expected;
             this.send_response=send_response;

--- a/tests/junit-functional/org/jgroups/tests/SetPropertyTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SetPropertyTest.java
@@ -2,7 +2,7 @@ package org.jgroups.tests;
 
 import org.jgroups.Global;
 import org.jgroups.JChannel;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -27,7 +27,7 @@ public class SetPropertyTest {
 
 
     public void testSetter() {
-        TP transport=ch.getProtocolStack().getTransport();
+        AbstractTP transport=ch.getProtocolStack().getTransport();
         int port=transport.getBindPort();
         System.out.println("port = " + port);
         transport.setBindPort(port +20);

--- a/tests/junit-functional/org/jgroups/tests/SizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SizeTest.java
@@ -925,13 +925,13 @@ public class SizeTest {
         assert len == serialized_form.length;
     }
 
-    private static void _testSize(Header hdr) throws Exception {
+    private static void _testSize(AbstractHeader hdr) throws Exception {
         long size=hdr.size();
         byte[] serialized_form=Util.streamableToByteBuffer(hdr);
         System.out.println(hdr.getClass().getSimpleName() + ": size=" + size + ", serialized size=" + serialized_form.length);
         Assert.assertEquals(serialized_form.length, size);
 
-        Header hdr2=(Header)Util.streamableFromByteBuffer(hdr.getClass(), serialized_form);
+        AbstractHeader hdr2=(AbstractHeader)Util.streamableFromByteBuffer(hdr.getClass(), serialized_form);
         assert hdr2.size() == hdr.size();
     }
 

--- a/tests/junit-functional/org/jgroups/tests/UnicastUnitTest.java
+++ b/tests/junit-functional/org/jgroups/tests/UnicastUnitTest.java
@@ -5,7 +5,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -162,7 +162,7 @@ public class UnicastUnitTest {
     protected Message msg(Address dest) {return new Message(dest);}
 
     protected JChannel create(String name, boolean use_batching) throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING().timeout(1000),
           new NAKACK2(),
@@ -183,12 +183,12 @@ public class UnicastUnitTest {
 
 
     protected static class MyReceiver extends ReceiverAdapter {
-        protected Channel             channel;
+        protected AbstractChannel channel;
         protected Throwable           ex;
         protected final List<Integer> list=new ArrayList<>();
 
         public               MyReceiver()           {this(null);}
-        public               MyReceiver(Channel ch) {this.channel=ch;}
+        public               MyReceiver(AbstractChannel ch) {this.channel=ch;}
         public Throwable     getEx()                {return ex;}
         public List<Integer> list()                 {return list;}
         public void          clear()                {list.clear();}

--- a/tests/junit/org/jgroups/blocks/MuxMessageDispatcherTest.java
+++ b/tests/junit/org/jgroups/blocks/MuxMessageDispatcherTest.java
@@ -177,7 +177,7 @@ public class MuxMessageDispatcherTest extends ChannelTestBase {
 //        Assert.assertEquals(response, "muxDispatcher[1][0]");
     }
 
-    private static void verifyResponse(Map<Address, Rsp<Object>> responses, Channel channel, Object expected) {
+    private static void verifyResponse(Map<Address, Rsp<Object>> responses, AbstractChannel channel, Object expected) {
         Rsp<?> response = responses.get(channel.getAddress());
         String address = channel.getAddress().toString();
         Assert.assertNotNull(response, address);

--- a/tests/junit/org/jgroups/blocks/MuxRpcDispatcherTest.java
+++ b/tests/junit/org/jgroups/blocks/MuxRpcDispatcherTest.java
@@ -173,7 +173,7 @@ public class MuxRpcDispatcherTest extends ChannelTestBase {
     }
 
 
-    private static void verifyResponse(Map<Address,Rsp<String>> responses, Channel channel, Object expected) {
+    private static void verifyResponse(Map<Address,Rsp<String>> responses, AbstractChannel channel, Object expected) {
         Rsp<?> response = responses.get(channel.getAddress());
         String address = channel.getAddress().toString();
         Assert.assertNotNull(response, address);

--- a/tests/junit/org/jgroups/blocks/RpcDispatcherAnycastServerObject.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherAnycastServerObject.java
@@ -1,7 +1,7 @@
 package org.jgroups.blocks;
 
 import org.jgroups.Address;
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.ReceiverAdapter;
 import org.jgroups.util.Rsp;
 import org.jgroups.util.RspList;
@@ -10,10 +10,10 @@ import java.util.*;
 
 public class RpcDispatcherAnycastServerObject extends ReceiverAdapter {
     int i=0;
-    private final Channel c;
+    private final AbstractChannel c;
     private final RpcDispatcher d;
 
-    public RpcDispatcherAnycastServerObject(Channel channel) throws Exception {
+    public RpcDispatcherAnycastServerObject(AbstractChannel channel) throws Exception {
         c=channel;
         d=new RpcDispatcher(c, this, this, this);
     }

--- a/tests/junit/org/jgroups/blocks/RpcDispatcherExceptionTest.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherExceptionTest.java
@@ -1,7 +1,7 @@
 package org.jgroups.blocks;
 
 
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.Global;
 import org.jgroups.tests.ChannelTestBase;
 import org.testng.annotations.AfterClass;
@@ -16,7 +16,7 @@ import java.io.NotSerializableException;
 @Test(groups=Global.STACK_DEPENDENT,singleThreaded=true)
 public class RpcDispatcherExceptionTest extends ChannelTestBase {
     RpcDispatcher disp;
-    Channel channel;
+    AbstractChannel channel;
     private final Target target=new Target();
 
     @BeforeClass

--- a/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherUnicastMethodExceptionTest.java
@@ -1,6 +1,6 @@
 package org.jgroups.blocks;
 
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.Global;
 import org.jgroups.TimeoutException;
 import org.jgroups.tests.ChannelTestBase;
@@ -16,7 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 @Test(groups=Global.STACK_DEPENDENT,singleThreaded=true)
 public class RpcDispatcherUnicastMethodExceptionTest extends ChannelTestBase {
     RpcDispatcher disp;
-    Channel channel;
+    AbstractChannel channel;
 
     @BeforeClass
     protected void setUp() throws Exception {

--- a/tests/junit/org/jgroups/blocks/executor/ExecutingServiceTest.java
+++ b/tests/junit/org/jgroups/blocks/executor/ExecutingServiceTest.java
@@ -8,7 +8,7 @@ import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
 import org.jgroups.protocols.CENTRAL_EXECUTOR;
-import org.jgroups.protocols.Executing.Owner;
+import org.jgroups.protocols.AbstractExecuting.Owner;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.tests.ChannelTestBase;
 import org.jgroups.util.NotifyingFuture;

--- a/tests/junit/org/jgroups/tests/ChannelTest.java
+++ b/tests/junit/org/jgroups/tests/ChannelTest.java
@@ -133,7 +133,7 @@ public class ChannelTest extends ChannelTestBase {
         ch1.setReceiver(checker);
         ch1.connect("testViewChange");
 
-        Channel ch2=createChannel(ch1);
+        AbstractChannel ch2=createChannel(ch1);
         try {
             ch2.connect("testViewChange");
             assertTrue(checker.getReason(), checker.isSuccess());
@@ -148,7 +148,7 @@ public class ChannelTest extends ChannelTestBase {
 
     public void testIsConnectedOnFirstViewChange() throws Exception {
         JChannel ch1 = createChannel(true,2);        
-        Channel ch2=createChannel(ch1);
+        AbstractChannel ch2=createChannel(ch1);
         ConnectedChecker tmp=new ConnectedChecker(ch2);
         ch2.setReceiver(tmp);
         try {
@@ -165,7 +165,7 @@ public class ChannelTest extends ChannelTestBase {
 
     public void testNoViewIsReceivedAfterDisconnect() throws Exception {
         JChannel ch1 = createChannel(true,2);        
-        Channel ch2=createChannel(ch1);
+        AbstractChannel ch2=createChannel(ch1);
         MyViewChecker ra = new MyViewChecker(ch2);
         ch2.setReceiver(ra);
 
@@ -185,7 +185,7 @@ public class ChannelTest extends ChannelTestBase {
 
     public void testNoViewIsReceivedAfterClose() throws Exception {
         JChannel ch1 = createChannel(true,2);        
-        Channel ch2=createChannel(ch1);
+        AbstractChannel ch2=createChannel(ch1);
         MyViewChecker ra = new MyViewChecker(ch2);
         ch2.setReceiver(ra);
 
@@ -284,11 +284,11 @@ public class ChannelTest extends ChannelTestBase {
     private static class ConnectedChecker extends ReceiverAdapter {
         boolean connected=false;
 
-        public ConnectedChecker(Channel channel) {
+        public ConnectedChecker(AbstractChannel channel) {
             this.channel=channel;
         }
 
-        final Channel channel;
+        final AbstractChannel channel;
 
         public boolean isConnected() {
             return connected;
@@ -300,11 +300,11 @@ public class ChannelTest extends ChannelTestBase {
     }
 
     private static class ViewChecker extends ReceiverAdapter {
-        final Channel channel;
+        final AbstractChannel channel;
         boolean success=true;
         String reason="";
 
-        public ViewChecker(Channel channel) {
+        public ViewChecker(AbstractChannel channel) {
             this.channel=channel;
         }
 
@@ -330,9 +330,9 @@ public class ChannelTest extends ChannelTestBase {
 
     private static class MyViewChecker extends ReceiverAdapter {
         private boolean receivedViewWhenDisconnected;
-        private final Channel ch;
+        private final AbstractChannel ch;
 
-        public MyViewChecker(Channel ch) {
+        public MyViewChecker(AbstractChannel ch) {
             this.ch=ch;
         }
 

--- a/tests/junit/org/jgroups/tests/ChannelTestBase.java
+++ b/tests/junit/org/jgroups/tests/ChannelTestBase.java
@@ -4,7 +4,7 @@ import org.jgroups.*;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
 import org.jgroups.protocols.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.ResourceManager;
 import org.jgroups.util.StackType;
@@ -162,7 +162,7 @@ public class ChannelTestBase {
             return createChannel(channel_conf);
         }
 
-        public Channel createChannel(boolean unique, int num) throws Exception {
+        public AbstractChannel createChannel(boolean unique, int num) throws Exception {
             JChannel c = createChannel(channel_conf);
             UNICAST2 uni=(UNICAST2)c.getProtocolStack().findProtocol(UNICAST2.class);
             if(uni != null) {
@@ -174,7 +174,7 @@ public class ChannelTestBase {
             return c;
         }
 
-        public Channel createChannel(final JChannel ch) throws Exception {
+        public AbstractChannel createChannel(final JChannel ch) throws Exception {
             return new JChannel(ch);
         }
 
@@ -182,15 +182,15 @@ public class ChannelTestBase {
             return new JChannel(configFile);
         }
 
-        protected void makeUnique(Channel channel, int num) throws Exception {
+        protected void makeUnique(AbstractChannel channel, int num) throws Exception {
             String str = Util.getProperty(new String[]{ Global.UDP_MCAST_ADDR, "jboss.partition.udpGroup" },
                                           null, "mcast_addr", null);
             makeUnique(channel, num, str);
         }
 
-        protected void makeUnique(Channel channel, int num, String mcast_address) throws Exception {
+        protected void makeUnique(AbstractChannel channel, int num, String mcast_address) throws Exception {
             ProtocolStack stack = channel.getProtocolStack();
-            Protocol transport = stack.getTransport();
+            AbstractProtocol transport = stack.getTransport();
 
             if (transport instanceof UDP) {
                 short mcast_port = ResourceManager.getNextMulticastPort(InetAddress.getByName(bind_addr));
@@ -201,12 +201,12 @@ public class ChannelTestBase {
                     String mcast_addr = ResourceManager.getNextMulticastAddress();
                     ((UDP) transport).setMulticastAddress(InetAddress.getByName(mcast_addr));
                 }
-            } else if (transport instanceof BasicTCP) {
+            } else if (transport instanceof AbstractBasicTCP) {
                 List<Short> ports = ResourceManager.getNextTcpPorts(InetAddress.getByName(bind_addr), num);
-                ((TP) transport).setBindPort(ports.get(0));
-                ((TP) transport).setPortRange(num);
+                ((AbstractTP) transport).setBindPort(ports.get(0));
+                ((AbstractTP) transport).setPortRange(num);
 
-                Protocol ping = stack.findProtocol(TCPPING.class);
+                AbstractProtocol ping = stack.findProtocol(TCPPING.class);
                 if (ping == null)
                     throw new IllegalStateException("TCP stack must consist of TCP:TCPPING - other config are not supported");
 
@@ -236,7 +236,7 @@ public class ChannelTestBase {
      * Base class for all aplications using channel
      */
     protected abstract class ChannelApplication extends ReceiverAdapter implements EventSequence, Runnable {
-        protected Channel channel;
+        protected AbstractChannel channel;
         protected Thread thread;
         protected Throwable exception;
         protected StringBuilder events;
@@ -291,7 +291,7 @@ public class ChannelTestBase {
             thread.start();
         }
 
-        public Channel getChannel() {
+        public AbstractChannel getChannel() {
             return channel;
         }
 

--- a/tests/junit/org/jgroups/tests/CloseTest.java
+++ b/tests/junit/org/jgroups/tests/CloseTest.java
@@ -216,7 +216,7 @@ public class CloseTest extends ChannelTestBase {
     }
 
 
-    private static void assertView(Channel ch, int num) {
+    private static void assertView(AbstractChannel ch, int num) {
         View view=ch.getView();
         String msg="view=" + view;
         assertNotNull(view);

--- a/tests/junit/org/jgroups/tests/ConcurrentCloseTest.java
+++ b/tests/junit/org/jgroups/tests/ConcurrentCloseTest.java
@@ -48,11 +48,11 @@ public class ConcurrentCloseTest extends ChannelTestBase {
 
 
     private static class Closer extends Thread {
-        private final Channel channel;
+        private final AbstractChannel channel;
         final private CyclicBarrier barrier;
 
 
-        public Closer(Channel channel, CyclicBarrier barrier) {
+        public Closer(AbstractChannel channel, CyclicBarrier barrier) {
             this.channel=channel;
             this.barrier=barrier;
         }

--- a/tests/junit/org/jgroups/tests/ConcurrentFlushTest.java
+++ b/tests/junit/org/jgroups/tests/ConcurrentFlushTest.java
@@ -142,14 +142,14 @@ public class ConcurrentFlushTest {
         assert l3.unblockReceived;
     }
 
-    protected static boolean startFlush(Channel ch, boolean automatic_resume) {
+    protected static boolean startFlush(AbstractChannel ch, boolean automatic_resume) {
         boolean result=Util.startFlush(ch);
         if(automatic_resume)
             ch.stopFlush();
         return result;
     }
 
-    protected boolean startFlush(Channel ch, int num_attempts, long timeout, boolean automatic_resume) {
+    protected boolean startFlush(AbstractChannel ch, int num_attempts, long timeout, boolean automatic_resume) {
         boolean result=Util.startFlush(ch, num_attempts, 10, timeout);
         if(automatic_resume)
             ch.stopFlush();

--- a/tests/junit/org/jgroups/tests/ConcurrentStartupTest.java
+++ b/tests/junit/org/jgroups/tests/ConcurrentStartupTest.java
@@ -46,7 +46,7 @@ public class ConcurrentStartupTest {
                 channels[i].connect(5+i);
 
             // Make sure everyone is in sync
-            Channel[] tmp=new Channel[channels.length];
+            AbstractChannel[] tmp=new AbstractChannel[channels.length];
             for(int i=0; i < channels.length; i++)
                 tmp[i]=channels[i].getChannel();
 

--- a/tests/junit/org/jgroups/tests/ConnectTest.java
+++ b/tests/junit/org/jgroups/tests/ConnectTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 
 
 import org.jgroups.*;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Promise;
 import org.jgroups.util.Util;
@@ -121,9 +121,9 @@ public class ConnectTest extends ChannelTestBase {
     }
 
 
-    private static void changeProps(Channel ch) {
+    private static void changeProps(AbstractChannel ch) {
         ProtocolStack stack=ch.getProtocolStack();
-        TP transport=stack.getTransport();
+        AbstractTP transport=stack.getTransport();
         transport.setLogDiscardMessages(false);
     }
 

--- a/tests/junit/org/jgroups/tests/DiscardTest.java
+++ b/tests/junit/org/jgroups/tests/DiscardTest.java
@@ -5,7 +5,7 @@ import org.jgroups.*;
 import org.jgroups.protocols.DISCARD;
 import org.jgroups.protocols.MERGE3;
 import org.jgroups.protocols.TCP_NIO2;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Promise;
 import org.jgroups.util.Util;
@@ -40,7 +40,7 @@ public class DiscardTest extends ChannelTestBase {
     
     @AfterMethod
     protected void tearDown() throws Exception {
-        TP tp_a=a.getProtocolStack().getTransport(), tp_b=b.getProtocolStack().getTransport();
+        AbstractTP tp_a=a.getProtocolStack().getTransport(), tp_b=b.getProtocolStack().getTransport();
         if(tp_a instanceof TCP_NIO2) {
             System.out.printf("partial writes in A: %d, partial writes in B: %d\n",
                               ((TCP_NIO2)tp_a).numPartialWrites(), ((TCP_NIO2)tp_b).numPartialWrites());

--- a/tests/junit/org/jgroups/tests/DuplicateTest.java
+++ b/tests/junit/org/jgroups/tests/DuplicateTest.java
@@ -136,11 +136,11 @@ public class DuplicateTest extends ChannelTestBase {
     }
 
 
-     private static void send(Channel sender_channel, Address dest, boolean oob, int num_msgs) throws Exception {
+     private static void send(AbstractChannel sender_channel, Address dest, boolean oob, int num_msgs) throws Exception {
          send(sender_channel, dest, oob, false, num_msgs);
      }
 
-     private static void send(Channel sender_channel, Address dest, boolean oob, boolean mixed, int num_msgs) throws Exception {
+     private static void send(AbstractChannel sender_channel, Address dest, boolean oob, boolean mixed, int num_msgs) throws Exception {
          long seqno=1;
          for(int i=0; i < num_msgs; i++) {
              Message msg=new Message(dest, null, seqno++);

--- a/tests/junit/org/jgroups/tests/FifoOrderTest.java
+++ b/tests/junit/org/jgroups/tests/FifoOrderTest.java
@@ -117,10 +117,10 @@ public class FifoOrderTest extends ChannelTestBase {
 
 
     private class Sender implements Runnable {
-        final Channel ch;
+        final AbstractChannel ch;
         final Address local_addr;
 
-        public Sender(Channel ch) {
+        public Sender(AbstractChannel ch) {
             this.ch=ch;
             local_addr=ch.getAddress();
         }

--- a/tests/junit/org/jgroups/tests/FlushTest.java
+++ b/tests/junit/org/jgroups/tests/FlushTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.*;
 import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.Test;
 
@@ -32,7 +32,7 @@ public class FlushTest {
         s.release(1);
 
         // Make sure everyone is in sync
-        Channel[] tmp = new Channel[receivers.length];
+        AbstractChannel[] tmp = new AbstractChannel[receivers.length];
         for (int i = 0; i < receivers.length; i++)
             tmp[i] = receivers[i].getChannel();
         Util.waitUntilAllChannelsHaveSameSize(10000, 1000, tmp);
@@ -95,7 +95,7 @@ public class FlushTest {
     }
     
     public void testSequentialFlushInvocation() throws Exception {
-        Channel a=null, b=null, c=null;
+        AbstractChannel a=null, b=null, c=null;
         try {
             a = createChannel("A");
             a.connect("testSequentialFlushInvocation");
@@ -289,7 +289,7 @@ public class FlushTest {
                 first = false;
             }
 
-            Channel[] tmp = new Channel[channels.size()];
+            AbstractChannel[] tmp = new AbstractChannel[channels.size()];
             int cnt = 0;
             for (FlushTestReceiver receiver : channels)
                 tmp[cnt++] = receiver.getChannel();
@@ -376,7 +376,7 @@ public class FlushTest {
     }
 
     protected JChannel createChannel(String name) throws Exception {
-          Protocol[] protocols={
+          AbstractProtocol[] protocols={
             new SHARED_LOOPBACK(),
             new SHARED_LOOPBACK_PING(),
             new FD_ALL().setValue("timeout", 3000).setValue("interval", 1000),
@@ -483,10 +483,10 @@ public class FlushTest {
     }
 
     private static class SimpleReplier extends ReceiverAdapter {
-        protected final Channel channel;
+        protected final AbstractChannel channel;
         protected boolean       handle_requests=false;
 
-        public SimpleReplier(Channel channel, boolean handle_requests) {
+        public SimpleReplier(AbstractChannel channel, boolean handle_requests) {
             this.channel = channel;
             this.handle_requests = handle_requests;
         }

--- a/tests/junit/org/jgroups/tests/FlushWithChannelJoinsAndFailuresTest.java
+++ b/tests/junit/org/jgroups/tests/FlushWithChannelJoinsAndFailuresTest.java
@@ -1,6 +1,6 @@
 package org.jgroups.tests;
 
-import org.jgroups.Channel;
+import org.jgroups.AbstractChannel;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.protocols.*;
@@ -8,7 +8,7 @@ import org.jgroups.protocols.pbcast.FLUSH;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 import org.testng.annotations.Test;
 
@@ -27,7 +27,7 @@ public class FlushWithChannelJoinsAndFailuresTest {
    
     public void testAndLoop() throws Exception {
         int numChannels = 10;
-        Channel channels[] = new Channel[numChannels];
+        AbstractChannel channels[] = new AbstractChannel[numChannels];
         for (int j = 0; j < numChannels; j++) {
             channels[j] = createChannel(String.valueOf((char)('A' + j)));
             channels[j].connect(cName);
@@ -51,7 +51,7 @@ public class FlushWithChannelJoinsAndFailuresTest {
     }
 
     protected JChannel createChannel(String name) throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new FD_ALL().setValue("timeout", 3000).setValue("interval", 1000),

--- a/tests/junit/org/jgroups/tests/GossipRouterTest.java
+++ b/tests/junit/org/jgroups/tests/GossipRouterTest.java
@@ -9,7 +9,7 @@ import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
 import org.jgroups.stack.GossipRouter;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.ResourceManager;
 import org.jgroups.util.StackType;
 import org.jgroups.util.Util;
@@ -110,7 +110,7 @@ public class GossipRouterTest {
     protected JChannel createTunnelChannel(String name, boolean include_failure_detection) throws Exception {
         TUNNEL tunnel=(TUNNEL)new TUNNEL().setValue("bind_addr", bind_addr).setValue("reconnect_interval", 1000);
         tunnel.setGossipRouterHosts(gossip_router_hosts);
-        List<Protocol> protocols=new ArrayList<>();
+        List<AbstractProtocol> protocols=new ArrayList<>();
         protocols.addAll(Arrays.asList(tunnel,new PING(),new MERGE3().setValue("min_interval",1000).setValue("max_interval",3000)));
         if(include_failure_detection)
             protocols.addAll(Arrays.asList(new FD().setValue("timeout", 2000).setValue("max_tries", 2), new VERIFY_SUSPECT()));

--- a/tests/junit/org/jgroups/tests/JoinTest.java
+++ b/tests/junit/org/jgroups/tests/JoinTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.GMS;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -185,7 +185,7 @@ public class JoinTest extends ChannelTestBase {
     }
 
 
-    protected class DELAY_JOIN_REQ extends Protocol {
+    protected class DELAY_JOIN_REQ extends AbstractProtocol {
         private long        delay=4000;
         private final short gms_id=ClassConfigurator.getProtocolId(GMS.class);
 

--- a/tests/junit/org/jgroups/tests/LargeStateTransferTest.java
+++ b/tests/junit/org/jgroups/tests/LargeStateTransferTest.java
@@ -4,7 +4,7 @@ package org.jgroups.tests;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.ReceiverAdapter;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Promise;
@@ -90,7 +90,7 @@ public class LargeStateTransferTest extends ChannelTestBase {
 
     private static void setOOBPoolSize(JChannel... channels) {
         for(JChannel channel: channels) {
-            TP transport=channel.getProtocolStack().getTransport();
+            AbstractTP transport=channel.getProtocolStack().getTransport();
             transport.setOOBThreadPoolMinThreads(2);
             transport.setOOBThreadPoolMaxThreads(8);
             transport.setOOBThreadPoolQueueEnabled(false);

--- a/tests/junit/org/jgroups/tests/MergeStressTest.java
+++ b/tests/junit/org/jgroups/tests/MergeStressTest.java
@@ -6,7 +6,7 @@ import org.jgroups.protocols.FD_SOCK;
 import org.jgroups.protocols.MERGE3;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.Assert;
@@ -104,7 +104,7 @@ public class MergeStressTest extends ChannelTestBase {
 
     private static void modifyStack(JChannel ch) {
         ProtocolStack stack=ch.getProtocolStack();
-        Protocol prot=stack.findProtocol(MERGE3.class);
+        AbstractProtocol prot=stack.findProtocol(MERGE3.class);
         if(prot != null) {
             MERGE3 merge=(MERGE3)prot;
             merge.setMinInterval(3000);
@@ -128,13 +128,13 @@ public class MergeStressTest extends ChannelTestBase {
     public class MyThread extends ReceiverAdapter implements Runnable {
         int index=-1;
         long total_connect_time=0, total_disconnect_time=0;
-        private final Channel ch;
+        private final AbstractChannel ch;
         private Address my_addr=null;
         private View current_view;
         private final Thread thread;
         private int num_members=0;
 
-        public MyThread(int i,Channel ch) {
+        public MyThread(int i,AbstractChannel ch) {
             this.ch=ch;
             thread=new Thread(this, "thread #" + i);
             index=i;

--- a/tests/junit/org/jgroups/tests/MergeTest.java
+++ b/tests/junit/org/jgroups/tests/MergeTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.*;
 import org.jgroups.protocols.DISCARD;
 import org.jgroups.protocols.MERGE3;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.stack.ProtocolStack;
@@ -123,7 +123,7 @@ public class MergeTest extends ChannelTestBase {
         for(JChannel ch: channels) {
             DISCARD discard=new DISCARD();
             discard.setDiscardAll(true);
-            ch.getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE,TP.class);
+            ch.getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE,AbstractTP.class);
         }
 
         for(JChannel ch: channels) {

--- a/tests/junit/org/jgroups/tests/MessageBundlingTest.java
+++ b/tests/junit/org/jgroups/tests/MessageBundlingTest.java
@@ -4,7 +4,7 @@ import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.Message;
 import org.jgroups.ReceiverAdapter;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Promise;
@@ -142,7 +142,7 @@ public class MessageBundlingTest extends ChannelTestBase {
 
     private static void setBundling(JChannel ch, int max_bytes, long timeout) {
         ProtocolStack stack=ch.getProtocolStack();
-        TP transport=stack.getTransport();
+        AbstractTP transport=stack.getTransport();
         transport.setMaxBundleSize(max_bytes);
         transport.setMaxBundleTimeout(timeout);
         GMS gms=(GMS)stack.findProtocol(GMS.class);

--- a/tests/junit/org/jgroups/tests/OOBTest.java
+++ b/tests/junit/org/jgroups/tests/OOBTest.java
@@ -2,11 +2,11 @@ package org.jgroups.tests;
 
 import org.jgroups.*;
 import org.jgroups.protocols.DISCARD;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.UNICAST2;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -63,7 +63,7 @@ public class OOBTest extends ChannelTestBase {
     public void testRegularAndOOBUnicasts() throws Exception {
         DISCARD discard=new DISCARD();
         ProtocolStack stack=a.getProtocolStack();
-        stack.insertProtocol(discard, ProtocolStack.BELOW,(Class<? extends Protocol>[])Util.getUnicastProtocols());
+        stack.insertProtocol(discard, ProtocolStack.BELOW,(Class<? extends AbstractProtocol>[])Util.getUnicastProtocols());
 
         Address dest=b.getAddress();
         Message m1=new Message(dest, 1);
@@ -91,7 +91,7 @@ public class OOBTest extends ChannelTestBase {
     public void testRegularAndOOBUnicasts2() throws Exception {
         DISCARD discard=new DISCARD();
         ProtocolStack stack=a.getProtocolStack();
-        stack.insertProtocol(discard, ProtocolStack.BELOW,(Class<? extends Protocol>[])Util.getUnicastProtocols());
+        stack.insertProtocol(discard, ProtocolStack.BELOW,(Class<? extends AbstractProtocol>[])Util.getUnicastProtocols());
 
         Address dest=b.getAddress();
         Message m1=new Message(dest, 1);
@@ -158,7 +158,7 @@ public class OOBTest extends ChannelTestBase {
         discard.setLocalAddress(a.getAddress());
         discard.setUpDiscardRate(0.5);
         ProtocolStack stack=a.getProtocolStack();
-        stack.insertProtocol(discard, ProtocolStack.ABOVE, TP.class);
+        stack.insertProtocol(discard, ProtocolStack.ABOVE, AbstractTP.class);
         MyReceiver r1=new MyReceiver("A"), r2=new MyReceiver("B");
         a.setReceiver(r1);
         b.setReceiver(r2);
@@ -194,7 +194,7 @@ public class OOBTest extends ChannelTestBase {
         MyReceiver receiver=new MySleepingReceiver("A", 1000);
         a.setReceiver(receiver);
 
-        TP transport=a.getProtocolStack().getTransport();
+        AbstractTP transport=a.getProtocolStack().getTransport();
         transport.setOOBRejectionPolicy("discard");
 
         final int NUM=10;
@@ -263,7 +263,7 @@ public class OOBTest extends ChannelTestBase {
                 threads[i]=new Thread() {
                     public void run() {
                         for(int j=0; j < msgs_per_thread; j++) {
-                            Channel sender=Util.tossWeightedCoin(0.5) ? a : b;
+                            AbstractChannel sender=Util.tossWeightedCoin(0.5) ? a : b;
                             boolean oob=Util.tossWeightedCoin(oob_prob);
                             int num=counter.incrementAndGet();
                             Message msg=new Message(dest, num);
@@ -288,7 +288,7 @@ public class OOBTest extends ChannelTestBase {
 
 
         for(int i=0; i < num_msgs; i++) {
-            Channel sender=Util.tossWeightedCoin(0.5) ? a : b;
+            AbstractChannel sender=Util.tossWeightedCoin(0.5) ? a : b;
             boolean oob=Util.tossWeightedCoin(oob_prob);
             Message msg=new Message(dest, null, i);
             if(oob)
@@ -355,15 +355,15 @@ public class OOBTest extends ChannelTestBase {
 
 
     private static void setOOBPoolSize(JChannel... channels) {
-        for(Channel channel: channels) {
-            TP transport=channel.getProtocolStack().getTransport();
+        for(AbstractChannel channel: channels) {
+            AbstractTP transport=channel.getProtocolStack().getTransport();
             transport.setOOBThreadPoolMinThreads(4);
             transport.setOOBThreadPoolMaxThreads(8);
         }
     }
 
     private static void setStableGossip(JChannel... channels) {
-        for(Channel channel: channels) {
+        for(AbstractChannel channel: channels) {
             ProtocolStack stack=channel.getProtocolStack();
             STABLE stable=(STABLE)stack.findProtocol(STABLE.class);
             stable.setDesiredAverageGossip(2000);

--- a/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
+++ b/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
@@ -372,7 +372,7 @@ public class OverlappingMergeTest extends ChannelTestBase {
             MERGE3 merge_prot=(MERGE3)ch.getProtocolStack().findProtocol(MERGE3.class);
             if(merge_prot == null) {
                 merge_prot=new MERGE3();
-                ch.getProtocolStack().insertProtocol(merge_prot, ProtocolStack.ABOVE, Discovery.class);
+                ch.getProtocolStack().insertProtocol(merge_prot, ProtocolStack.ABOVE, AbstractDiscovery.class);
                 merge_prot.init();
                 merge_prot.down(new Event(Event.SET_LOCAL_ADDRESS, ch.getAddress()));
                 merge_prot.setMinInterval(2000);

--- a/tests/junit/org/jgroups/tests/ReconciliationTest.java
+++ b/tests/junit/org/jgroups/tests/ReconciliationTest.java
@@ -6,7 +6,7 @@ import org.jgroups.protocols.pbcast.FLUSH;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.Assert;
@@ -221,7 +221,7 @@ public class ReconciliationTest {
     }
 
     protected JChannel createChannel(String name) throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK(),
           new SHARED_LOOPBACK_PING(),
           new FD_ALL().setValue("timeout", 3000).setValue("interval", 1000),
@@ -269,10 +269,10 @@ public class ReconciliationTest {
 
     protected static class MyReceiver extends ReceiverAdapter {
         protected final Map<Address,List<Integer>> msgs=new HashMap<>(10);
-        protected final Channel channel;
+        protected final AbstractChannel channel;
         protected final String  name;
 
-        public MyReceiver(Channel ch,String name) {
+        public MyReceiver(AbstractChannel ch, String name) {
             this.channel=ch;
             this.name=name;
         }
@@ -329,7 +329,7 @@ public class ReconciliationTest {
         Util.close(b,a);
     }
 
-    protected static void flush(Channel channel) {
+    protected static void flush(AbstractChannel channel) {
         try {
             assert Util.startFlush(channel);
         }
@@ -340,10 +340,10 @@ public class ReconciliationTest {
 
     protected static class Cache extends ReceiverAdapter {
         protected final Map<Object,Object> data;
-        protected Channel                  ch;
+        protected AbstractChannel ch;
         protected String                   name;
 
-        public Cache(Channel ch,String name) {
+        public Cache(AbstractChannel ch, String name) {
             this.data=new HashMap<>();
             this.ch=ch;
             this.name=name;

--- a/tests/junit/org/jgroups/tests/SCOPE_Test.java
+++ b/tests/junit/org/jgroups/tests/SCOPE_Test.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 
 import org.jgroups.*;
 import org.jgroups.protocols.SCOPE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
@@ -51,7 +51,7 @@ public class SCOPE_Test extends ChannelTestBase {
 
     public void testOrderWithScopedMulticasts() throws Exception {
         ProtocolStack stack=b.getProtocolStack();
-        Protocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
         SCOPE scope=new SCOPE();
         stack.insertProtocolInStack(scope, neighbor, ProtocolStack.ABOVE);
         scope.init();
@@ -112,7 +112,7 @@ public class SCOPE_Test extends ChannelTestBase {
     protected void sendMessages(Address dest, boolean use_scopes) throws Exception {
         if(use_scopes) {
             ProtocolStack stack=b.getProtocolStack();
-            Protocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
+            AbstractProtocol neighbor=stack.findProtocol(Util.getUnicastProtocols());
             SCOPE scope=new SCOPE();
             stack.insertProtocolInStack(scope, neighbor, ProtocolStack.ABOVE);
             scope.init();

--- a/tests/junit/org/jgroups/tests/SequencerMergeTest.java
+++ b/tests/junit/org/jgroups/tests/SequencerMergeTest.java
@@ -7,7 +7,7 @@ import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Digest;
 import org.jgroups.util.MutableDigest;
 import org.jgroups.util.Util;
@@ -217,7 +217,7 @@ public class SequencerMergeTest {
             GMS gms=(GMS)ch.getProtocolStack().findProtocol(GMS.class);
             gms.installView(view);
 
-            Protocol nak=ch.getProtocolStack().findProtocol(NAKACK.class, NAKACK2.class);
+            AbstractProtocol nak=ch.getProtocolStack().findProtocol(NAKACK.class, NAKACK2.class);
             if(nak != null)
                 nak.down(new Event(Event.SET_DIGEST, digest));
         }
@@ -233,7 +233,7 @@ public class SequencerMergeTest {
     protected static Digest getDigest(final View view, JChannel ... channels) {
         MutableDigest digest=new MutableDigest(view.getMembersRaw());
         for(JChannel ch: channels) {
-            Protocol nak=ch.getProtocolStack().findProtocol(NAKACK.class, NAKACK2.class);
+            AbstractProtocol nak=ch.getProtocolStack().findProtocol(NAKACK.class, NAKACK2.class);
             Digest tmp=(Digest)nak.down(new Event(Event.GET_DIGEST, ch.getAddress()));
             if(tmp != null)
                 digest.set(tmp);

--- a/tests/junit/org/jgroups/tests/SharedTransportTest.java
+++ b/tests/junit/org/jgroups/tests/SharedTransportTest.java
@@ -4,12 +4,12 @@ import org.jgroups.*;
 import org.jgroups.conf.ConfiguratorFactory;
 import org.jgroups.conf.ProtocolConfiguration;
 import org.jgroups.conf.ProtocolStackConfigurator;
-import org.jgroups.protocols.BasicTCP;
+import org.jgroups.protocols.AbstractBasicTCP;
 import org.jgroups.protocols.TCPPING;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.UDP;
 import org.jgroups.protocols.pbcast.GMS;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.ResourceManager;
 import org.jgroups.util.TimeScheduler;
@@ -321,7 +321,7 @@ public class SharedTransportTest extends ChannelTestBase {
     public void testFailedFirstChannel() throws Exception {
         a=createSharedChannel(SINGLETON_1, "A");
 
-        TP transport=a.getProtocolStack().getTransport();
+        AbstractTP transport=a.getProtocolStack().getTransport();
         transport.setBindPort(128); // set the bind_port to an incorrect value (< 1024), this will fail on connect()
         a.setReceiver(new MyReceiver("A"));
         try {
@@ -569,9 +569,9 @@ public class SharedTransportTest extends ChannelTestBase {
     }
 
 
-    protected static void makeUnique(Channel channel, int num) throws Exception {
+    protected static void makeUnique(AbstractChannel channel, int num) throws Exception {
         ProtocolStack stack=channel.getProtocolStack();
-        TP transport=stack.getTransport();
+        AbstractTP transport=stack.getTransport();
         InetAddress bind_addr=transport.getBindAddress();
 
         if(transport instanceof UDP) {
@@ -580,12 +580,12 @@ public class SharedTransportTest extends ChannelTestBase {
             ((UDP)transport).setMulticastAddress(InetAddress.getByName(mcast_addr));
             ((UDP)transport).setMulticastPort(mcast_port);
         }
-        else if(transport instanceof BasicTCP) {
+        else if(transport instanceof AbstractBasicTCP) {
             List<Short> ports=ResourceManager.getNextTcpPorts(bind_addr, num);
             transport.setBindPort(ports.get(0));
             transport.setPortRange(num);
 
-            Protocol ping=stack.findProtocol(TCPPING.class);
+            AbstractProtocol ping=stack.findProtocol(TCPPING.class);
             if(ping == null)
                 throw new IllegalStateException("TCP stack must consist of TCP:TCPPING - other config are not supported");
 
@@ -647,13 +647,13 @@ public class SharedTransportTest extends ChannelTestBase {
     
     private static class ConnectTask implements Runnable
     {
-       private final Channel channel;
+       private final AbstractChannel channel;
        private final String clusterName;
        private final CountDownLatch startLatch;
        private final CountDownLatch finishLatch;
        private Exception exception;
        
-       ConnectTask(Channel channel, String clusterName, CountDownLatch startLatch, CountDownLatch finishLatch)
+       ConnectTask(AbstractChannel channel, String clusterName, CountDownLatch startLatch, CountDownLatch finishLatch)
        {
           this.channel = channel;
           this.clusterName = clusterName;

--- a/tests/junit/org/jgroups/tests/StateTransferTest.java
+++ b/tests/junit/org/jgroups/tests/StateTransferTest.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.protocols.pbcast.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.ArrayIterator;
 import org.jgroups.util.Util;
@@ -95,7 +95,7 @@ public class StateTransferTest extends ChannelTestBase {
         }
 
         // Make sure everyone is in sync
-        Channel[] tmp=new Channel[apps.length];
+        AbstractChannel[] tmp=new AbstractChannel[apps.length];
         for(int i=0; i < apps.length; i++)
             tmp[i]=apps[i].getChannel();
 
@@ -193,14 +193,14 @@ public class StateTransferTest extends ChannelTestBase {
 
     protected long getSeqno(Message msg) {
         for(short id: ids) {
-            Header hdr=msg.getHeader(id);
+            AbstractHeader hdr=msg.getHeader(id);
             if(hdr != null)
                 return getSeqnoFromHeader(hdr);
         }
         return -1;
     }
 
-    protected long getSeqnoFromHeader(Header hdr) {
+    protected long getSeqnoFromHeader(AbstractHeader hdr) {
         Field field=Util.getField(hdr.getClass(), "seqno");
         return (Long)Util.getField(field, hdr);
     }
@@ -210,13 +210,13 @@ public class StateTransferTest extends ChannelTestBase {
         ProtocolStack stack=ch.getProtocolStack();
         if(stack.findProtocol(state_transfer_class) != null)
             return; // protocol of the right class is already in stack
-        Protocol prot=stack.findProtocol(STATE_TRANSFER.class, StreamingStateTransfer.class);
-        Protocol new_state_transfer_protcol=(Protocol)state_transfer_class.newInstance();
+        AbstractProtocol prot=stack.findProtocol(STATE_TRANSFER.class, AbstractStreamingStateTransfer.class);
+        AbstractProtocol new_state_transfer_protcol=(AbstractProtocol)state_transfer_class.newInstance();
         if(prot != null) {
             stack.replaceProtocol(prot, new_state_transfer_protcol);
         }
         else { // no state transfer protocol found in stack
-            Protocol flush=stack.findProtocol(FLUSH.class);
+            AbstractProtocol flush=stack.findProtocol(FLUSH.class);
             if(flush != null)
                 stack.insertProtocol(new_state_transfer_protcol, ProtocolStack.BELOW, FLUSH.class);
             else

--- a/tests/junit/org/jgroups/tests/StateTransferTest2.java
+++ b/tests/junit/org/jgroups/tests/StateTransferTest2.java
@@ -5,7 +5,7 @@ import org.jgroups.JChannel;
 import org.jgroups.ReceiverAdapter;
 import org.jgroups.StateTransferException;
 import org.jgroups.protocols.pbcast.*;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.ArrayIterator;
 import org.jgroups.util.Util;
@@ -103,13 +103,13 @@ public class StateTransferTest2 extends ChannelTestBase {
         ProtocolStack stack=ch.getProtocolStack();
         if(stack.findProtocol(state_transfer_class) != null)
             return; // protocol of the right class is already in stack
-        Protocol prot=stack.findProtocol(STATE_TRANSFER.class, StreamingStateTransfer.class);
-        Protocol new_state_transfer_protcol=(Protocol)state_transfer_class.newInstance();
+        AbstractProtocol prot=stack.findProtocol(STATE_TRANSFER.class, AbstractStreamingStateTransfer.class);
+        AbstractProtocol new_state_transfer_protcol=(AbstractProtocol)state_transfer_class.newInstance();
         if(prot != null) {
             stack.replaceProtocol(prot, new_state_transfer_protcol);
         }
         else { // no state transfer protocol found in stack
-            Protocol flush=stack.findProtocol(FLUSH.class);
+            AbstractProtocol flush=stack.findProtocol(FLUSH.class);
             if(flush != null)
                 stack.insertProtocol(new_state_transfer_protcol, ProtocolStack.BELOW, FLUSH.class);
             else

--- a/tests/junit/org/jgroups/tests/TUNNEL_Test.java
+++ b/tests/junit/org/jgroups/tests/TUNNEL_Test.java
@@ -7,7 +7,7 @@ import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
 import org.jgroups.stack.GossipRouter;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Promise;
 import org.jgroups.util.ResourceManager;
 import org.jgroups.util.StackType;
@@ -254,7 +254,7 @@ public class TUNNEL_Test extends ChannelTestBase {
     protected JChannel createTunnelChannel(String name, boolean include_failure_detection) throws Exception {
         TUNNEL tunnel=(TUNNEL)new TUNNEL().setValue("bind_addr", bind_addr);
         tunnel.setGossipRouterHosts(gossip_router_hosts);
-        List<Protocol> protocols=new ArrayList<>();
+        List<AbstractProtocol> protocols=new ArrayList<>();
         protocols.addAll(Arrays.asList(tunnel, new PING(), new MERGE3().setValue("min_interval", 1000).setValue("max_interval", 3000)));
         if(include_failure_detection)
             protocols.addAll(Arrays.asList(new FD().setValue("timeout", 2000).setValue("max_tries", 2), new VERIFY_SUSPECT()));

--- a/tests/junit/org/jgroups/tests/TransportThreadPoolTest.java
+++ b/tests/junit/org/jgroups/tests/TransportThreadPoolTest.java
@@ -4,7 +4,7 @@ import org.jgroups.Global;
 import org.jgroups.JChannel;
 import org.jgroups.Message;
 import org.jgroups.ReceiverAdapter;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -44,7 +44,7 @@ public class TransportThreadPoolTest extends ChannelTestBase {
         Util.waitUntilAllChannelsHaveSameSize(10000, 1000, c1, c2);
         assert c2.getView().size() == 2 : "view is " + c2.getView() + ", but should have had a size of 2";
         
-        TP transport=c1.getProtocolStack().getTransport();
+        AbstractTP transport=c1.getProtocolStack().getTransport();
         ExecutorService thread_pool=Executors.newFixedThreadPool(2);
         transport.setDefaultThreadPool(thread_pool);
 

--- a/tests/junit/org/jgroups/tests/UnicastLoopbackTest.java
+++ b/tests/junit/org/jgroups/tests/UnicastLoopbackTest.java
@@ -1,7 +1,7 @@
 package org.jgroups.tests;
 
 import org.jgroups.*;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.util.Promise;
 import org.jgroups.util.Util;
 import org.testng.Assert;
@@ -76,7 +76,7 @@ public class UnicastLoopbackTest extends ChannelTestBase {
      * @throws Exception
      */
     private static long getNumMessagesSentViaNetwork(JChannel ch) throws Exception {
-        TP transport = ch.getProtocolStack().getTransport();
+        AbstractTP transport = ch.getProtocolStack().getTransport();
         if (transport == null)
             throw new Exception("transport layer is not present - check default stack configuration") ;
         return transport.getNumMessagesSent();

--- a/tests/other/org/jgroups/tests/LargeState.java
+++ b/tests/other/org/jgroups/tests/LargeState.java
@@ -27,7 +27,7 @@ import java.io.OutputStream;
  * @author Bela Ban Dec 13 2001
  */
 public class LargeState extends ReceiverAdapter {
-    Channel  channel;
+    AbstractChannel channel;
     byte[]   state=null;
     boolean  rc=false;
     String   props;

--- a/tests/other/org/jgroups/tests/MessageDispatcherSpeedTest.java
+++ b/tests/other/org/jgroups/tests/MessageDispatcherSpeedTest.java
@@ -12,7 +12,7 @@ import org.jgroups.util.Util;
  * @author Bela Ban
  */
 public class MessageDispatcherSpeedTest implements MembershipListener, RequestHandler {
-    Channel             channel;
+    AbstractChannel channel;
     MessageDispatcher   disp;
     String              props=null;
     boolean             server=false; // role is client by default

--- a/tests/other/org/jgroups/tests/ParseMessages.java
+++ b/tests/other/org/jgroups/tests/ParseMessages.java
@@ -2,7 +2,7 @@ package org.jgroups.tests;
 
 import org.jgroups.Message;
 import org.jgroups.Version;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.util.MessageBatch;
 import org.jgroups.util.Util;
 
@@ -50,7 +50,7 @@ public class ParseMessages {
                 boolean multicast=(flags & MULTICAST) == MULTICAST;
 
                 if(is_message_list) { // used if message bundling is enabled
-                    final MessageBatch[] batches=TP.readMessageBatch(dis,multicast);
+                    final MessageBatch[] batches= AbstractTP.readMessageBatch(dis,multicast);
                     for(MessageBatch batch: batches) {
                         if(batch != null)
                             for(Message msg: batch)
@@ -58,7 +58,7 @@ public class ParseMessages {
                     }
                 }
                 else {
-                    Message msg=TP.readMessage(dis);
+                    Message msg= AbstractTP.readMessage(dis);
                     retval.add(msg);
                 }
             }

--- a/tests/other/org/jgroups/tests/RpcDispatcherBlocking.java
+++ b/tests/other/org/jgroups/tests/RpcDispatcherBlocking.java
@@ -2,7 +2,6 @@
 package org.jgroups.tests;
 
 import org.jgroups.*;
-import org.jgroups.blocks.Request;
 import org.jgroups.blocks.RequestOptions;
 import org.jgroups.blocks.ResponseMode;
 import org.jgroups.blocks.RpcDispatcher;
@@ -32,7 +31,7 @@ import org.jgroups.util.Util;
  */
 public class RpcDispatcherBlocking implements MembershipListener {
     RpcDispatcher disp;
-    Channel       channel;
+    AbstractChannel channel;
     long          timeout=30000;
     String        props=null;
     int           i=0;

--- a/tests/other/org/jgroups/tests/RpcDispatcherSpeedTest.java
+++ b/tests/other/org/jgroups/tests/RpcDispatcherSpeedTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CountDownLatch;
  * @version $Revision: 1.23 $
  */
 public class RpcDispatcherSpeedTest implements MembershipListener {
-    Channel             channel;
+    AbstractChannel channel;
     RpcDispatcher       disp;
     String              props=null;
     boolean             server=false; // role is client by default

--- a/tests/other/org/jgroups/tests/UnicastTest.java
+++ b/tests/other/org/jgroups/tests/UnicastTest.java
@@ -6,7 +6,7 @@ import org.jgroups.jmx.JmxConfigurator;
 import org.jgroups.protocols.UNICAST;
 import org.jgroups.protocols.UNICAST2;
 import org.jgroups.protocols.UNICAST3;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.Util;
 
 import javax.management.MBeanServer;
@@ -34,7 +34,7 @@ public class UnicastTest {
     protected static final byte    DATA  = 2; // | length (int) | data (byte[]) |
 
 
-    public void init(Protocol[] props, long sleep_time, String name) throws Exception {
+    public void init(AbstractProtocol[] props, long sleep_time, String name) throws Exception {
         _init(new JChannel(props), sleep_time, name);
     }
 
@@ -112,7 +112,7 @@ public class UnicastTest {
     }
 
     protected void printConnections() {
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         if(prot instanceof UNICAST)
             System.out.println(((UNICAST)prot).printConnections());
         else if(prot instanceof UNICAST2)
@@ -123,7 +123,7 @@ public class UnicastTest {
 
 
     protected void removeAllConnections() {
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         if(prot instanceof UNICAST)
             ((UNICAST)prot).removeAllConnections();
         else if(prot instanceof UNICAST2)

--- a/tests/other/org/jgroups/tests/UnicastTestSharedLoopback.java
+++ b/tests/other/org/jgroups/tests/UnicastTestSharedLoopback.java
@@ -6,7 +6,7 @@ import org.jgroups.protocols.UNICAST3;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 
 /**
  * Tests UnicastTest with SHARED_LOOPBACK and 2 UnicastTest instances
@@ -29,8 +29,8 @@ public class UnicastTestSharedLoopback {
     }
 
 
-    protected static Protocol[] props() {
-        return new Protocol[]{
+    protected static AbstractProtocol[] props() {
+        return new AbstractProtocol[]{
           new SHARED_LOOPBACK().setValue("bundler_type", "sender-sends").setValue("ignore_dont_bundle", false),
           new SHARED_LOOPBACK_PING(),
           new NAKACK2(),

--- a/tests/perf/org/jgroups/tests/perf/MPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/MPerf.java
@@ -728,7 +728,7 @@ public class MPerf extends ReceiverAdapter {
         }
     }
 
-    protected static class MPerfHeader extends Header {
+    protected static class MPerfHeader extends AbstractHeader {
         protected static final byte DATA          =  1;
         protected static final byte START_SENDING =  2;
         protected static final byte SENDING_DONE  =  3;

--- a/tests/perf/org/jgroups/tests/perf/UPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/UPerf.java
@@ -5,11 +5,11 @@ import org.jgroups.annotations.Property;
 import org.jgroups.blocks.*;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.jmx.JmxConfigurator;
-import org.jgroups.protocols.TP;
+import org.jgroups.protocols.AbstractTP;
 import org.jgroups.protocols.relay.RELAY2;
 import org.jgroups.protocols.relay.SiteMaster;
 import org.jgroups.stack.AddressGenerator;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import javax.management.MBeanServer;
@@ -92,7 +92,7 @@ public class UPerf extends ReceiverAdapter {
             channel.setName(name);
 
         if(bind_port > 0) {
-            TP transport=channel.getProtocolStack().getTransport();
+            AbstractTP transport=channel.getProtocolStack().getTransport();
             transport.setBindPort(bind_port);
         }
 
@@ -370,7 +370,7 @@ public class UPerf extends ReceiverAdapter {
         double total_reqs_sec=total_reqs / ( total_time/ 1000.0);
         double throughput=total_reqs_sec * BUFFER.length;
         double ms_per_req=total_time / (double)total_reqs;
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         System.out.println("\n");
         System.out.println(Util.bold("Average of " + f.format(total_reqs_sec) + " requests / sec (" +
                                        Util.printBytes(throughput) + " / sec), " +

--- a/tests/perf/org/jgroups/tests/perf/UUPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/UUPerf.java
@@ -6,7 +6,7 @@ import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.jmx.JmxConfigurator;
 import org.jgroups.protocols.UNICAST;
 import org.jgroups.protocols.UNICAST2;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.util.*;
 
 import javax.management.MBeanServer;
@@ -260,7 +260,7 @@ public class UUPerf extends ReceiverAdapter {
     }
 
     private void printConnections() {
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         if(prot instanceof UNICAST)
             System.out.println("connections:\n" + ((UNICAST)prot).printConnections());
         else if(prot instanceof UNICAST2)
@@ -270,7 +270,7 @@ public class UUPerf extends ReceiverAdapter {
     private void removeConnection() {
         Address member=getReceiver();
         if(member != null) {
-            Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+            AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
             if(prot instanceof UNICAST)
                 ((UNICAST)prot).removeConnection(member);
             else if(prot instanceof UNICAST2)
@@ -279,7 +279,7 @@ public class UUPerf extends ReceiverAdapter {
     }
 
     private void removeAllConnections() {
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         if(prot instanceof UNICAST)
             ((UNICAST)prot).removeAllConnections();
         else if(prot instanceof UNICAST2)
@@ -310,7 +310,7 @@ public class UUPerf extends ReceiverAdapter {
         double total_reqs_sec=total_reqs / (total_time / 1000.0);
         double throughput=total_reqs_sec * msg_size;
         double ms_per_req=total_time / (double)total_reqs;
-        Protocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
+        AbstractProtocol prot=channel.getProtocolStack().findProtocol(Util.getUnicastProtocols());
         System.out.println("\n");
         System.out.println(Util.bold("Average of " + f.format(total_reqs_sec) + " requests / sec (" +
                                        Util.printBytes(throughput) + " / sec), " +

--- a/tests/stress/org/jgroups/tests/NakReceiverWindowStressTest.java
+++ b/tests/stress/org/jgroups/tests/NakReceiverWindowStressTest.java
@@ -5,7 +5,7 @@ package org.jgroups.tests;
 import org.jgroups.Address;
 import org.jgroups.Message;
 import org.jgroups.stack.NakReceiverWindow;
-import org.jgroups.stack.Retransmitter;
+import org.jgroups.stack.AbstractRetransmitter;
 import org.jgroups.util.DefaultTimeScheduler;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
@@ -19,7 +19,7 @@ import java.io.IOException;
  *
  * @author Bela Ban
  */
-public class NakReceiverWindowStressTest implements Retransmitter.RetransmitCommand {
+public class NakReceiverWindowStressTest implements AbstractRetransmitter.RetransmitCommand {
     NakReceiverWindow win=null;
     final Address sender=Util.createRandomAddress("A");
     int num_msgs=1000, prev_value=0;

--- a/tests/stress/org/jgroups/tests/NakReceiverWindowStressTest2.java
+++ b/tests/stress/org/jgroups/tests/NakReceiverWindowStressTest2.java
@@ -3,7 +3,7 @@ package org.jgroups.tests;
 import org.jgroups.Address;
 import org.jgroups.Message;
 import org.jgroups.stack.NakReceiverWindow;
-import org.jgroups.stack.Retransmitter;
+import org.jgroups.stack.AbstractRetransmitter;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.TimeScheduler3;
 import org.jgroups.util.Util;
@@ -40,7 +40,7 @@ public class NakReceiverWindowStressTest2 {
         Address sender=Util.createRandomAddress("A");
         TimeScheduler timer=new TimeScheduler3();
 
-        NakReceiverWindow win=new NakReceiverWindow(sender, new Retransmitter.RetransmitCommand() {
+        NakReceiverWindow win=new NakReceiverWindow(sender, new AbstractRetransmitter.RetransmitCommand() {
 
             public void retransmit(long first_seqno, long last_seqno, Address sender) {
                 System.out.println("-- retransmit(" + first_seqno + "-" + last_seqno);

--- a/tests/stress/org/jgroups/tests/RemoteGetStressTest.java
+++ b/tests/stress/org/jgroups/tests/RemoteGetStressTest.java
@@ -10,7 +10,7 @@ import org.jgroups.protocols.*;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
+import org.jgroups.stack.AbstractProtocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.Util;
 
@@ -98,7 +98,7 @@ public class RemoteGetStressTest {
     }
 
     protected static JChannel createChannel(String name) throws Exception {
-        Protocol[] protocols={
+        AbstractProtocol[] protocols={
           new SHARED_LOOPBACK().setValue("oob_thread_pool_min_threads", 1)
             .setValue("oob_thread_pool_max_threads", 5)
           .setValue("oob_thread_pool_queue_enabled", false),
@@ -129,7 +129,7 @@ public class RemoteGetStressTest {
     }
 
     protected static void insertDISCARD(JChannel ch, double discard_rate) throws Exception {
-        TP transport=ch.getProtocolStack().getTransport();
+        AbstractTP transport=ch.getProtocolStack().getTransport();
         DISCARD discard=new DISCARD();
         discard.setUpDiscardRate(discard_rate);
         ch.getProtocolStack().insertProtocol(discard, ProtocolStack.ABOVE, transport.getClass());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00118
- Abstract class names should comply with a naming convention
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00118
Please let me know if you have any questions.
M-Ezzat