### PR TITLE
JGRP-2022 XSD schemas do not properly validate

### DIFF
--- a/conf/EncryptKeyStore.xml
+++ b/conf/EncryptKeyStore.xml
@@ -3,8 +3,8 @@
 <!-- input file: jGroupsEncryptedServerConfig.xml -->
  
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/EncryptNoKeyStore.xml
+++ b/conf/EncryptNoKeyStore.xml
@@ -3,8 +3,8 @@
 <!-- input file: jGroupsEncryptedServerConfig.xml -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/auth_X509.xml
+++ b/conf/auth_X509.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/auth_fixedlist.xml
+++ b/conf/auth_fixedlist.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP bind_addr="localhost"
          bind_port="1025"/>
     <PING            />

--- a/conf/auth_krb5.xml
+++ b/conf/auth_krb5.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING />
     <MERGE3 />

--- a/conf/auth_md5.xml
+++ b/conf/auth_md5.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/auth_regex.xml
+++ b/conf/auth_regex.xml
@@ -8,8 +8,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/auth_simple.xml
+++ b/conf/auth_simple.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/encrypt-entire-message.xml
+++ b/conf/encrypt-entire-message.xml
@@ -2,9 +2,9 @@
 <!-- This encrypts the entire message, even UNICAST3 and NAKACK headers (to reveal sequence numbers).
      Note that ENCRYPT could be placed even lower, e.g. just above UDP -->
 
-<config xmlns="urn:org:jgroups"
+<config xmlns="urn:org.jgroups:jgroups:3.6"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/encrypt.xml
+++ b/conf/encrypt.xml
@@ -3,8 +3,8 @@
 <!-- input file: encrypt.old.xml -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/execution-service.xml
+++ b/conf/execution-service.xml
@@ -5,8 +5,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/external.xml
+++ b/conf/external.xml
@@ -1,0 +1,27 @@
+
+<!-- Dummy file to check parsing of external schemas -->
+
+<config xmlns="urn:org.jgroups:jgroups:3.6"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
+    <UDP mcast_port="${jgroups.udp.mcast_port:45588}" />
+    <relay.RELAY2>
+        <RelayConfiguration xmlns:relay="urn:org.jgroups:relay:3.6">
+            <relay:sites>
+                <relay:site name="">
+                    <relay:bridges />
+                </relay:site>
+            </relay:sites>
+        </RelayConfiguration>
+    </relay.RELAY2>
+    <FORK>
+        <fork-stacks xmlns:fork="urn:org.jgroups:fork:3.6">
+            <fork:stack id="foo">
+                <PING />
+            </fork:stack>
+            <fork:stack id="bar">
+                <MPING />
+            </fork:stack>
+        </fork-stacks>
+    </FORK>
+</config>

--- a/conf/fast.xml
+++ b/conf/fast.xml
@@ -8,8 +8,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP
          mcast_port="${jgroups.udp.mcast_port:45588}"
          ip_ttl="0"

--- a/conf/flush-tcp.xml
+++ b/conf/flush-tcp.xml
@@ -6,8 +6,8 @@
         
 -->        
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <TCP bind_port="7800"/>
     <TCPPING initial_hosts="${jgroups.tcpping.initial_hosts:localhost[7800],localhost[7801]}"
              port_range="1"/>

--- a/conf/flush-udp.xml
+++ b/conf/flush-udp.xml
@@ -4,8 +4,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/fork-stacks.xml
+++ b/conf/fork-stacks.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 
-
-<fork-stacks xmlns="fork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="fork fork-stacks.xsd">
+<fork-stacks xmlns="urn:org.jgroups:fork:3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="urn:org.jgroups:fork:3.6 http://www.jgroups.org/schema/fork-3.6.xsd">
 
     <fork-stack id="counter">
         <config>

--- a/conf/fork-stacks.xml
+++ b/conf/fork-stacks.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0"?>
 
-<fork-stacks xmlns="urn:org.jgroups:fork:3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<fork:stacks xmlns:fork="urn:org.jgroups:fork:3.6"
+             xmlns="urn:org.jgroups:jgroups:3.6"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="urn:org.jgroups:fork:3.6 http://www.jgroups.org/schema/fork-3.6.xsd">
 
