### PR TITLE
JGRP-2014 FILE_PING destination file name can include File.separator

### DIFF
--- a/src/org/jgroups/protocols/Discovery.java
+++ b/src/org/jgroups/protocols/Discovery.java
@@ -468,7 +468,7 @@ public abstract class Discovery extends Protocol {
                 out.write(phys_addr.toString().getBytes());
                 out.write(WHITESPACE);
 
-                out.write(data.isCoord()? "T\n".getBytes() : "F\n".getBytes());
+                out.write(data.isCoord()? String.format("T%n").getBytes() : String.format("F%n").getBytes());
             }
         }
         finally {

--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -141,8 +141,7 @@ public class FILE_PING extends Discovery {
     protected static String addressToFilename(Address mbr) {
         String logical_name=UUID.get(mbr);
         return (addressAsString(mbr) + (logical_name != null? "." + logical_name + SUFFIX : SUFFIX))
-          .replace(File.separatorChar, '-')
-          .replace('/', '-');
+          .replaceAll("[\0<>:\"/\\|?*]", "-");
     }
 
     protected void createRootDir() {


### PR DESCRIPTION
characters

Filter out all illegal filename characters in
FILE_PING.addressToFilename()
Use platform specific line endings when writing to a file