### PR TITLE
Added a null check before returning retval from tryLock.

### DIFF
--- a/src/org/jgroups/blocks/locking/LockService.java
+++ b/src/org/jgroups/blocks/locking/LockService.java
@@ -132,7 +132,7 @@ public class LockService {
             Boolean retval=(Boolean)ch.down(new Event(Event.LOCK, new LockInfo(name, true, false, false, 0, TimeUnit.MILLISECONDS)));
             if(retval != null && retval)
                 holder.set(Thread.currentThread());
-            return retval;
+            return retval == null ? false : retval;
         }
 
         /**
@@ -151,7 +151,7 @@ public class LockService {
                 throw new InterruptedException();
             if(retval != null && retval)
                 holder.set(Thread.currentThread());
-            return retval;
+            return retval == null ? false : retval;
         }
 
         /**


### PR DESCRIPTION
Return type of tryLock is boolean while the type of retval is Boolean, so unboxing will be done at returning retval from tryLock. If retval happens to be null, it will throw a null pointer exception. I've added a null check to prevent that.