### PR TITLE
squid:S2097 - "equals(Object obj)" should test argument type

### DIFF
--- a/src/org/jgroups/protocols/relay/Relayer.java
+++ b/src/org/jgroups/protocols/relay/Relayer.java
@@ -205,7 +205,15 @@ public class Relayer {
         }
 
         public boolean equals(Object obj) {
-            return compareTo((Route)obj) == 0;
+            if (obj == null) {
+                return false;
+            }
+
+            if (this.getClass() != obj.getClass()) {
+                return false;
+            }
+
+            return compareTo((Route) obj) == 0;
         }
 
         public int hashCode() {

--- a/src/org/jgroups/protocols/relay/SiteMaster.java
+++ b/src/org/jgroups/protocols/relay/SiteMaster.java
@@ -38,6 +38,14 @@ public class SiteMaster extends SiteUUID {
     }
 
     public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
         return compareTo((Address)obj) == 0;
     }
 

--- a/src/org/jgroups/stack/RouterStub.java
+++ b/src/org/jgroups/stack/RouterStub.java
@@ -231,6 +231,14 @@ public class RouterStub extends ReceiverAdapter implements Comparable<RouterStub
     public int hashCode() {return remote.hashCode();}
 
     public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
         return compareTo((RouterStub)obj) == 0;
     }
 

--- a/src/org/jgroups/stack/RouterStubManager.java
+++ b/src/org/jgroups/stack/RouterStubManager.java
@@ -304,6 +304,14 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
         }
 
         public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+
+            if (this.getClass() != obj.getClass()) {
+                return false;
+            }
+
             return compare(this, (Target)obj) == 0;
         }
 

--- a/src/org/jgroups/util/Digest.java
+++ b/src/org/jgroups/util/Digest.java
@@ -104,6 +104,14 @@ public class Digest implements Streamable, Iterable<Digest.Entry> {
 
     /** 2 digests are equal if their memberships match and all highest-delivered and highest-received seqnos match */
     public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
         if(this == obj)
             return true;
         Digest other=(Digest)obj;
@@ -288,6 +296,14 @@ public class Digest implements Streamable, Iterable<Digest.Entry> {
         public long    getHighest()               {return max(hd,hr);}
 
         public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+
+            if (this.getClass() != obj.getClass()) {
+                return false;
+            }
+
             Entry other=(Entry)obj;
             return member.equals(other.member) && hd == other.hd && hr == other.hr;
         }

--- a/src/org/jgroups/util/Owner.java
+++ b/src/org/jgroups/util/Owner.java
@@ -42,8 +42,14 @@ public class Owner implements Streamable {
     }
 
     public boolean equals(Object obj) {
-        if(obj == null)
+        if (obj == null) {
             return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
         Owner other=(Owner)obj;
         return address.equals(other.address) && thread_id == other.thread_id;
     }

--- a/src/org/jgroups/util/Range.java
+++ b/src/org/jgroups/util/Range.java
@@ -37,6 +37,14 @@ public class Range implements Streamable, Comparable<Range> {
     }
 
     public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
         Range other=(Range)obj;
         return compareTo(other) == 0;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - "equals(Object obj)" should test argument type

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2097

Please let me know if you have any questions.

M-Ezzat