### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition …

### DIFF
--- a/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
+++ b/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
@@ -115,7 +115,7 @@ public class SimpleAuthorizingCallbackHandler implements CallbackHandler {
             } else if (current instanceof RealmCallback) {
                 String realm = ((RealmCallback) current).getDefaultText();
                 if (realm != null) {
-                    if (this.realm.equals(realm) == false) {
+                    if (!this.realm.equals(realm)) {
                         throw new IOException("Invalid realm " + realm);
                     }
                 }

--- a/src/org/jgroups/protocols/AUTH.java
+++ b/src/org/jgroups/protocols/AUTH.java
@@ -266,7 +266,7 @@ public class AUTH extends Protocol {
     protected boolean callUpHandlers(Event evt) {
         boolean pass_up=true;
         for(UpHandler handler: up_handlers) {
-            if(handler.handleUpEvent(evt) == false)
+            if(!handler.handleUpEvent(evt))
                 pass_up=false;
         }
         return pass_up;

--- a/src/org/jgroups/protocols/Executing.java
+++ b/src/org/jgroups/protocols/Executing.java
@@ -731,7 +731,7 @@ abstract public class Executing extends Protocol {
             _tasks.put(threadId, runnable);
             
             CyclicBarrier barrier = _taskBarriers.remove(threadId);
-            if ((received = barrier != null) == true) {
+            if (received = barrier != null) {
                 // Only wait 10 milliseconds, in case if the consumer was
                 // stopped between when we were told it was available and now
                 barrier.await(10, TimeUnit.MILLISECONDS);

--- a/src/org/jgroups/stack/ProtocolStack.java
+++ b/src/org/jgroups/stack/ProtocolStack.java
@@ -846,7 +846,7 @@ public class ProtocolStack extends Protocol {
      * Each layer can perform some initialization, e.g. create a multicast socket
      */
     public void startStack(String cluster, Address local_addr) throws Exception {
-        if(stopped == false) return;
+        if(!stopped) return;
         for(Protocol prot: getProtocols())
             prot.start();
         TP transport=getTransport();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1125 - Literal boolean values should not be used in condition expressions
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1125
Please let me know if you have any questions.
M-Ezzat