### PR TITLE
NullPointerException from COUNTER protocol

### DIFF
--- a/src/org/jgroups/protocols/COUNTER.java
+++ b/src/org/jgroups/protocols/COUNTER.java
@@ -888,7 +888,6 @@ public class COUNTER extends Protocol {
 
         public void readFrom(DataInput in) throws Exception {
             int len=in.readInt();
-            if(len == 0) return;
             names=readReconciliationNames(in, len);
             values=readReconciliationLongs(in, len);
             versions=readReconciliationLongs(in,len);
@@ -1060,7 +1059,6 @@ public class COUNTER extends Protocol {
 
         public void readFrom(DataInput in) throws Exception {
             int len=in.readInt();
-            if(len == 0) return;
             names=readReconciliationNames(in, len);
             values=readReconciliationLongs(in, len);
             versions=readReconciliationLongs(in,len);


### PR DESCRIPTION
I was planning to submit a Jira issue with the description for this pull request, but my JBoss Dev account still isn't activated. Anyway, we encountered NullPointerExceptions from the COUNTER protocol in situations where the cluster is split up.

JGroups version: 3.6.10.Final

```
(...)
13:49:29.200 145924 [Incoming-2,matthijs,matthijsws-17469] ERROR org.jgroups.protocols.COUNTER - JGRP000175: failed handling message
java.lang.NullPointerException: null
	at org.jgroups.protocols.COUNTER$ReconcileRequest.toString(COUNTER.java:897) ~[jgroups-3.6.10.Final.jar:3.6.10.Final]
	at java.lang.String.valueOf(String.java:2994) ~[na:1.8.0_91]
	at java.lang.StringBuilder.append(StringBuilder.java:131) ~[na:1.8.0_91]
	at org.jgroups.protocols.COUNTER.up(COUNTER.java:181) ~[jgroups-3.6.10.Final.jar:3.6.10.Final]
	(...)
	at org.jgroups.protocols.TP.passMessageUp(TP.java:1601) [jgroups-3.6.10.Final.jar:3.6.10.Final]
	at org.jgroups.protocols.TP$SingleMessageHandler.run(TP.java:1817) [jgroups-3.6.10.Final.jar:3.6.10.Final]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_91]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_91]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]
```

Protocol stack:
```
<config xmlns="urn:org:jgroups"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">

    <TCP bind_port="7600"
         bind_addr="${jgroups.bind_addr}"     
    />

    <MPING
            bind_addr="${jgroups.bind_addr}"
            mcast_port="${jgroups.udp.mcast_port:45588}"/>

    <MERGE3  min_interval="10000"
             max_interval="30000"/>

    <FD_SOCK/>

    <FD timeout="3000" max_tries="3" />

    <VERIFY_SUSPECT timeout="1500"  />

    <BARRIER />

    <pbcast.NAKACK2 use_mcast_xmit="false"
                   discard_delivered_msgs="true"/>

    <UNICAST3 />

    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="4M"/>

    <pbcast.GMS print_local_addr="true" join_timeout="2000"
                view_bundling="true"/>

    <MFC max_credits="2M"
         min_threshold="0.4"/>

    <FRAG2 frag_size="60K"  />

    <pbcast.STATE_TRANSFER/>

    <CENTRAL_LOCK num_backups="2"/>

    <COUNTER bypass_bundling="true"
             num_backups="10"/>

</config>
```

I figured the `names` field in `ReconcileRequest` and `ReconcileResponse` can become `null` after streaming, because the `readFrom` method stops reading data if it reads a `0` for `len`. The `readReconciliation*` methods should handle the `0` length just fine, so by removing the check on `len==0`, the `names` field won't be `null` anymore.
