### PR TITLE
[BZ-1380657] Logs ASYM_ENCRYPT message "key server is currently not set" with debug level

### DIFF
--- a/src/org/jgroups/protocols/ASYM_ENCRYPT.java
+++ b/src/org/jgroups/protocols/ASYM_ENCRYPT.java
@@ -80,7 +80,7 @@ public class ASYM_ENCRYPT extends EncryptBase {
     @ManagedOperation(description="Triggers a request for the secret key to the current keyserver")
     public void sendKeyRequest() {
         if(key_server_addr == null) {
-            log.error(String.format("%s: key server is currently not set", local_addr));
+            log.debug(String.format("%s: key server is currently not set", local_addr));
             return;
         }
         sendKeyRequest(key_server_addr);


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1380657
Cherry pick of #327 for EAP 6.4.z