-    <fork-stack id="counter">
-        <config>
-            <COUNTER bypass_bundling="true"/>
-            <COMPRESS/>
-        </config>
-    </fork-stack>
+    <fork:stack id="counter">
+        <COUNTER bypass_bundling="true"/>
+        <COMPRESS/>
+    </fork:stack>
 
-    <fork-stack id="locking">
-        <config>
-            <CENTRAL_LOCK num_backups="2"/>
-        </config>
-    </fork-stack>
+    <fork:stack id="locking">
+        <CENTRAL_LOCK num_backups="2"/>
+    </fork:stack>
 
 
-</fork-stacks>
+</fork:stacks>

--- a/conf/fork-stacks.xsd
+++ b/conf/fork-stacks.xsd
@@ -1,11 +1,12 @@
 <?xml version="1.0"?>
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="fork"
-           elementFormDefault="qualified" attributeFormDefault="qualified"
-           xmlns:jgroups="urn:org:jgroups">
+           targetNamespace="urn:org.jgroups:fork:3.6"
+           elementFormDefault="qualified" attributeFormDefault="unqualified"
+           xmlns="urn:org.jgroups:fork:3.6"
+           xmlns:jgroups="urn:org.jgroups:jgroups:3.6">
 
-   <xs:import namespace="urn:org:jgroups" schemaLocation="http://www.jgroups.org/schema/jgroups.xsd"/>
+    <xs:import namespace="urn:org.jgroups:jgroups:3.6" schemaLocation="http://www.jgroups.org/schema/jgroups-3.6.xsd"/>
 
     <xs:complexType name="ForkStack">
         <xs:sequence>

--- a/conf/fork.xsd
+++ b/conf/fork.xsd
@@ -9,19 +9,19 @@
     <xs:import namespace="urn:org.jgroups:jgroups:3.6" schemaLocation="http://www.jgroups.org/schema/jgroups-3.6.xsd"/>
 
     <xs:complexType name="ForkStack">
-        <xs:sequence>
-            <xs:element name="config" type="jgroups:ConfigType"/>
-        </xs:sequence>
-        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:complexContent>
+            <xs:extension base="jgroups:ConfigType">
+                <xs:attribute name="id" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="ForkStacksType">
-        <xs:sequence minOccurs="1" maxOccurs="unbounded">
-            <xs:element name="fork-stack" type="ForkStack"/>
+        <xs:sequence >
+            <xs:element name="stack" type="ForkStack" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="fork-stacks" type="ForkStacksType"/>
-
+    <xs:element name="stacks" type="ForkStacksType"/>
 
 </xs:schema>

--- a/conf/mping.xml
+++ b/conf/mping.xml
@@ -6,8 +6,8 @@ Author: Bela Ban
  -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <TCP bind_port="7800"
          sock_conn_timeout="500"/>
     <MPING receive_on_all_interfaces="true"

--- a/conf/relay.xsd
+++ b/conf/relay.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema attributeFormDefault="qualified"
+<xs:schema attributeFormDefault="unqualified"
            elementFormDefault="qualified"
-           targetNamespace="urn:jgroups:relay:1.0"
+           targetNamespace="urn:org.jgroups:relay:3.6"
+           xmlns="urn:org.jgroups:relay:3.6"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:complexType name="RelayConfigurationType">

--- a/conf/relay1.xml
+++ b/conf/relay1.xml
@@ -8,9 +8,9 @@
      **** we're trying to simplify it
      ****
  -->
-<RelayConfiguration xmlns="urn:jgroups:relay:1.0"
+<RelayConfiguration xmlns="urn:org.jgroups:relay:3.6"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="urn:jgroups:relay:1.0 relay.xsd">
+                    xsi:schemaLocation="urn:org.jgroups:relay:3.6 http://www.jgroups.org/schema/relay-3.6.xsd">
 
     <sites>
         <site name="lon">

--- a/conf/relay2.xml
+++ b/conf/relay2.xml
@@ -8,9 +8,9 @@
     **** we're trying to simplify it
     ****
 -->
