### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/src/org/jgroups/blocks/ReplicatedHashMap.java
+++ b/src/org/jgroups/blocks/ReplicatedHashMap.java
@@ -517,7 +517,7 @@ public class ReplicatedHashMap<K, V> extends
         return new SynchronizedReplicatedMap<>(map);
     }
 
-    private static class SynchronizedReplicatedMap<K, V>
+    private static final class SynchronizedReplicatedMap<K, V>
             implements ReplicatedMap<K,V> {
         private final ReplicatedMap<K,V> map;
         private final Object mutex;

--- a/src/org/jgroups/blocks/ReplicatedTree.java
+++ b/src/org/jgroups/blocks/ReplicatedTree.java
@@ -682,7 +682,7 @@ public class ReplicatedTree extends ReceiverAdapter {
     }
 
 
-    public static class Node implements Serializable {
+    public static final class Node implements Serializable {
         String name=null;     // relative name (e.g. "Security")
         String fqn=null;      // fully qualified name (e.g. "/federations/fed1/servers/Security")
         Node parent=null;   // parent node
@@ -831,7 +831,7 @@ public class ReplicatedTree extends ReceiverAdapter {
     }
 
 
-    private static class StringHolder {
+    private static final class StringHolder {
         String s=null;
 
         private StringHolder() {
@@ -850,7 +850,7 @@ public class ReplicatedTree extends ReceiverAdapter {
     /**
      * Class used to multicast add(), remove() and set() methods to all members.
      */
-    private static class Request implements Serializable {
+    private static final class Request implements Serializable {
         static final int PUT=1;
         static final int REMOVE=2;
 

--- a/src/org/jgroups/protocols/PRIO.java
+++ b/src/org/jgroups/protocols/PRIO.java
@@ -188,7 +188,7 @@ public class PRIO extends Protocol {
 	 * <P>
 	 * The messageQueue contains the prioritized messages 
 	 */
-	private class DownMessageThread extends MessageThread {
+	private final class DownMessageThread extends MessageThread {
 		private DownMessageThread( PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
 			super( prio, messageQueue );
 		}
@@ -204,7 +204,7 @@ public class PRIO extends Protocol {
 	 * <P>
 	 * The messageQueue contains the prioritized messages
 	 */
-	private class UpMessageThread extends MessageThread {
+	private final class UpMessageThread extends MessageThread {
 		private UpMessageThread( PRIO prio, PriorityBlockingQueue<PriorityMessage> messageQueue  ) {
 			super( prio, messageQueue );
 		}

--- a/src/org/jgroups/protocols/pbcast/FLUSH.java
+++ b/src/org/jgroups/protocols/pbcast/FLUSH.java
@@ -953,7 +953,7 @@ public class FLUSH extends Protocol {
     }
 
 
-    private static class FlushStartResult {
+    private static final class FlushStartResult {
         private final Boolean result;
         private final Exception failureCause;
       

--- a/src/org/jgroups/protocols/tom/SenderManager.java
+++ b/src/org/jgroups/protocols/tom/SenderManager.java
@@ -97,7 +97,7 @@ public class SenderManager {
     /**
      * The state of a message (destination, proposes missing, the highest sequence number proposed, etc...)
      */
-    private static class MessageInfo {
+    private static final class MessageInfo {
         private final ArrayList<Address> destinations;
         private long highestSequenceNumberReceived;
         private BitSet receivedPropose;

--- a/src/org/jgroups/util/Base64.java
+++ b/src/org/jgroups/util/Base64.java
@@ -147,7 +147,7 @@ package org.jgroups.util;
  * @author rob@iharder.net
  * @version 2.3.7
  */
-public class Base64
+public final class Base64
 {
     
 /* ********  P U B L I C   F I E L D S  ******** */   

--- a/src/org/jgroups/util/ResourceManager.java
+++ b/src/org/jgroups/util/ResourceManager.java
@@ -14,7 +14,7 @@ import java.util.StringTokenizer;
  * 
  * @author Bela Ban
  */
-public class ResourceManager {
+public final class ResourceManager {
 	private static final IpAddressRep rep;
 	private static short mcast_port;
 	private static short tcp_port;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat