### PR TITLE
JGRP-2072 UFC and MFC headers get mixed up

### DIFF
--- a/src/org/jgroups/protocols/FlowControl.java
+++ b/src/org/jgroups/protocols/FlowControl.java
@@ -41,7 +41,7 @@ public abstract class FlowControl extends Protocol {
      * a REPLENISHMENT request to the members from which we expect credits. A value <= 0 means to wait forever.
      */
     @Property(description="Max time (in ms) to block")
-    protected long max_block_time=5000;
+    protected long max_block_time=500;
 
     /**
      * Defines the max number of milliseconds for a message to block before being sent, based on the length of

--- a/src/org/jgroups/protocols/MFC.java
+++ b/src/org/jgroups/protocols/MFC.java
@@ -2,6 +2,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.Address;
 import org.jgroups.Event;
+import org.jgroups.Header;
 import org.jgroups.Message;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
@@ -36,6 +37,8 @@ import java.util.concurrent.TimeUnit;
  */
 @MBean(description="Simple flow control protocol based on a credit system")
 public class MFC extends FlowControl {
+    protected final static FcHeader MFC_REPLENISH_HDR = new FcHeader(FcHeader.REPLENISH);
+    protected final static FcHeader MFC_CREDIT_REQUEST_HDR = new FcHeader(FcHeader.CREDIT_REQUEST);
 
     
     
@@ -120,7 +123,15 @@ public class MFC extends FlowControl {
         return down_prot.down(evt);
     }
 
+    @Override
+    protected Header getReplenishHeader() {
+        return MFC_REPLENISH_HDR;
+    }
 
+    @Override
+    protected Header getCreditRequestHeader() {
+        return MFC_CREDIT_REQUEST_HDR;
+    }
 
 
     protected synchronized boolean needToSendCreditRequest() {

--- a/src/org/jgroups/protocols/UFC.java
+++ b/src/org/jgroups/protocols/UFC.java
@@ -2,6 +2,7 @@ package org.jgroups.protocols;
 
 import org.jgroups.Address;
 import org.jgroups.Event;
+import org.jgroups.Header;
 import org.jgroups.Message;
 import org.jgroups.annotations.MBean;
 import org.jgroups.annotations.ManagedAttribute;
@@ -35,7 +36,9 @@ import java.util.Map;
  */
 @MBean(description="Simple flow control protocol based on a credit system")
 public class UFC extends FlowControl {
-    
+    protected final static FcHeader UFC_REPLENISH_HDR = new FcHeader(FcHeader.REPLENISH);
+    protected final static FcHeader UFC_CREDIT_REQUEST_HDR = new FcHeader(FcHeader.CREDIT_REQUEST);
+
     /**
      * Map<Address,Long>: keys are members, values are credits left. For each send,
      * the number of credits is decremented by the message size
@@ -133,6 +136,16 @@ public class UFC extends FlowControl {
 
         // send message - either after regular processing, or after blocking (when enough credits available again)
         return down_prot.down(evt);
+    }
+
+    @Override
+    protected Header getReplenishHeader() {
+        return UFC_REPLENISH_HDR;
+    }
+
+    @Override
+    protected Header getCreditRequestHeader() {
+        return UFC_CREDIT_REQUEST_HDR;
     }
 
 

--- a/src/org/jgroups/util/CreditMap.java
+++ b/src/org/jgroups/util/CreditMap.java
@@ -2,6 +2,8 @@ package org.jgroups.util;
 
 import org.jgroups.Address;
 import org.jgroups.annotations.GuardedBy;
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -14,6 +16,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Bela Ban
  */
 public class CreditMap {
+    protected static final Log log = LogFactory.getLog(CreditMap.class);
     protected final long              max_credits;
 
     @GuardedBy("lock")
@@ -141,6 +144,7 @@ public class CreditMap {
             if(timeout <= 0)
                 return false;
 
+            log.trace("Waiting for credits: %d requested, %s - %d available", credits, this.credits, accumulated_credits);
             long start=System.nanoTime();
             try {
                 credits_available.await(timeout, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2072

Create separate FcHeader instances for UFC and MFC.

More of a workaround than a proper fix: the message includes the protocol id, not just the header id, so there should be no way to confuse the headers.