-<RelayConfiguration xmlns="urn:jgroups:relay:1.0"
+<RelayConfiguration xmlns="urn:org.jgroups:relay:3.6"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="urn:jgroups:relay:1.0 relay.xsd">
+                    xsi:schemaLocation="urn:org.jgroups:relay:3.6 http://www.jgroups.org/schema/relay-3.6.xsd">
 
     <sites>
         <site name="lon">

--- a/conf/rules.xml
+++ b/conf/rules.xml
@@ -4,8 +4,8 @@
      Sample config file for SUPERVISOR
  -->
 
-<rules xmlns="urn:jgroups:rules:1.0"
+<rules xmlns="urn:org.jgroups:rules:3.6"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="urn:jgroups:rules:1.0 rules.xsd">
+       xsi:schemaLocation="urn:org.jgroups:rules:3.6 http://www.jgroups.org/schema/rules-3.6.xsd">
     <rule name="rule1" class="org.jgroups.protocols.rules.CheckFDMonitor" interval="1000"/>
 </rules>

--- a/conf/rules.xsd
+++ b/conf/rules.xsd
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema attributeFormDefault="qualified" elementFormDefault="qualified"
-           targetNamespace="urn:jgroups:rules:1.0"
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="urn:org.jgroups:rules:3.6"
+           xmlns="urn:org.jgroups:rules:3.6"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="rules" type="urn:rulesType" xmlns:urn="urn:jgroups:rules:1.0">
+  <xs:element name="rules" type="rulesType">
     <xs:annotation>
       <xs:documentation>Sample config file for SUPERVISOR</xs:documentation>
     </xs:annotation>

--- a/conf/sequencer.xml
+++ b/conf/sequencer.xml
@@ -6,8 +6,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP/>
     <PING/>
     <MERGE3/>

--- a/conf/tcp-nio.xml
+++ b/conf/tcp-nio.xml
@@ -6,8 +6,8 @@
     author: Bela Ban
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <TCP_NIO2 bind_port="7800"
          recv_buf_size="${tcp.recv_buf_size:5M}"
          send_buf_size="${tcp.send_buf_size:5M}"

--- a/conf/tcp.xml
+++ b/conf/tcp.xml
@@ -6,8 +6,8 @@
     author: Bela Ban
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <TCP bind_port="7800"
          recv_buf_size="${tcp.recv_buf_size:5M}"
          send_buf_size="${tcp.send_buf_size:5M}"

--- a/conf/tcpgossip.xml
+++ b/conf/tcpgossip.xml
@@ -7,8 +7,8 @@
 	<!-- input file: tcpgossip.old.xml -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
 	<TCP bind_port="7800"
 		use_send_queues="true"
 		sock_conn_timeout="300"/>

--- a/conf/toa.xml
+++ b/conf/toa.xml
@@ -6,8 +6,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP
          mcast_port="${jgroups.udp.mcast_port:45588}"
          tos="8"

--- a/conf/tunnel.xml
+++ b/conf/tunnel.xml
@@ -5,8 +5,8 @@
 <!-- input file: tunnel.old.xml -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
   
     <TUNNEL gossip_router_hosts="${jgroups.tunnel.gossip_router_hosts:localhost[12001]}"/>
     <PING/>

--- a/conf/udp-largecluster.xml
+++ b/conf/udp-largecluster.xml
@@ -6,8 +6,8 @@
 -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:org:jgroups"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xmlns="urn:org.jgroups:jgroups:3.6"
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
 
     <UDP mcast_addr="${jgroups.udp.mcast_addr:239.9.9.9}"
          mcast_port="${jgroups.udp.mcast_port:45588}"

--- a/conf/udp.xml
+++ b/conf/udp.xml
@@ -5,9 +5,9 @@
   author: Bela Ban
 -->
 
-<config xmlns="urn:org:jgroups"
+<config xmlns="urn:org.jgroups:jgroups:3.6"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP
          mcast_port="${jgroups.udp.mcast_port:45588}"
          ip_ttl="4"

--- a/doc/design/FORK.txt
+++ b/doc/design/FORK.txt
@@ -122,12 +122,14 @@ Declarative configuration would look like this:
     <MFC/>
     <UFC/>
     <FORK>
