### PR TITLE
squid:S2676 - Neither Math.abs nor negation should be used on numbers…

### DIFF
--- a/src/org/jgroups/demos/Draw.java
+++ b/src/org/jgroups/demos/Draw.java
@@ -179,9 +179,9 @@ public class Draw extends ReceiverAdapter implements ActionListener, ChannelList
 
 
     private Color selectColor() {
-        int red=Math.abs(random.nextInt()) % 255;
-        int green=Math.abs(random.nextInt()) % 255;
-        int blue=Math.abs(random.nextInt()) % 255;
+        int red=Math.abs(random.nextInt() % 255);
+        int green=Math.abs(random.nextInt() % 255);
+        int blue=Math.abs(random.nextInt() % 255);
         return new Color(red, green, blue);
     }
 

--- a/src/org/jgroups/demos/StompDraw.java
+++ b/src/org/jgroups/demos/StompDraw.java
@@ -86,9 +86,9 @@ public class StompDraw implements StompConnection.Listener, ActionListener {
 
 
     private Color selectColor() {
-        int red=Math.abs(random.nextInt()) % 255;
-        int green=Math.abs(random.nextInt()) % 255;
-        int blue=Math.abs(random.nextInt()) % 255;
+        int red=Math.abs(random.nextInt() % 255);
+        int green=Math.abs(random.nextInt() % 255);
+        int blue=Math.abs(random.nextInt() % 255);
         return new Color(red, green, blue);
     }
 

--- a/src/org/jgroups/demos/applets/DrawApplet.java
+++ b/src/org/jgroups/demos/applets/DrawApplet.java
@@ -134,9 +134,9 @@ public class DrawApplet extends Applet implements MouseMotionListener, ActionLis
 
 
     private void selectColor() {
-        red=Math.abs(random.nextInt()) % 255;
-        green=Math.abs(random.nextInt()) % 255;
-        blue=Math.abs(random.nextInt()) % 255;
+        red=Math.abs(random.nextInt() % 255);
+        green=Math.abs(random.nextInt() % 255);
+        blue=Math.abs(random.nextInt() % 255);
         default_color=new Color(red, green, blue);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2676 - Neither Math.abs nor negation should be used on numbers that could be MIN_VALUE

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2676

Please let me know if you have any questions.

M-Ezzat