### PR TITLE
squid:S1197 -  Array designators [] should be on the type, not the va…

### DIFF
--- a/src/org/jgroups/conf/PropertyConverters.java
+++ b/src/org/jgroups/conf/PropertyConverters.java
@@ -186,7 +186,7 @@ public final class PropertyConverters {
     public static class LongArray implements PropertyConverter {
 
         public Object convert(Object obj, Class<?> propertyFieldType, String propertyName, String propertyValue, boolean check_scope) throws Exception {
-            long tmp [] = Util.parseCommaDelimitedLongs(propertyValue);
+            long[] tmp = Util.parseCommaDelimitedLongs(propertyValue);
             if(tmp != null && tmp.length > 0){
                 return tmp;
             }else{

--- a/src/org/jgroups/demos/QuoteClient.java
+++ b/src/org/jgroups/demos/QuoteClient.java
@@ -254,7 +254,7 @@ public class QuoteClient extends Frame implements WindowListener, ActionListener
     public void unblock() {
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         QuoteClient client=new QuoteClient();
         client.start();
     }

--- a/src/org/jgroups/demos/QuoteServer.java
+++ b/src/org/jgroups/demos/QuoteServer.java
@@ -107,7 +107,7 @@ public class QuoteServer extends ReceiverAdapter {
     }
 
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         try {
             QuoteServer server=new QuoteServer();
             server.start();

--- a/src/org/jgroups/demos/ReplicatedHashMapDemo.java
+++ b/src/org/jgroups/demos/ReplicatedHashMapDemo.java
@@ -218,7 +218,7 @@ public class ReplicatedHashMapDemo extends Frame implements WindowListener, Acti
         setTitle("ReplicatedHashMapDemo: " + num + " server(s)");
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         ReplicatedHashMapDemo     client=new ReplicatedHashMapDemo();
         JChannel                  channel;
         String                    props="udp.xml";

--- a/src/org/jgroups/demos/ViewDemo.java
+++ b/src/org/jgroups/demos/ViewDemo.java
@@ -40,7 +40,7 @@ public class ViewDemo extends ReceiverAdapter {
     }
 
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         ViewDemo t=new ViewDemo();
         String props="udp.xml";
 

--- a/src/org/jgroups/demos/applets/DrawApplet.java
+++ b/src/org/jgroups/demos/applets/DrawApplet.java
@@ -182,7 +182,9 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
     }
 
     public void mouseDragged(MouseEvent e) {
-        int tmp[]=new int[1], x, y;
+        int[] tmp = new int[1];
+        int x;
+        int y;
 
         tmp[0]=0;
         x=e.getX();
@@ -220,7 +222,7 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
 
 
     public void sendClearPanelMsg() {
-        int tmp[]=new int[1];
+        int[] tmp = new int[1];
         tmp[0]=0;
 
         clearPanel();

--- a/src/org/jgroups/protocols/FRAG.java
+++ b/src/org/jgroups/protocols/FRAG.java
@@ -406,7 +406,7 @@ public class FRAG extends Protocol {
             //the total number of fragment in this message
             int tot_frags=0;
             // each fragment is a byte buffer
-            byte[] fragments[]=null;
+            byte[][] fragments = null;
             //the number of fragments we have received
             int number_of_frags_recvd=0;
             // the message ID

--- a/src/org/jgroups/protocols/FRAG2.java
+++ b/src/org/jgroups/protocols/FRAG2.java
@@ -306,7 +306,7 @@ public class FRAG2 extends Protocol {
      */
     protected static class FragEntry {
         // each fragment is a byte buffer
-        final Message fragments[];
+        final Message[] fragments;
         //the number of fragments we have received
         int number_of_frags_recvd=0;
 

--- a/src/org/jgroups/protocols/S3_PING.java
+++ b/src/org/jgroups/protocols/S3_PING.java
@@ -1099,7 +1099,7 @@ public class S3_PING extends FILE_PING {
                 }
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 if(currText != null)
                     this.currText.append(ch, start, length);
             }
@@ -1324,7 +1324,7 @@ public class S3_PING extends FILE_PING {
                     this.currText=new StringBuffer();
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 this.currText.append(ch, start, length);
             }
 
@@ -1448,7 +1448,7 @@ public class S3_PING extends FILE_PING {
                 this.currText=new StringBuffer();
             }
 
-            public void characters(char ch[], int start, int length) {
+            public void characters(char[] ch, int start, int length) {
                 this.currText.append(ch, start, length);
             }
 

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -652,7 +652,7 @@ public class UDP extends TP {
 
 
         public void run() {
-            final byte           receive_buf[]=new byte[66000]; // to be on the safe side (IPv6 == 65575 bytes, IPv4 = 65535)
+            final byte[] receive_buf = new byte[66000]; // to be on the safe side (IPv6 == 65575 bytes, IPv4 = 65535)
             final DatagramPacket packet=new DatagramPacket(receive_buf, receive_buf.length);
 
             while(thread != null && Thread.currentThread().equals(thread)) {

--- a/src/org/jgroups/protocols/pbcast/STATE.java
+++ b/src/org/jgroups/protocols/pbcast/STATE.java
@@ -131,7 +131,7 @@ public class STATE extends StreamingStateTransfer {
         public void write(int b) throws IOException {
             if(closed.get())
                 throw new IOException("The output stream is closed");
-            byte buf[]={(byte)b};
+            byte[] buf = {(byte) b};
             write(buf);
         }
 

--- a/src/org/jgroups/util/ByteArrayDataInputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataInputStream.java
@@ -65,7 +65,7 @@ public class ByteArrayDataInputStream implements DataInput {
         return (pos < limit) ? (buf[pos++] & 0xff) : -1;
     }
 
-    public int read(byte b[], int off, int len) {
+    public int read(byte[] b, int off, int len) {
         if (b == null)
             throw new NullPointerException();
 

--- a/src/org/jgroups/util/ByteBufferInputStream.java
+++ b/src/org/jgroups/util/ByteBufferInputStream.java
@@ -111,7 +111,7 @@ public class ByteBufferInputStream implements DataInput {
 
     public String readLine() throws IOException {
         char[] lineBuffer=new char[128];
-        char buffer[] = lineBuffer;
+        char[] buffer = lineBuffer;
 
         if (buffer == null) {
             buffer = lineBuffer = new char[128];

--- a/src/org/jgroups/util/InputStreamAdapter.java
+++ b/src/org/jgroups/util/InputStreamAdapter.java
@@ -21,11 +21,11 @@ public class InputStreamAdapter extends InputStream {
     }
 
 
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         return input.read(b, off, len);
     }
 

--- a/src/org/jgroups/util/OutputStreamAdapter.java
+++ b/src/org/jgroups/util/OutputStreamAdapter.java
@@ -19,11 +19,11 @@ public class OutputStreamAdapter extends OutputStream {
         output.write(b);
     }
 
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         output.write(b);
     }
 
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         output.write(b, off, len);
     }
 

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -1275,7 +1275,8 @@ public class Util {
     }
 
     public static byte[] readFileContents(InputStream input) throws IOException {
-        byte contents[]=new byte[10000], buf[]=new byte[1024];
+        byte[] contents = new byte[10000];
+        byte[] buf = new byte[1024];
         InputStream in=new BufferedInputStream(input);
         int bytes_read=0;
 
@@ -1769,7 +1770,7 @@ public class Util {
      * @return An array of byte buffers ({@code byte[]}).
      */
     public static byte[][] fragmentBuffer(byte[] buf,int frag_size,final int length) {
-        byte[] retval[];
+        byte[][] retval;
         int accumulated_size=0;
         byte[] fragment;
         int tmp_size=0;
@@ -1831,7 +1832,7 @@ public class Util {
      * @param fragments An array of byte buffers ({@code byte[]})
      * @return A byte buffer
      */
-    public static byte[] defragmentBuffer(byte[] fragments[]) {
+    public static byte[] defragmentBuffer(byte[][] fragments) {
         int total_length=0;
         byte[] ret;
         int index=0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule Array designators [] should be on the type, not the variable and squid:S1197
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
Please let me know if you have any questions.
M-Ezzat