### PR TITLE
improve performance for Request.cancel

### DIFF
--- a/src/org/jgroups/blocks/Request.java
+++ b/src/org/jgroups/blocks/Request.java
@@ -36,9 +36,9 @@ public abstract class Request implements NotifyingFuture, org.jgroups.util.Condi
     protected volatile boolean        done;
     protected boolean                 block_for_results=true;
     protected volatile FutureListener listener;
+    private long req_id;
 
 
-    
     public Request(Message request, RequestCorrelator corr, RequestOptions options) {
         this.request_msg=request;
         this.corr=corr;
@@ -181,5 +181,11 @@ public abstract class Request implements NotifyingFuture, org.jgroups.util.Condi
         return cond.waitFor(this, timeout, TimeUnit.MILLISECONDS);
     }
 
+    public void setRequestId(final long req_id) {
+        this.req_id = req_id;
+    }
 
+    public long getRequestId() {
+        return req_id;
+    }
 }


### PR DESCRIPTION
This pull-request fixes serious performance problems we encountered with 3.6.7-final when cancelling a lot of requests at once. 

The Problem can be tracked down to the RequestCorrelator, more exactly `this.requests.values().remove(req)`.
If the request Map has a lot of entries, removing by value gets really slow. 

The basic idea is to keep the request ID for each Request as part of the Object, so it can be used later to remove the value from the Map by key instead of value.