### PR TITLE
fixes JDBC_PING.readAll() executing ResultSet.deleteRow() on readonly ResultSet

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -262,8 +262,22 @@ public class JDBC_PING extends Discovery {
         }
     }
 
+	protected static final PreparedStatement prepareStatement(final Connection connection, final String sql, final int resultSetType,
+		final int resultSetConcurrency) throws SQLException {
+		try {
+			return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
+		} catch(final SQLException x) {
+			try {
+				return connection.prepareStatement(sql);
+			} catch(final SQLException x2) {
+				x.addSuppressed(x2);
+				throw x;
+			}
+		}
+	}
+
     protected void readAll(Connection connection, List<Address> members, String clustername, Responses rsps) throws SQLException {
-        try (PreparedStatement ps=connection.prepareStatement(select_all_pingdata_sql)) {
+        try (PreparedStatement ps=prepareStatement(connection, select_all_pingdata_sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE)) {
             ps.setString(1, clustername);
             try (ResultSet resultSet=ps.executeQuery()) {
 	            while(resultSet.next()) {


### PR DESCRIPTION
After updating JGroups the JDBC_PING constantly printed the failed removing row; please delete it manually error message. The cause was my program not exiting cleanly before updating, leaving rows in the cluster table. After the update, the PingData of the previous version failed deserialization and JGroups attempted deleting the offending row. Since the PreparedStatement was created readonly using the default parameters of Connection.prepareStatement(), the call resulted in an error causing the message printout.

The fix creates the statement as updatable so that the row can be deleted.