### PR TITLE
select_all_pingdata_sql must select primary keys for ResultSet.deleteRows() to work properly as this required by JDBC standard

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -79,8 +79,8 @@ public class JDBC_PING extends Discovery {
     
     @Property(description = "SQL used to fetch all node's PingData. Customizable, but keep the order of parameters and pick compatible types: " + 
                 "only one parameter needed, String compatible, representing the Cluster name. Must return a byte[], the Serialized PingData as" + 
-                " it was stored by the insert_single_sql statement")
-    protected String select_all_pingdata_sql = "SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?";
+                " it was stored by the insert_single_sql statement. Must select primary keys subsequently for cleanup to work properly")
+    protected String select_all_pingdata_sql = "SELECT ping_data, own_addr, cluster_name FROM JGROUPSPING WHERE cluster_name=?";
 
     @Property(description="Finds a given entry by its address and cluster name, used to implement a contains()")
     protected String contains_sql="SELECT count(own_addr) as RECORDCOUNT from JGROUPSPING WHERE cluster_name=? AND own_addr=?";


### PR DESCRIPTION
Actually the fix turned out to be incomplete as JDBC standard requires for deleteRow() to have all primary keys seleted,. It turned out, this is checked by some drivers such as MySQL.