-       <fork-stack id="1">
-          <CENTRAL_LOCK num_backups="2" ... />
-       </fork-stack>
-       <fork-stack id="2">
-          <COUNTER bypass_bundling="true" timeout="5000" ... />
-       </fork-stack>
+       <fork-stacks xmlns:fork="urn:org.jgroups:fork:3.6">
+          <fork:stack id="1">
+             <CENTRAL_LOCK num_backups="2" ... />
+          </fork:stack>
+          <fork:stack id="2">
+             <COUNTER bypass_bundling="true" timeout="5000" ... />
+          </fork:stack>
+       </fork-stacks>
     </FORK>
     <FRAG2/>
     <TOA/>

--- a/doc/manual/advanced.adoc
+++ b/doc/manual/advanced.adoc
@@ -2943,21 +2943,17 @@ FORK refers to an external file to configure its fork stacks:
 [source,xml]
 ----
 
-<fork-stacks xmlns="fork-stacks">
-    <fork-stack id="counter">
-        <config>
-            <COUNTER bypass_bundling="true"/>
-        </config>
-    </fork-stack>
+<fork:stacks xmlns="fork-stacks">
+    <fork:stack id="counter">
+         <COUNTER bypass_bundling="true"/>
+    </fork:stack>
 
-    <fork-stack id="lock">
-         <config>
-             <CENTRAL_LOCK num_backups="2"/>
-             <STATS/>
-         </config>
-    </fork-stack>
+    <fork:stack id="lock">
+         <CENTRAL_LOCK num_backups="2"/>
+         <STATS/>
+    </fork:stack>
 
-</fork-stacks>
+</fork:stacks>
             
 ----
 

--- a/doc/manual/advanced.adoc
+++ b/doc/manual/advanced.adoc
@@ -99,9 +99,9 @@ A typical protocol stack configuration using UDP is:
 [source,xml]
 ----
 
-<config xmlns="urn:org:jgroups"
+<config xmlns="urn:org.jgroups:jgroups:3.6"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP
          mcast_port="${jgroups.udp.mcast_port:45588}"
          ucast_recv_buf_size="20M"
@@ -1614,22 +1614,22 @@ The config property points to an XML file which defines the setup of the sites, 
 [source,xml]
 ----
 
-<RelayConfiguration xmlns="urn:jgroups:relay:1.0">
+<RelayConfiguration xmlns="urn:org.jgroups:relay:3.6">
 
     <sites>
-        <site name="lon" id="0">
+        <site name="lon">
             <bridges>
                 <bridge config="/home/bela/global.xml" name="global"/>
             </bridges>
         </site>
 
-        <site name="nyc" id="1">
+        <site name="nyc">
             <bridges>
                 <bridge config="/home/bela/global.xml" name="global"/>
             </bridges>
         </site>
 
-        <site name="sfo" id="2">
+        <site name="sfo">
             <bridges>
                 <bridge name="global" config="/home/bela/global.xml"/>
             </bridges>
@@ -2227,7 +2227,7 @@ All rules to be installed in SUPERVISOR are listed in an XML file, e.g. rules.xm
 [source,xml]
 ----
 
-<rules xmlns="urn:jgroups:rules:1.0">
+<rules xmlns="urn:org.jgroups:rules:3.6">
      <rule name="rule1" class="org.jgroups.protocols.rules.CheckFDMonitorRule"
            interval="1000"/>
 </rules>

--- a/doc/manual/api.adoc
+++ b/doc/manual/api.adoc
@@ -408,9 +408,9 @@ A sample XML configuration looks like this (edited from `udp.xml`):
 
 [source,xml]
 ----
-<config xmlns="urn:org:jgroups"
+<config xmlns="urn:org.jgroups:jgroups:3.6"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+        xsi:schemaLocation="urn:org.jgroups:jgroups:3.6 http://www.jgroups.org/schema/jgroups-3.6.xsd">
     <UDP
          mcast_port="${jgroups.udp.mcast_port:45588}"
          ucast_recv_buf_size="20M"

