### PR TITLE
squid:S1611 - Parentheses should be removed from a single lambda inpu…

### DIFF
--- a/src/org/jgroups/blocks/ReplicatedHashMap.java
+++ b/src/org/jgroups/blocks/ReplicatedHashMap.java
@@ -493,7 +493,7 @@ public class ReplicatedHashMap<K, V> extends
         // 2. Compute set of members that left: all that were in old_mbrs, but not in new_mbrs
         List<Address> left=old_mbrs.stream().filter(mbr -> !new_mbrs.contains(mbr)).collect(Collectors.toList());
 
-        notifs.forEach((notif) -> notif.viewChange(view, joined, left));
+        notifs.forEach( notif -> notif.viewChange(view, joined, left));
     }
 
 

--- a/src/org/jgroups/demos/RelayDemoRpc.java
+++ b/src/org/jgroups/demos/RelayDemoRpc.java
@@ -133,7 +133,7 @@ public class RelayDemoRpc extends ReceiverAdapter {
                 // mcasting the call to all local cluster members
                 RspList<Object> rsps=disp.callRemoteMethods(null, call,
                                                             new RequestOptions(ResponseMode.GET_ALL, RPC_TIMEOUT).anycasting(false));
-                rsps.entrySet().stream().forEach((entry) -> {
+                rsps.entrySet().stream().forEach( entry  -> {
                     Rsp<Object> val=entry.getValue();
                     System.out.println("<< " + val.getValue() + " from " + entry.getKey());
                 });

--- a/src/org/jgroups/protocols/TCPGOSSIP.java
+++ b/src/org/jgroups/protocols/TCPGOSSIP.java
@@ -149,7 +149,7 @@ public class TCPGOSSIP extends Discovery implements RouterStub.MembersNotificati
         }
 
         log.trace("fetching members from GossipRouter(s)");
-        stubManager.forEach((stub) -> {
+        stubManager.forEach( stub -> {
             try {
                 stub.getMembers(TCPGOSSIP.this.cluster_name, TCPGOSSIP.this);
             }

--- a/src/org/jgroups/protocols/TUNNEL.java
+++ b/src/org/jgroups/protocols/TUNNEL.java
@@ -236,7 +236,7 @@ public class TUNNEL extends TP implements RouterStub.StubReceiver {
     private class DefaultTUNNELPolicy implements TUNNELPolicy {
 
         public void sendToAllMembers(final String group, final byte[] data, final int offset, final int length) throws Exception {
-            stubManager.forAny((stub) -> {
+            stubManager.forAny( stub -> {
                 try {
                     if(log.isTraceEnabled())
                         log.trace("sent a message to all members, GR used %s", stub.gossipRouterAddress());
@@ -249,7 +249,7 @@ public class TUNNEL extends TP implements RouterStub.StubReceiver {
         }
 
         public void sendToSingleMember(final String group, final Address dest, final byte[] data, final int offset, final int length) throws Exception {
-            stubManager.forAny((stub) -> {
+            stubManager.forAny( stub -> {
                 try {
                     if(log.isTraceEnabled())
                         log.trace("sent a message to all members, GR used %s", stub.gossipRouterAddress());

--- a/src/org/jgroups/protocols/UNICAST3.java
+++ b/src/org/jgroups/protocols/UNICAST3.java
@@ -128,7 +128,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
 
     protected static final Message         DUMMY_OOB_MSG=new Message().setFlag(Message.Flag.OOB);
 
-    protected final Predicate<Message>     drop_oob_and_dont_loopback_msgs_filter=(msg) ->
+    protected final Predicate<Message>     drop_oob_and_dont_loopback_msgs_filter= msg ->
       msg != null && msg != DUMMY_OOB_MSG
         && (!msg.isFlagSet(Message.Flag.OOB) || msg.setTransientFlagIfAbsent(Message.TransientFlag.OOB_DELIVERED))
         && !(msg.isTransientFlagSet(Message.TransientFlag.DONT_LOOPBACK) && local_addr != null && local_addr.equals(msg.src()));

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -135,7 +135,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
     protected static final Message         DUMMY_OOB_MSG=new Message().setFlag(Message.Flag.OOB);
 
     // Accepts messages which are (1) non-null, (2) no DUMMY_OOB_MSGs and (3) not OOB_DELIVERED
-    protected final Predicate<Message> no_dummy_and_no_oob_delivered_msgs_and_no_dont_loopback_msgs=(msg) ->
+    protected final Predicate<Message> no_dummy_and_no_oob_delivered_msgs_and_no_dont_loopback_msgs= msg ->
       msg != null && msg != DUMMY_OOB_MSG
         && (!msg.isFlagSet(Message.Flag.OOB) || msg.setTransientFlagIfAbsent(Message.TransientFlag.OOB_DELIVERED))
         && !(msg.isTransientFlagSet(Message.TransientFlag.DONT_LOOPBACK) && this.local_addr != null && this.local_addr.equals(msg.getSrc()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1611 - Parentheses should be removed from a single lambda input parameter when its type is inferred

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1611

Please let me know if you have any questions.

M-Ezzat