### PR TITLE
JGRP-2014 FILE_PING destination file name can include File.separator

### DIFF
--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -141,7 +141,7 @@ public class FILE_PING extends Discovery {
     protected static String addressToFilename(Address mbr) {
         String logical_name=UUID.get(mbr);
         return (addressAsString(mbr) + (logical_name != null? "." + logical_name + SUFFIX : SUFFIX))
-            .replace(File.separatorChar, '-');
+            .replace('/', '-');
     }
 
     protected void createRootDir() {


### PR DESCRIPTION
characters

Replace File.separatorChar with '/' to fix this issue on Windows