--- a/src/org/jgroups/annotations/XmlInclude.java
+++ b/src/org/jgroups/annotations/XmlInclude.java
@@ -8,13 +8,13 @@ import java.lang.annotation.Target;
 /**
  * Used to include other schemas by {@link org.jgroups.util.XMLSchemaGenerator}. Example:
  * <pre>
- *     {@literal @}XmlInclude(schema="relay.xsd",type=Type.IMPORT,namespace="urn:jgroups:relay:1.0",alias="relay")
+ *     {@literal @}XmlInclude(schema="relay.xsd",type=Type.IMPORT,namespace="urn:org.jgroups:relay:3.6",alias="relay")
  * </pre>
  * results in the following include in the schema element:
  * <pre>
- *     &lt;xs:schema... xmlns:relay="urn:jgroups:relay:1.0" /&gt;
+ *     &lt;xs:schema... xmlns:relay="urn:org.jgroups:relay:3.6" /&gt;
  *     ...
- *     &lt;xs:import schemaLocation="fork-stacks.xsd" namespace="urn:jgroups:relay:1.0" /&gt;
+ *     &lt;xs:import schemaLocation="fork-stacks.xsd" namespace="urn:org.jgroups:relay:3.6" /&gt;
  * </pre>
  * @author Bela Ban
  * @since  3.5

--- a/src/org/jgroups/annotations/XmlInclude.java
+++ b/src/org/jgroups/annotations/XmlInclude.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
  * <pre>
  *     &lt;xs:schema... xmlns:relay="urn:org.jgroups:relay:3.6" /&gt;
  *     ...
- *     &lt;xs:import schemaLocation="fork-stacks.xsd" namespace="urn:org.jgroups:relay:3.6" /&gt;
+ *     &lt;xs:import schemaLocation="fork.xsd" namespace="urn:org.jgroups:relay:3.6" /&gt;
  * </pre>
  * @author Bela Ban
  * @since  3.5

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  * @author Bela Ban
  * @since  3.4
  */
