### PR TITLE
Ignore lock requests from members not known in our current view

### DIFF
--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -219,6 +219,11 @@ abstract public class Locking extends Protocol {
                 if(hdr == null)
                     break;
 
+                if (null != view && !view.containsMember(msg.getSrc())) {
+                    log.error(String.format("Received locking event from '%s' but member is not present in the current view - ignoring request"));
+                    return null;
+                }                
+                
                 Request req=null;
                 try {
                     req=Util.streamableFromBuffer(Request.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());


### PR DESCRIPTION
This fixes a (rare) bug we had on cluster splits/merges where two nodes used the same lock but where not (yet) present in the current view. This caused deadlocks. Ignoring requests from members not in the current view fixed the problem. It only happens when using UDP as transport protocol.

I tried to create an isolated testcase for this but failed to do so. I can't properly determine if there are side effects with this patch but as far as I can tell there shouldnt be any.