### PR TITLE
quid:HiddenFieldCheck - Local variables should not shadow class fields

### DIFF
--- a/src/org/jgroups/auth/Krb5Token.java
+++ b/src/org/jgroups/auth/Krb5Token.java
@@ -148,9 +148,9 @@ public class Krb5Token extends AuthToken {
     }
     
     private void validateRemoteServiceTicket(Krb5Token remoteToken) throws Exception {
-        byte[] remoteKrbServiceTicket = remoteToken.remoteKrbServiceTicket;
+        byte[] remoteKrbServiceTicketLocal = remoteToken.remoteKrbServiceTicket;
         
-        String clientPrincipalName = kerb5Utils.validateSecurityContext(subject, remoteKrbServiceTicket);
+        String clientPrincipalName = kerb5Utils.validateSecurityContext(subject, remoteKrbServiceTicketLocal);
         
         if (!clientPrincipalName.equals(this.client_principal_name))
             throw new Exception("Client Principal Names did not match");

--- a/src/org/jgroups/auth/sasl/FileWatchTask.java
+++ b/src/org/jgroups/auth/sasl/FileWatchTask.java
@@ -25,9 +25,9 @@ public class FileWatchTask extends TimerTask {
 
    @Override
    public void run() {
-      long modified = file.lastModified();
-      if (this.modified != modified) {
-         this.modified = modified;
+      long modifiedLocal = file.lastModified();
+      if (this.modified != modifiedLocal) {
+         this.modified = modifiedLocal;
          observer.fileChanged(file);
       }
    }

--- a/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
+++ b/src/org/jgroups/auth/sasl/SimpleAuthorizingCallbackHandler.java
@@ -113,9 +113,9 @@ public class SimpleAuthorizingCallbackHandler implements CallbackHandler {
             } else if (current instanceof PasswordCallback) {
                 responseCallbacks.add(current);
             } else if (current instanceof RealmCallback) {
-                String realm = ((RealmCallback) current).getDefaultText();
-                if (realm != null && !this.realm.equals(realm)) {
-                    throw new IOException("Invalid realm " + realm);
+                String realmLocal = ((RealmCallback) current).getDefaultText();
+                if (realmLocal != null && !this.realm.equals(realmLocal)) {
+                    throw new IOException("Invalid realm " + realmLocal);
                 }
                 responseCallbacks.add(current);
             } else {

--- a/src/org/jgroups/demos/ExecutionServiceDemo.java
+++ b/src/org/jgroups/demos/ExecutionServiceDemo.java
@@ -94,9 +94,9 @@ public class ExecutionServiceDemo {
 
         @Override
         public void writeTo(DataOutput out) throws Exception {
-            int size = buffer.limit() - buffer.position();
-            out.writeInt(size);
-            out.write(buffer.array(), buffer.position(), size);
+            int sizeLocal = buffer.limit() - buffer.position();
+            out.writeInt(sizeLocal);
+            out.write(buffer.array(), buffer.position(), sizeLocal);
         }
 
         @Override
@@ -307,10 +307,10 @@ public class ExecutionServiceDemo {
             else if(line.startsWith("size")) {
                 String thresholdSize = line.substring("size".length()).trim();
                 if (thresholdSize.length() > 0) {
-                    int size = Integer.parseInt(thresholdSize);
+                    int sizeLocal = Integer.parseInt(thresholdSize);
                     
-                    this.size = size;
-                    System.out.println("Changed sort threshold size to " + size);
+                    this.size = sizeLocal;
+                    System.out.println("Changed sort threshold size to " + sizeLocal);
                 }
                 else {
                     System.out.println("Threshold Size: " + size);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - Local variables should not shadow class fields

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.

M-Ezzat