### PR TITLE
squid:S2446, squid:S2325 - "notifyAll" should be used, private method…

### DIFF
--- a/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
+++ b/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
@@ -83,7 +83,7 @@ public class SimpleAuthorizingCallbackHandler implements CallbackHandler {
         realm = properties.getProperty("sasl.realm");
     }
 
-    private String requireProperty(Properties properties, String propertyName) {
+    private static String requireProperty(Properties properties, String propertyName) {
         String value = properties.getProperty(propertyName);
         if (value == null) {
             throw new IllegalStateException("The required system property " + propertyName + " has not been set");

--- a/src/org/jgroups/demos/wb/Whiteboard.java
+++ b/src/org/jgroups/demos/wb/Whiteboard.java
@@ -46,7 +46,7 @@ public class Whiteboard extends Applet implements MessageListener, MembershipLis
         panel.setState(istream);
     }
 
-    private String getInfo() {
+    private static String getInfo() {
         StringBuilder ret = new StringBuilder();
         ret.append(" (" + System.getProperty("os.name") + ' ' + System.getProperty("os.version") +
                    ' ' + System.getProperty("os.arch") + ')');

--- a/src/org/jgroups/protocols/S3_PING.java
+++ b/src/org/jgroups/protocols/S3_PING.java
@@ -351,7 +351,7 @@ public class S3_PING extends FILE_PING {
             }
         }
 
-        private String parseBucketFromHost(String host) {
+        private static String parseBucketFromHost(String host) {
             int s3Index = host.lastIndexOf(".s3.");
             if (s3Index > 0) {
                 host = host.substring(0, s3Index);
@@ -853,7 +853,7 @@ public class S3_PING extends FILE_PING {
             return connection;
         }
 
-        private HttpURLConnection makePreSignedRequest(String method, String preSignedUrl, Map headers) throws IOException {
+        private static HttpURLConnection makePreSignedRequest(String method, String preSignedUrl, Map headers) throws IOException {
             URL url = new URL(preSignedUrl);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod(method);

--- a/src/org/jgroups/protocols/tom/DeliveryManagerImpl.java
+++ b/src/org/jgroups/protocols/tom/DeliveryManagerImpl.java
@@ -80,7 +80,7 @@ public class DeliveryManagerImpl implements DeliveryManager {
             }
 
             if (deliverySet.first().isReadyToDeliver()) {
-                deliverySet.notify();
+                deliverySet.notifyAll();
             }
         }
     }
@@ -97,7 +97,7 @@ public class DeliveryManagerImpl implements DeliveryManager {
 
             deliverySet.removeAll(toRemove);
             if (!deliverySet.isEmpty() && deliverySet.first().isReadyToDeliver()) {
-                deliverySet.notify();
+                deliverySet.notifyAll();
             }
         }
         for (MessageInfo removed : toRemove) {
@@ -151,7 +151,7 @@ public class DeliveryManagerImpl implements DeliveryManager {
             messageInfo.updateAndmarkReadyToDeliver(sequenceNumber);
             deliverySet.add(messageInfo);
             if (deliverySet.first().isReadyToDeliver()) {
-                deliverySet.notify();
+                deliverySet.notifyAll();
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2446, squid:S2325 - "notifyAll" should be used, private methods that don't access instance data should be static

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2446
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat