### PR TITLE
squid:S2162 - "equals" methods should be symmetric and work for subcl…

### DIFF
--- a/src/org/jgroups/View.java
+++ b/src/org/jgroups/View.java
@@ -144,7 +144,7 @@ public class View implements Comparable<View>, Streamable, Iterable<Address> {
     }
 
     public boolean equals(Object obj) {
-        return obj instanceof View && (this == obj || compareTo((View)obj) == 0);
+        return this.getClass() == obj.getClass() && (this == obj || compareTo((View)obj) == 0);
     }
 
     public boolean deepEquals(View other) {

--- a/src/org/jgroups/ViewId.java
+++ b/src/org/jgroups/ViewId.java
@@ -93,7 +93,7 @@ public class ViewId implements Comparable<ViewId>, Streamable {
 
 
     public boolean equals(Object other) {
-        return other instanceof ViewId && (this == other  || compareTo((ViewId)other) == 0);
+        return this.getClass() == other.getClass() && (this == other  || compareTo((ViewId)other) == 0);
     }
 
 

--- a/src/org/jgroups/blocks/mux/NoMuxHandler.java
+++ b/src/org/jgroups/blocks/mux/NoMuxHandler.java
@@ -21,7 +21,7 @@ public class NoMuxHandler implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if ((object == null) || !(object instanceof NoMuxHandler)) return false;
+        if ((object == null) || (this.getClass() != object.getClass())) { return false; }
         NoMuxHandler handler = (NoMuxHandler) object;
         return (id == handler.id);
     }

--- a/src/org/jgroups/protocols/PingData.java
+++ b/src/org/jgroups/protocols/PingData.java
@@ -103,8 +103,9 @@ public class PingData implements SizeStreamable {
 
 
     public boolean equals(Object obj) {
-        if(!(obj instanceof PingData))
+        if(this.getClass() != obj.getClass()) {
             return false;
+        }
         PingData other=(PingData)obj;
         return sender != null && sender.equals(other.sender);
     }

--- a/src/org/jgroups/stack/IpAddress.java
+++ b/src/org/jgroups/stack/IpAddress.java
@@ -133,8 +133,9 @@ public class IpAddress implements PhysicalAddress {
     public final boolean equals(Object obj) {
         if(this == obj) return true; // added Nov 7 2005, makes sense with canonical addresses
 
-        if(!(obj instanceof IpAddress))
+        if(this.getClass() != obj.getClass()) {
             return false;
+        }
         IpAddress other=(IpAddress)obj;
         boolean sameIP;
         if(this.ip_addr != null)

--- a/src/org/jgroups/util/AsciiString.java
+++ b/src/org/jgroups/util/AsciiString.java
@@ -64,7 +64,7 @@ public class AsciiString implements Comparable<AsciiString> {
 
 
     public boolean equals(Object obj) {
-        return obj instanceof AsciiString && compareTo((AsciiString)obj) == 0;
+        return this.getClass() == obj.getClass() && compareTo((AsciiString)obj) == 0;
     }
 
     public int hashCode() {

--- a/src/org/jgroups/util/MergeId.java
+++ b/src/org/jgroups/util/MergeId.java
@@ -30,7 +30,7 @@ public class MergeId implements Streamable {
     }
 
     public boolean equals(Object obj) {
-        return obj instanceof MergeId && initiator.equals(((MergeId)obj).initiator) && id == ((MergeId)obj).id;
+        return this.getClass() == obj && initiator.equals(((MergeId)obj).initiator) && id == ((MergeId)obj).id;
     }
 
     public int hashCode() {

--- a/src/org/jgroups/util/Rsp.java
+++ b/src/org/jgroups/util/Rsp.java
@@ -43,8 +43,9 @@ public class Rsp<T> {
     }
 
     public boolean equals(Object obj) {
-        if(!(obj instanceof Rsp))
+        if(this.getClass() != obj.getClass()) {
             return false;
+        }
         Rsp<T> other=(Rsp<T>)obj;
         if(sender != null)
             return sender.equals(other.sender);

--- a/src/org/jgroups/util/Seqno.java
+++ b/src/org/jgroups/util/Seqno.java
@@ -81,7 +81,7 @@ public class Seqno {
     }
 
     public boolean equals(Object obj) {
-        return obj instanceof Seqno && low == ((Seqno)obj).low;
+        return this.getClass() == obj.getClass() && low == ((Seqno)obj).low;
     }
 
     public String toString() {

--- a/src/org/jgroups/util/SingletonAddress.java
+++ b/src/org/jgroups/util/SingletonAddress.java
@@ -63,8 +63,9 @@ public class SingletonAddress implements Address {
     }
 
     public boolean equals(Object obj) {
-        if(!(obj instanceof Address))
+        if(this.getClass() != obj.getClass()) {
             throw new IllegalArgumentException("argument is " + obj.getClass());
+        }
         return compareTo((Address)obj) == 0;
     }
 

--- a/src/org/jgroups/util/UUID.java
+++ b/src/org/jgroups/util/UUID.java
@@ -264,8 +264,9 @@ public class UUID implements Address {
      * @return  {@code true} if the objects are the same; {@code false} otherwise
      */
     public boolean equals(Object obj) {
-        if (!(obj instanceof UUID))
+        if (this.getClass() != obj.getClass()) {
             return false;
+        }
         UUID id = (UUID)obj;
         return this == id || (mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - equals methods should be symmetric and work for subclasses
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
Please let me know if you have any questions.
M-Ezzat