### PR TITLE
Remove unaccessible staging repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,21 +84,6 @@
         </repository>
 
         <repository>
-            <id>jboss-releases-repository</id>
-            <name>JBoss Public Maven Repository Staging</name>
-            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>interval:120</updatePolicy>
-            </snapshots>
-        </repository>
-
-        <repository>
             <id>jboss-snapshots-repository</id>
             <name>JBoss Nexus snapshots repository</name>
             <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>


### PR DESCRIPTION
The maven build is broken (mvn install), because https://repository.jboss.org/nexus/service/local/staging/deploy/maven2 cannot be accessed (I don't know why not, haven't found any information about that repo online). JGroups builds fine without it, though.