### PR TITLE
squid:S2063, squid:S1155 - Comparators should be Serializable, Collec…

### DIFF
--- a/src/org/jgroups/demos/wb/GraphPanel.java
+++ b/src/org/jgroups/demos/wb/GraphPanel.java
@@ -53,7 +53,7 @@ public class GraphPanel extends Panel implements MouseListener, MouseMotionListe
         Node n;
 
         synchronized(nodes) {
-            if(nodes.size() < 1)
+            if(nodes.isEmpty())
                 return null;
             for(int i=nodes.size() - 1; i >= 0; i--) {
                 n=nodes.get(i);

--- a/src/org/jgroups/protocols/PRIO.java
+++ b/src/org/jgroups/protocols/PRIO.java
@@ -8,6 +8,7 @@ import org.jgroups.annotations.Property;
 import org.jgroups.stack.Protocol;
 import org.jgroups.util.MessageBatch;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.concurrent.PriorityBlockingQueue;
 
@@ -270,7 +271,8 @@ public class PRIO extends Protocol {
     /**
      * Comparator for PriorityMessage's
      */
-    private static class PriorityCompare implements Comparator<PriorityMessage> {
+    private static class PriorityCompare implements Comparator<PriorityMessage>, Serializable {
+        private static final long serialVersionUID = 1L;
         /**
          * Compare two messages based on priority and time stamp in that order
          * @param msg1 - first message

--- a/src/org/jgroups/protocols/pbcast/ParticipantGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ParticipantGmsImpl.java
@@ -149,7 +149,7 @@ public class ParticipantGmsImpl extends ServerGmsImpl {
      */
     boolean wouldIBeCoordinator() {
         List<Address> mbrs=gms.computeNewMembership(gms.members.getMembers(), null, null, suspected_mbrs);
-        if(mbrs.size() < 1) return false;
+        if(mbrs.isEmpty()) return false;
         Address new_coord=mbrs.get(0);
         return gms.local_addr.equals(new_coord);
     }

--- a/src/org/jgroups/stack/RouterStubManager.java
+++ b/src/org/jgroups/stack/RouterStubManager.java
@@ -9,6 +9,7 @@ import org.jgroups.logging.LogFactory;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
 
+import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -284,7 +285,9 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
 
 
 
-    protected static class Target implements Comparator<Target> {
+    protected static class Target implements Comparator<Target>, Serializable {
+        private static final long serialVersionUID = 1L;
+
         protected final IpAddress               bind_addr, router_addr;
         protected final RouterStub.StubReceiver receiver;
 

--- a/src/org/jgroups/util/SeqnoComparator.java
+++ b/src/org/jgroups/util/SeqnoComparator.java
@@ -1,11 +1,14 @@
 package org.jgroups.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * @author Bela Ban
  */
-public class SeqnoComparator implements Comparator<Seqno> {
+public class SeqnoComparator implements Comparator<Seqno>, Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int compare(Seqno o1, Seqno o2) {
 
         // o1 and o2 are either Seqnos or SeqnoRanges, so we just compare on 'low'


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063, squid:S1155 - Comparators should be "Serializable", Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat
