### PR TITLE
squid:S2272,findbugs:DM_NUMBER_CTOR - Iterator.next() methods should …

### DIFF
--- a/src/org/jgroups/demos/wb/GraphPanel.java
+++ b/src/org/jgroups/demos/wb/GraphPanel.java
@@ -266,7 +266,7 @@ public class GraphPanel extends Panel implements MouseListener, MouseMotionListe
 
         try {
             MethodCall call=new MethodCall("addNode",
-                                           new Object[]{name,my_addr,new Integer(xloc),new Integer(yloc)},
+                                           new Object[]{name,my_addr,Integer.valueOf(xloc),Integer.valueOf(yloc)},
                                            new Class[]{String.class,Address.class,int.class,int.class});
             wb.disp.callRemoteMethods(null, call, new RequestOptions(ResponseMode.GET_ALL, 0));
         }

--- a/src/org/jgroups/util/RingBuffer.java
+++ b/src/org/jgroups/util/RingBuffer.java
@@ -403,6 +403,9 @@ public class RingBuffer<T> implements Iterable<T> {
         }
 
         public T next() {
+            if(!hasNext()){
+                throw new NoSuchElementException();
+            }
             if(current <= hd)
                 current=hd+1;
             return buffer[index(current++)];

--- a/src/org/jgroups/util/RingBufferLockless.java
+++ b/src/org/jgroups/util/RingBufferLockless.java
@@ -410,6 +410,9 @@ public class RingBufferLockless<T> implements Iterable<T> {
         }
 
         public T next() {
+            if(!hasNext()){
+                throw new NoSuchElementException();
+            }
             if(current <= hd)
                 current=hd+1;
             return buffer.get(index(current++));

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -153,7 +153,7 @@ public class Util {
 
         try {
             String tmp=System.getProperty(Global.DEFAULT_HEADERS);
-            DEFAULT_HEADERS=tmp != null? new Integer(tmp) : 4;
+            DEFAULT_HEADERS=tmp != null? Integer.valueOf(tmp) : 4;
         }
         catch(Throwable t) {
             throw new IllegalArgumentException(String.format("property %s has an incorrect value", Global.DEFAULT_HEADERS), t);
@@ -2644,7 +2644,7 @@ public class Util {
         if(s == null) return null;
         tok=new StringTokenizer(s,",");
         while(tok.hasMoreTokens()) {
-            l=new Integer(tok.nextToken());
+            l= Integer.valueOf(tok.nextToken());
             v.add(l);
         }
         if(v.isEmpty()) return null;
@@ -2667,7 +2667,7 @@ public class Util {
         if(s == null) return null;
         tok=new StringTokenizer(s,",");
         while(tok.hasMoreTokens()) {
-            l=new Long(tok.nextToken());
+            l=Long.valueOf(tok.nextToken());
             v.add(l);
         }
         if(v.isEmpty()) return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule findbugs:DM_NUMBER_CTOR, squid:S2272 - Comparators should be "Serializable", Performance - Method invokes inefficient Number constructor; use static valueOf instead

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_NUMBER_CTOR
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2272

Please let me know if you have any questions.

M-Ezzat