### PR TITLE
squid:S2275 - Printf-style format strings should not lead to unexpect…

### DIFF
--- a/src/org/jgroups/demos/PubClient.java
+++ b/src/org/jgroups/demos/PubClient.java
@@ -29,13 +29,13 @@ public class PubClient extends ReceiverAdapter implements ConnectionListener {
     @Override
     public void receive(Address sender, ByteBuffer buf) {
         String msg=new String(buf.array(), buf.arrayOffset(), buf.limit());
-        System.out.printf("-- %s\n", msg);
+        System.out.printf("-- %s%n", msg);
     }
 
     @Override
     public void receive(Address sender, byte[] buf, int offset, int length) {
         String msg=new String(buf, offset, length);
-        System.out.printf("-- %s\n", msg);
+        System.out.printf("-- %s%n", msg);
     }
 
 
@@ -58,7 +58,7 @@ public class PubClient extends ReceiverAdapter implements ConnectionListener {
         client.receiver(this);
         client.addConnectionListener(this);
         client.start();
-        byte[] buf=String.format("%s joined\n", name).getBytes();
+        byte[] buf=String.format("%s joined%n", name).getBytes();
         ((Client)client).send(buf, 0, buf.length);
         eventLoop();
         client.stop();
@@ -75,7 +75,7 @@ public class PubClient extends ReceiverAdapter implements ConnectionListener {
                 if(line.startsWith("quit") || line.startsWith("exit")) {
                     break;
                 }
-                byte[] buf=String.format("%s: %s\n", name, line).getBytes();
+                byte[] buf=String.format("%s: %s%n", name, line).getBytes();
                 ((Client)client).send(buf, 0, buf.length);
             }
             catch(Exception e) {

--- a/src/org/jgroups/protocols/HDRS.java
+++ b/src/org/jgroups/protocols/HDRS.java
@@ -24,7 +24,7 @@ public class HDRS extends Protocol {
     public Object up(Event evt) {
         if(print_up && evt.getType() == Event.MSG) {
             Message msg=(Message)evt.getArg();
-            System.out.printf("-- [s] from %s (%d bytes): %s\n", msg.src(), msg.getLength(), msg.printHeaders());
+            System.out.printf("-- [s] from %s (%d bytes): %s%n", msg.src(), msg.getLength(), msg.printHeaders());
         }
         return up_prot.up(evt); // Pass up to the layer above us
     }
@@ -32,7 +32,7 @@ public class HDRS extends Protocol {
     public void up(MessageBatch batch) {
         if(print_up) {
             for(Message msg : batch)
-                System.out.printf("-- [b] from %s (%d bytes): %s\n", msg.src(), msg.getLength(), msg.printHeaders());
+                System.out.printf("-- [b] from %s (%d bytes): %s%n", msg.src(), msg.getLength(), msg.printHeaders());
         }
         if(!batch.isEmpty())
             up_prot.up(batch);
@@ -41,7 +41,7 @@ public class HDRS extends Protocol {
     public Object down(Event evt) {
         if(print_down && evt.getType() == Event.MSG) {
             Message msg=(Message)evt.getArg();
-            System.out.printf("-- to %s (%d bytes): %s\n", msg.dest(), msg.getLength(), msg.printHeaders());
+            System.out.printf("-- to %s (%d bytes): %s%n", msg.dest(), msg.getLength(), msg.printHeaders());
         }
 
         return down_prot.down(evt);  // Pass on to the layer below us

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -489,12 +489,12 @@ public class UDP extends TP {
         formatter.format("mcast_addr=%s, bind_addr=%s, ttl=%d", mcast_addr, bind_addr, ip_ttl);
 
         if(sock != null)
-            formatter.format("\nsock: bound to %s:%d, receive buffer size=%d, send buffer size=%d",
+            formatter.format("%nsock: bound to %s:%d, receive buffer size=%d, send buffer size=%d",
                              sock.getLocalAddress().getHostAddress(), sock.getLocalPort(),
                              sock.getReceiveBufferSize(), sock.getSendBufferSize());
 
         if(mcast_sock != null)
-            formatter.format("\nmcast_sock: bound to %s:%d, send buffer size=%d, receive buffer size=%d",
+            formatter.format("%nmcast_sock: bound to %s:%d, send buffer size=%d, receive buffer size=%d",
                              mcast_sock.getInterface().getHostAddress(), mcast_sock.getLocalPort(),
                              mcast_sock.getSendBufferSize(), mcast_sock.getReceiveBufferSize());
         return sb.toString();

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -370,7 +370,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
     public String dumpXmitTablesNumCurrentRows() {
         StringBuilder sb=new StringBuilder();
         for(Map.Entry<Address,Table<Message>> entry: xmit_table.entrySet())
-            sb.append(String.format("%s: %d\n", entry.getKey(), entry.getValue().getNumRows()));
+            sb.append(String.format("%s: %d%n", entry.getKey(), entry.getValue().getNumRows()));
         return sb.toString();
     }
 
@@ -435,7 +435,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
     }
 
     public String printStats() {
-        return String.format("\nStability messages received\n%s\n", printStabilityMessages());
+        return String.format("%nStability messages received%n%s%n", printStabilityMessages());
     }
 
 

--- a/src/org/jgroups/stack/GossipRouter.java
+++ b/src/org/jgroups/stack/GossipRouter.java
@@ -191,7 +191,7 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
                 Entry val2=entry2.getValue();
                 if(val2 == null)
                     continue;
-                sb.append(String.format("  %s: %s (client_addr: %s, uuid:%s)\n", val2.logical_name, val2.phys_addr, val2.client_addr, logical_addr));
+                sb.append(String.format("  %s: %s (client_addr: %s, uuid:%s)%n", val2.logical_name, val2.phys_addr, val2.client_addr, logical_addr));
             }
         }
         return sb.toString();
@@ -550,9 +550,9 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
         System.out.println("    -expiry <msecs>       - Time for closing idle connections. 0");
         System.out.println("                            means don't expire.");
         System.out.println();
-        System.out.printf("     -nio <true|false>     - Whether or not to use non-blocking connections (NIO)");
+        System.out.println("     -nio <true|false>     - Whether or not to use non-blocking connections (NIO)");
         System.out.println();
-        System.out.printf("     -suspect <true|false> - Whether or not to use send SUSPECT events when a conn is closed");
+        System.out.println("     -suspect <true|false> - Whether or not to use send SUSPECT events when a conn is closed");
         System.out.println();
     }
 }

--- a/src/org/jgroups/stack/RouterStubManager.java
+++ b/src/org/jgroups/stack/RouterStubManager.java
@@ -147,7 +147,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
     }
 
     public String print() {
-        return String.format("Stubs: %s\nReconnect list: %s", printStubs(), printReconnectList());
+        return String.format("Stubs: %s%nReconnect list: %s", printStubs(), printReconnectList());
     }
 
     public void run() {

--- a/src/org/jgroups/util/RequestTable.java
+++ b/src/org/jgroups/util/RequestTable.java
@@ -262,7 +262,7 @@ public class RequestTable<T> {
                 if(el != null) {
                     long hash=el.hashCode();
                     int small_idx=index(i, new_cap);
-                    sb.append(String.format("seqno %d: index: %d val: %d, index in %d-buffer: %d\n", i, index, hash, new_cap, small_idx));
+                    sb.append(String.format("seqno %d: index: %d val: %d, index in %d-buffer: %d%n", i, index, hash, new_cap, small_idx));
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275

Please let me know if you have any questions.

M-Ezzat