### PR TITLE
squid:S2184 - Math operands should be cast before assignment

### DIFF
--- a/src/org/jgroups/Message.java
+++ b/src/org/jgroups/Message.java
@@ -859,7 +859,7 @@ public class Message implements Streamable {
     * @return The number of bytes for the marshalled message
     */
     public long size() {
-        long retval=Global.BYTE_SIZE   // leading byte
+        long retval=(long)Global.BYTE_SIZE   // leading byte
                 + Global.SHORT_SIZE;   // flags
         if(dest_addr != null)
             retval+=Util.size(dest_addr);

--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -251,7 +251,7 @@ public class StompConnection implements Runnable {
                 if (!isConnected() && reconnect) {
                     log.info("Reconnecting in "+timeout+"s.");
                     try {
-                        Thread.sleep(timeout * 1000);
+                        Thread.sleep((long)timeout * 1000);
                     }
                     catch (InterruptedException e1) {
                         // pass

--- a/src/org/jgroups/protocols/TCP.java
+++ b/src/org/jgroups/protocols/TCP.java
@@ -84,7 +84,7 @@ public class TCP extends BasicTCP {
                 log.warn("reaper_interval was 0, set it to %d", reaper_interval);
             }
             if(conn_expire_time == 0) {
-                conn_expire_time=1000 * 60 * 5;
+                conn_expire_time=(long) 1000 * 60 * 5;
                 log.warn("conn_expire_time was 0, set it to %d", conn_expire_time);
             }
             server.connExpireTimeout(conn_expire_time).reaperInterval(reaper_interval);

--- a/src/org/jgroups/protocols/TCP_NIO2.java
+++ b/src/org/jgroups/protocols/TCP_NIO2.java
@@ -112,7 +112,7 @@ public class TCP_NIO2 extends BasicTCP {
                 log.warn("reaper_interval was 0, set it to %d", reaper_interval);
             }
             if(conn_expire_time == 0) {
-                conn_expire_time=1000 * 60 * 5;
+                conn_expire_time=(long) 1000 * 60 * 5;
                 log.warn("conn_expire_time was 0, set it to %d", conn_expire_time);
             }
             server.connExpireTimeout(conn_expire_time).reaperInterval(reaper_interval);

--- a/src/org/jgroups/protocols/UNICAST3.java
+++ b/src/org/jgroups/protocols/UNICAST3.java
@@ -39,7 +39,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
 
     @Property(description="Time (in milliseconds) after which an idle incoming or outgoing connection is closed. The " +
       "connection will get re-established when used again. 0 disables connection reaping")
-    protected long    conn_expiry_timeout=60000 * 2;
+    protected long    conn_expiry_timeout=(long) 60000 * 2;
 
     @Property(description="Time (in ms) until a connection marked to be closed will get removed. 0 disables this")
     protected long    conn_close_timeout=10000;
@@ -56,7 +56,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
 
     @Property(description="Number of milliseconds after which the matrix in the retransmission table " +
       "is compacted (only for experts)",writable=false)
-    protected long    xmit_table_max_compaction_time=10 * 60 * 1000;
+    protected long    xmit_table_max_compaction_time= (long) 10 * 60 * 1000;
 
     // @Property(description="Max time (in ms) after which a connection to a non-member is closed")
     protected long    max_retransmit_time=60 * 1000L;

--- a/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
@@ -56,7 +56,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
     protected int                 max_pool=5;
 
     @Property(description="Keep alive for pool threads serving state requests")
-    protected long                pool_thread_keep_alive=20 * 1000;
+    protected long                pool_thread_keep_alive=(long) 20 * 1000;
 
 
 

--- a/src/org/jgroups/util/Table.java
+++ b/src/org/jgroups/util/Table.java
@@ -607,7 +607,7 @@ public class Table<T> implements Iterable<T> {
         int from=computeRow(low), to=computeRow(hr);
         int range=to - from +1;  // e.g. from=3, to=5, new_size has to be [3 .. 5] (=3)
 
-        int new_size=(int)Math.max(range * resize_factor, range +1);
+        int new_size=(int)Math.max( (double)range * resize_factor, (double) range +1 );
         new_size=Math.max(new_size, num_rows); // don't fall below the initial size defined
         if(new_size < matrix.length) {
             T[][] new_matrix=(T[][])new Object[new_size][];

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -1805,7 +1805,7 @@ public class Util {
      */
     public static List<Range> computeFragOffsets(int offset,int length,int frag_size) {
         List<Range> retval=new ArrayList<>();
-        long total_size=length + offset;
+        long total_size=(long)length + offset;
         int index=offset;
         int tmp_size=0;
         Range r;
@@ -2964,7 +2964,7 @@ public class Util {
             }
         }
 
-        long counter=Util.random(Short.MAX_VALUE * 2);
+        long counter=Util.random((long)Short.MAX_VALUE * 2);
         return retval + "-" + counter;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - Math operands should be cast before assignment

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2184

Please let me know if you have any questions.

M-Ezzat