-@XmlInclude(schema="fork-stacks.xsd",type=XmlInclude.Type.IMPORT,namespace="fork",alias="fork")
+@XmlInclude(schema="fork-stacks.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:fork:3.6",alias="fork")
 @XmlElement(name="fork-stacks",type="fork:ForkStacksType")
 @MBean(description="Implementation of FORK protocol")
 public class FORK extends Protocol {

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  * @author Bela Ban
  * @since  3.4
  */
-@XmlInclude(schema="fork-stacks.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:fork:3.6",alias="fork")
+@XmlInclude(schema="http://www.jgroups.org/schema/fork-3.6.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:fork:3.6",alias="fork")
 @XmlElement(name="fork-stacks",type="fork:ForkStacksType")
 @MBean(description="Implementation of FORK protocol")
 public class FORK extends Protocol {

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Bela Ban
  * @since 3.2
  */
-@XmlInclude(schema="relay.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:jgroups:relay:1.0",alias="relay")
+@XmlInclude(schema="relay.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:relay:3.6",alias="relay")
 @XmlElement(name="RelayConfiguration",type="relay:RelayConfigurationType")
 @MBean(description="RELAY2 protocol")
 public class RELAY2 extends Protocol {

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Bela Ban
  * @since 3.2
  */
-@XmlInclude(schema="relay.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:relay:3.6",alias="relay")
+@XmlInclude(schema="http://www.jgroups.org/schema/relay-3.6.xsd",type=XmlInclude.Type.IMPORT,namespace="urn:org.jgroups:relay:3.6",alias="relay")
 @XmlElement(name="RelayConfiguration",type="relay:RelayConfigurationType")
 @MBean(description="RELAY2 protocol")
 public class RELAY2 extends Protocol {

--- a/src/org/jgroups/util/XMLSchemaGenerator.java
+++ b/src/org/jgroups/util/XMLSchemaGenerator.java
@@ -85,7 +85,7 @@ public class XMLSchemaGenerator {
 
             Element anyProtocol = xmldoc.createElement("xs:any");
             anyProtocol.setAttribute("namespace", "##other");
-            complexType.appendChild(anyProtocol);
+            allType.appendChild(anyProtocol);
 
             Element xsElement = xmldoc.createElement("xs:element");
             xsElement.setAttribute("name", "config");

--- a/src/org/jgroups/util/XMLSchemaGenerator.java
+++ b/src/org/jgroups/util/XMLSchemaGenerator.java
@@ -62,12 +62,16 @@ public class XMLSchemaGenerator {
         try {
             FileWriter fw = new FileWriter(f, false);
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
             DocumentBuilder builder = factory.newDocumentBuilder();
             DOMImplementation impl = builder.getDOMImplementation();
-            Document xmldoc = impl.createDocument("http://www.w3.org/2001/XMLSchema", "xs:schema", null);
-            xmldoc.getDocumentElement().setAttribute("targetNamespace", "urn:org:jgroups");
+            String targetNamespace = "urn:org.jgroups:jgroups:" + Version.major + "." + Version.minor;
+            Document xmldoc = impl.createDocument(targetNamespace, "xs:schema", null);
+            xmldoc.getDocumentElement().setAttribute("targetNamespace", targetNamespace);
+            xmldoc.getDocumentElement().setAttribute("xmlns", targetNamespace);
+            xmldoc.getDocumentElement().setAttribute("xmlns:xs", "http://www.w3.org/2001/XMLSchema");
             xmldoc.getDocumentElement().setAttribute("elementFormDefault", "qualified");
-            xmldoc.getDocumentElement().setAttribute("attributeFormDefault", "qualified");
+            xmldoc.getDocumentElement().setAttribute("attributeFormDefault", "unqualified");
 
             Element complexType = xmldoc.createElement("xs:complexType");
             complexType.setAttribute("name", "ConfigType");
@@ -78,6 +82,10 @@ public class XMLSchemaGenerator {
             complexType.appendChild(allType);
 
             generateProtocolSchema(xmldoc, allType, PACKAGES);
+
+            Element anyProtocol = xmldoc.createElement("xs:any");
+            anyProtocol.setAttribute("namespace", "##other");
+            complexType.appendChild(anyProtocol);
 
             Element xsElement = xmldoc.createElement("xs:element");
             xsElement.setAttribute("name", "config");
@@ -167,7 +175,7 @@ public class XMLSchemaGenerator {
     }
 
     private static Element createXMLTree(Document xmldoc, Class<?> clazz, String pkgname) throws Exception {
-
+        Set<String> generatedAttributes = new HashSet<String>();
         Element classElement = xmldoc.createElement("xs:element");
         String elementName = pkgname + "." + clazz.getSimpleName();
         if(elementName == null || elementName.isEmpty()) {
@@ -204,6 +212,7 @@ public class XMLSchemaGenerator {
                     attributeElement.setAttribute("name", attr);
                     attributeElement.setAttribute("type", "xs:string");
                     complexType.appendChild(attributeElement);
+                    generatedAttributes.add(attr);
                 }
             }
         }
@@ -224,6 +233,11 @@ public class XMLSchemaGenerator {
                     if(property == null || property.isEmpty()) {
                         throw new IllegalArgumentException("Cannot create empty attribute name for element xs:attribute, field is " + field);
                     }
+                    if (generatedAttributes.contains(property)) {
+                        continue;
+                    }
+                    generatedAttributes.add(property);
+
                     Element attributeElement = xmldoc.createElement("xs:attribute");
                     attributeElement.setAttribute("name", property);
 
@@ -254,6 +268,11 @@ public class XMLSchemaGenerator {
                 if (name.length() < 1) {
                     name = Util.methodNameToAttributeName(method.getName());
                 }
+                if (generatedAttributes.contains(name)) {
+                    continue;
+                }
+                generatedAttributes.add(name);
+
                 Element attributeElement = xmldoc.createElement("xs:attribute");
                 attributeElement.setAttribute("name", name);
                 attributeElement.setAttribute("type", "xs:string");


### PR DESCRIPTION
All schemas now use namespace urn:org.jgroups:SOMETHING:VERSION where
SOMETHING is one of jgroups, fork and relay, and VERSION is aligned with
major.minor JGroups version and published on
http://www.jgroups.org/schema/SOMETHING-VERSION.xsd (it is not necessary
to publish new schema if it has not changed since the previous version,
though; older schema can be still used even in newer version).
Note that once published (in x.x.0 release), the schema should not be further
changed until next minor version.

https://issues.jboss.org/browse/JGRP-2022