### PR TITLE
[JBEAP-6563] Logs ASYM_ENCRYPT message "key server is currently not set" with debug level

### DIFF
--- a/src/org/jgroups/protocols/ASYM_ENCRYPT.java
+++ b/src/org/jgroups/protocols/ASYM_ENCRYPT.java
@@ -82,7 +82,7 @@ public class ASYM_ENCRYPT extends EncryptBase {
     @ManagedOperation(description="Triggers a request for the secret key to the current keyserver")
     public void sendKeyRequest() {
         if(key_server_addr == null) {
-            log.error("%s: key server is currently not set", key_server_addr);
+            log.debug("%s: key server is currently not set", key_server_addr);
             return;
         }
         sendKeyRequest(key_server_addr);


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBEAP-6563
Cherry pick of #327 for EAP 7.1.x and EAP 7.0.x