### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the var…

### DIFF
--- a/src/org/jgroups/blocks/ConnectionTableNIO.java
+++ b/src/org/jgroups/blocks/ConnectionTableNIO.java
@@ -1141,7 +1141,7 @@ public class ConnectionTableNIO extends BasicConnectionTable implements Runnable
       private void processWrite(Selector selector)
       {
          Set keys = selector.selectedKeys();
-         Object arr[] = keys.toArray();
+          Object[] arr = keys.toArray();
           for (Object anArr : arr) {
               SelectionKey key = (SelectionKey) anArr;
               SelectorWriteHandler entry = (SelectorWriteHandler) key.attachment();

--- a/src/org/jgroups/conf/PropertyConverters.java
+++ b/src/org/jgroups/conf/PropertyConverters.java
@@ -186,7 +186,7 @@ public final class PropertyConverters {
     public static class LongArray implements PropertyConverter {
 
         public Object convert(Object obj, Class<?> propertyFieldType, String propertyName, String propertyValue, boolean check_scope) throws Exception {
-            long tmp [] = Util.parseCommaDelimitedLongs(propertyValue);
+            long[] tmp = Util.parseCommaDelimitedLongs(propertyValue);
             if(tmp != null && tmp.length > 0){
                 return tmp;
             }else{

--- a/src/org/jgroups/demos/QuoteClient.java
+++ b/src/org/jgroups/demos/QuoteClient.java
@@ -254,7 +254,7 @@ public class QuoteClient extends Frame implements WindowListener, ActionListener
     public void unblock() {
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         QuoteClient client=new QuoteClient();
         client.start();
     }

--- a/src/org/jgroups/demos/QuoteServer.java
+++ b/src/org/jgroups/demos/QuoteServer.java
@@ -107,7 +107,7 @@ public class QuoteServer extends ReceiverAdapter {
     }
 
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         try {
             QuoteServer server=new QuoteServer();
             server.start();

--- a/src/org/jgroups/demos/ReplicatedHashMapDemo.java
+++ b/src/org/jgroups/demos/ReplicatedHashMapDemo.java
@@ -218,7 +218,7 @@ public class ReplicatedHashMapDemo extends Frame implements WindowListener, Acti
         setTitle("ReplicatedHashMapDemo: " + num + " server(s)");
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         ReplicatedHashMapDemo     client=new ReplicatedHashMapDemo();
         JChannel                  channel;
         String                    props="udp.xml";

--- a/src/org/jgroups/demos/ViewDemo.java
+++ b/src/org/jgroups/demos/ViewDemo.java
@@ -40,7 +40,7 @@ public class ViewDemo extends ReceiverAdapter {
     }
 
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         ViewDemo t=new ViewDemo();
         String props="udp.xml";
 

--- a/src/org/jgroups/demos/applets/DrawApplet.java
+++ b/src/org/jgroups/demos/applets/DrawApplet.java
@@ -182,7 +182,9 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
     }
 
     public void mouseDragged(MouseEvent e) {
-        int tmp[]=new int[1], x, y;
+        int[] tmp = new int[1];
+        int x;
+        int y;
 
         tmp[0]=0;
         x=e.getX();
@@ -220,7 +222,7 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
 
 
     public void sendClearPanelMsg() {
-        int tmp[]=new int[1];
+        int[] tmp = new int[1];
         tmp[0]=0;
 
         clearPanel();

--- a/src/org/jgroups/protocols/FRAG.java
+++ b/src/org/jgroups/protocols/FRAG.java
@@ -406,7 +406,7 @@ public class FRAG extends Protocol {
             //the total number of fragment in this message
             int tot_frags=0;
             // each fragment is a byte buffer
-            byte[] fragments[]=null;
+            byte[][] fragments = null;
             //the number of fragments we have received
             int number_of_frags_recvd=0;
             // the message ID

--- a/src/org/jgroups/protocols/FRAG2.java
+++ b/src/org/jgroups/protocols/FRAG2.java
@@ -306,7 +306,7 @@ public class FRAG2 extends Protocol {
      */
     protected static class FragEntry {
         // each fragment is a byte buffer
-        final Message fragments[];
+        final Message[] fragments;
         //the number of fragments we have received
         int number_of_frags_recvd=0;
 

--- a/src/org/jgroups/protocols/S3_PING.java
+++ b/src/org/jgroups/protocols/S3_PING.java
@@ -1099,7 +1099,7 @@ public class S3_PING extends FILE_PING {
                 }
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 if(currText != null)
                     this.currText.append(ch, start, length);
             }
@@ -1324,7 +1324,7 @@ public class S3_PING extends FILE_PING {
                     this.currText=new StringBuffer();
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 this.currText.append(ch, start, length);
             }
 
@@ -1448,7 +1448,7 @@ public class S3_PING extends FILE_PING {
                 this.currText=new StringBuffer();
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 this.currText.append(ch, start, length);
             }
 

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -681,7 +681,7 @@ public class UDP extends TP {
 
 
         public void run() {
-            final byte           receive_buf[]=new byte[66000]; // to be on the safe side (IPv6 == 65575 bytes, IPv4 = 65535)
+            final byte[] receive_buf = new byte[66000]; // to be on the safe side (IPv6 == 65575 bytes, IPv4 = 65535)
             final DatagramPacket packet=new DatagramPacket(receive_buf, receive_buf.length);
 
             while(thread != null && Thread.currentThread().equals(thread)) {

--- a/src/org/jgroups/protocols/pbcast/STATE.java
+++ b/src/org/jgroups/protocols/pbcast/STATE.java
@@ -131,7 +131,7 @@ public class STATE extends StreamingStateTransfer {
         public void write(int b) throws IOException {
             if(closed.get())
                 throw new IOException("The output stream is closed");
-            byte buf[]={(byte)b};
+            byte[] buf = {(byte) b};
             write(buf);
         }
 

--- a/src/org/jgroups/util/ByteArrayDataInputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataInputStream.java
@@ -65,7 +65,7 @@ public class ByteArrayDataInputStream implements DataInput {
         return (pos < limit) ? (buf[pos++] & 0xff) : -1;
     }
 
-    public int read(byte b[], int off, int len) {
+    public int read(byte[] b, int off, int len) {
         if (b == null)
             throw new NullPointerException();
 

--- a/src/org/jgroups/util/ByteBufferInputStream.java
+++ b/src/org/jgroups/util/ByteBufferInputStream.java
@@ -111,7 +111,7 @@ public class ByteBufferInputStream implements DataInput {
 
     public String readLine() throws IOException {
         char[] lineBuffer=new char[128];
-        char buffer[] = lineBuffer;
+        char[] buffer = lineBuffer;
 
         if (buffer == null) {
             buffer = lineBuffer = new char[128];

--- a/src/org/jgroups/util/InputStreamAdapter.java
+++ b/src/org/jgroups/util/InputStreamAdapter.java
@@ -21,11 +21,11 @@ public class InputStreamAdapter extends InputStream {
     }
 
 
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         return input.read(b, off, len);
     }
 

--- a/src/org/jgroups/util/OutputStreamAdapter.java
+++ b/src/org/jgroups/util/OutputStreamAdapter.java
@@ -19,11 +19,11 @@ public class OutputStreamAdapter extends OutputStream {
         output.write(b);
     }
 
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         output.write(b);
     }
 
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         output.write(b, off, len);
     }
 

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -1297,7 +1297,8 @@ public class Util {
     }
 
     public static byte[] readFileContents(InputStream input) throws IOException {
-        byte contents[]=new byte[10000], buf[]=new byte[1024];
+        byte[] contents = new byte[10000];
+        byte[] buf = new byte[1024];
         InputStream in=new BufferedInputStream(input);
         int bytes_read=0;
 
@@ -1796,7 +1797,7 @@ public class Util {
      * @return An array of byte buffers (<code>byte[]</code>).
      */
     public static byte[][] fragmentBuffer(byte[] buf,int frag_size,final int length) {
-        byte[] retval[];
+        byte[][] retval;
         int accumulated_size=0;
         byte[] fragment;
         int tmp_size=0;
@@ -1858,7 +1859,7 @@ public class Util {
      * @param fragments An array of byte buffers (<code>byte[]</code>)
      * @return A byte buffer
      */
-    public static byte[] defragmentBuffer(byte[] fragments[]) {
+    public static byte[] defragmentBuffer(byte[][] fragments) {
         int total_length=0;
         byte[] ret;
         int index=0;

--- a/tests/junit-functional/org/jgroups/tests/ByteArrayDataInputOutputStreamTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ByteArrayDataInputOutputStreamTest.java
@@ -49,7 +49,7 @@ public class ByteArrayDataInputOutputStreamTest {
         assert in.position() == 0;
         assert in.limit() == 4;
         assert in.capacity() == buf.length;
-        byte tmp[]=new byte[4];
+        byte[] tmp = new byte[4];
         in.read(tmp, 0, tmp.length);
         assert "Bela".equals(new String(tmp));
     }
@@ -61,7 +61,7 @@ public class ByteArrayDataInputOutputStreamTest {
         assert in.position() == 10;
         assert in.limit() == 14;
         assert in.capacity() == buf.length;
-        byte tmp[]=new byte[4];
+        byte[] tmp = new byte[4];
         in.read(tmp, 0, tmp.length);
         assert "Bela".equals(new String(tmp));
     }
@@ -73,7 +73,7 @@ public class ByteArrayDataInputOutputStreamTest {
         assert in.position() == 10;
         assert in.limit() == 14;
         assert in.capacity() == buf.length;
-        byte tmp[]=new byte[5];
+        byte[] tmp = new byte[5];
         try {
             in.readFully(tmp, 0, tmp.length);
             assert false : " should have gotten an exception";

--- a/tests/junit-functional/org/jgroups/tests/LargeMergeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/LargeMergeTest.java
@@ -161,7 +161,7 @@ public class LargeMergeTest {
 
 
     @Test(enabled=false)
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         LargeMergeTest test=new LargeMergeTest();
         test.setUp();
         test.testClusterFormationAfterMerge();

--- a/tests/junit-functional/org/jgroups/tests/TableTest.java
+++ b/tests/junit-functional/org/jgroups/tests/TableTest.java
@@ -146,7 +146,7 @@ public class TableTest {
 
     public static void testAdditionListWithOffset() {
         Table<Integer> table=new Table<>(3, 10, 100);
-        long seqnos[]={101,105,109,110,111,119,120,129};
+        long[] seqnos = {101, 105, 109, 110, 111, 119, 120, 129};
         List<Tuple<Long,Integer>> msgs=createList(seqnos);
         System.out.println("table: " + table.dump());
         assert table.add(msgs);

--- a/tests/junit/org/jgroups/tests/FlushTest.java
+++ b/tests/junit/org/jgroups/tests/FlushTest.java
@@ -27,7 +27,7 @@ public class FlushTest {
 
     public void testSingleChannel() throws Exception {
         Semaphore s = new Semaphore(1);
-        FlushTestReceiver receivers[] ={ new FlushTestReceiver("c1", s, 0, FlushTestReceiver.CONNECT_ONLY) };
+        FlushTestReceiver[] receivers = {new FlushTestReceiver("c1", s, 0, FlushTestReceiver.CONNECT_ONLY)};
         receivers[0].start();
         s.release(1);
 
@@ -264,7 +264,7 @@ public class FlushTest {
         _testChannels(names, FlushTestReceiver.CONNECT_AND_GET_STATE);
     }
 
-    private void _testChannels(String names[], int connectType) throws Exception {
+    private void _testChannels(String[] names, int connectType) throws Exception {
         int count = names.length;
 
         List<FlushTestReceiver> channels = new ArrayList<>(count);

--- a/tests/junit/org/jgroups/tests/FlushWithChannelJoinsAndFailuresTest.java
+++ b/tests/junit/org/jgroups/tests/FlushWithChannelJoinsAndFailuresTest.java
@@ -27,7 +27,7 @@ public class FlushWithChannelJoinsAndFailuresTest {
    
     public void testAndLoop() throws Exception {
         int numChannels = 10;
-        Channel channels[] = new Channel[numChannels];
+        Channel[] channels = new Channel[numChannels];
         for (int j = 0; j < numChannels; j++) {
             channels[j] = createChannel(String.valueOf((char)('A' + j)));
             channels[j].connect(cName);
@@ -37,7 +37,7 @@ public class FlushWithChannelJoinsAndFailuresTest {
         Util.waitUntilAllChannelsHaveSameSize(10000, 500, channels);
 
         for (int i = 1; i <= 2; i++) {
-            int killPositions[] = { 0, 3, 5, 8 };
+            int[] killPositions = {0, 3, 5, 8};
             for (int index : killPositions)
                 Util.shutdown(channels[index]);
             int ch='M';

--- a/tests/junit/org/jgroups/tests/ReconciliationTest.java
+++ b/tests/junit/org/jgroups/tests/ReconciliationTest.java
@@ -85,7 +85,7 @@ public class ReconciliationTest {
                 channel.stopFlush();
             };
         };
-        String apps[]={"A", "B", "C"};
+        String[] apps = {"A", "B", "C"};
         reconciliationHelper(apps, t);
     }
 
@@ -115,7 +115,7 @@ public class ReconciliationTest {
                 }
             };
         };
-        String apps[]={"A", "B", "C"};
+        String[] apps = {"A", "B", "C"};
         reconciliationHelper(apps, t);
     }
 

--- a/tests/other/org/jgroups/tests/McastReceiverTest.java
+++ b/tests/other/org/jgroups/tests/McastReceiverTest.java
@@ -21,7 +21,7 @@ import java.util.Enumeration;
  */
 public class McastReceiverTest {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         InetAddress mcast_addr=null, bind_addr=null;
         String tmp;
         int port=5555;
@@ -90,7 +90,7 @@ public class McastReceiverTest {
     static class Receiver extends Thread {
         MulticastSocket sock=null;
         DatagramPacket packet;
-        byte buf[]=null;
+        byte[] buf = null;
         byte[] recv_buf;
         int recv_len=0;
 

--- a/tests/other/org/jgroups/tests/McastSenderTest.java
+++ b/tests/other/org/jgroups/tests/McastSenderTest.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public class McastSenderTest {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         MulticastSocket[] sockets=null;
         MulticastSocket sock;
         InetAddress mcast_addr=null, bind_addr=null;

--- a/tests/other/org/jgroups/tests/ModClusterAdvertizeListener.java
+++ b/tests/other/org/jgroups/tests/ModClusterAdvertizeListener.java
@@ -13,11 +13,11 @@ import java.util.Enumeration;
  */
 public class ModClusterAdvertizeListener {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         MulticastSocket sock;
         InetAddress bind_addr=null, mcast_addr=null;
         DatagramPacket packet;
-        byte buf[]=null;
+        byte[] buf = null;
         byte[] recv_buf;
         String tmp;
         int port=23364;

--- a/tests/other/org/jgroups/tests/UnicastTestTcpRpc.java
+++ b/tests/other/org/jgroups/tests/UnicastTestTcpRpc.java
@@ -118,7 +118,7 @@ public class UnicastTestTcpRpc {
                    case RECEIVE_SYNC:
                        long val=in.readLong();
                        int len=in.readInt();
-                       byte data[]=new byte[len];
+                       byte[] data = new byte[len];
                        in.readFully(data, 0, data.length);
                        receiveData(val, data);
                        if(type == RECEIVE_SYNC) {

--- a/tests/other/org/jgroups/tests/mcast.java
+++ b/tests/other/org/jgroups/tests/mcast.java
@@ -79,7 +79,7 @@ public class mcast {
         }
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         InetAddress mcast_addr=null, bind_addr=null;
         int mcast_port=5555;
         int local_port=0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule Array designators [] should be on the type, not the variable and squid:S1197
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
Please let me know if you have any questions.
M-Ezzat