### PR TITLE
[DRAFT] JGRP 1388/dns ping

### DIFF
--- a/conf/jg-protocol-ids.xml
+++ b/conf/jg-protocol-ids.xml
@@ -62,6 +62,7 @@
     <class id="58" name="org.jgroups.protocols.SYM_ENCRYPT"/>
     <class id="59" name="org.jgroups.protocols.ASYM_ENCRYPT"/>
     <class id="60" name="org.jgroups.protocols.NAMING"/>
+    <class id="61" name="org.jgroups.protocols.dns.DNS_PING"/>
 
     <!-- IDs reserved for building blocks -->
     <class id="200" name="org.jgroups.blocks.RequestCorrelator"/> <!-- ID should be the same as Global.BLOCKS_START_ID -->

--- a/pom.xml
+++ b/pom.xml
@@ -105,13 +105,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>(2,)</version>
+            <version>2.7</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>(2,)</version>
+            <version>2.7</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/org/jgroups/conf/ClassConfigurator.java
+++ b/src/org/jgroups/conf/ClassConfigurator.java
@@ -2,6 +2,19 @@
 package org.jgroups.conf;
 
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.jgroups.Constructable;
 import org.jgroups.Global;
 import org.jgroups.Header;
@@ -11,13 +24,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Maintains a mapping between magic IDs and classes (defined in jg-magic-map.xml), and between protocol IDs and
@@ -225,6 +231,11 @@ public class ClassConfigurator {
             }
 
             Object inst=magicMap[m].get();
+
+            if(inst == null) {
+                continue;
+            }
+
             // test to confirm that the Constructable impl returns an instance of the correct type
             if(!inst.getClass().equals(clazz))
                 throw new IllegalStateException(String.format("%s.create() returned the wrong class: %s\n",

--- a/src/org/jgroups/logging/LogFactory.java
+++ b/src/org/jgroups/logging/LogFactory.java
@@ -1,9 +1,9 @@
 package org.jgroups.logging;
 
+import java.lang.reflect.Constructor;
+
 import org.jgroups.Global;
 import org.jgroups.util.Util;
-
-import java.lang.reflect.Constructor;
 
 
 /**
@@ -91,16 +91,16 @@ public final class LogFactory {
             }
         }
 
-        if(use_jdk_logger)
+//        if(use_jdk_logger)
             return new JDKLogImpl(clazz);
 
-        if(IS_LOG4J2_AVAILABLE)
-            return new Log4J2LogImpl(clazz);
-
-        if (IS_SLF4J_AVAILABLE)
-            return new Slf4jLogImpl(clazz);
-
-        return new JDKLogImpl(clazz);
+//        if(IS_LOG4J2_AVAILABLE)
+//            return new Log4J2LogImpl(clazz);
+//
+//        if (IS_SLF4J_AVAILABLE)
+//            return new Slf4jLogImpl(clazz);
+//
+//        return new JDKLogImpl(clazz);
     }
 
     public static Log getLog(String category) {

--- a/src/org/jgroups/protocols/dns/DNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DNSResolver.java
@@ -1,0 +1,15 @@
+package org.jgroups.protocols.dns;
+
+import java.util.List;
+
+import org.jgroups.Address;
+
+public interface DNSResolver {
+
+   enum DNSRecordType {
+      A, SRV
+   }
+
+   List<Address> resolveIps(String dnsQuery, DNSRecordType recordType);
+
+}

--- a/src/org/jgroups/protocols/dns/DNS_PING.java
+++ b/src/org/jgroups/protocols/dns/DNS_PING.java
@@ -1,0 +1,165 @@
+package org.jgroups.protocols.dns;
+
+import java.util.List;
+
+import org.jgroups.Address;
+import org.jgroups.Event;
+import org.jgroups.Message;
+import org.jgroups.PhysicalAddress;
+import org.jgroups.annotations.Property;
+import org.jgroups.protocols.Discovery;
+import org.jgroups.protocols.PingData;
+import org.jgroups.protocols.PingHeader;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.BoundedList;
+import org.jgroups.util.NameCache;
+import org.jgroups.util.Responses;
+import org.jgroups.util.Tuple;
+
+public class DNS_PING extends Discovery {
+
+   private static final String DEFAULT_DNS_FACTORY = "com.sun.jndi.dns.DnsContextFactory";
+   private static final String DEFAULT_DNS_RECORD_TYPE = "A";
+
+   @Property(description = "DNS Context Factory")
+   protected String dns_context_factory = DEFAULT_DNS_FACTORY;
+
+   @Property(description = "DNS Address. This property will be assembed with the 'dns://' prefix")
+   protected String dns_address;
+
+   @Property(description = "DNS Record type")
+   protected String dns_record_type = DEFAULT_DNS_RECORD_TYPE;
+
+   @Property(description = "DNS query for fetching members")
+   protected String dns_query;
+
+   protected volatile DNSResolver dns_Resolver;
+
+   protected BoundedList<Address> discovered_hosts = new BoundedList<>();
+
+   private int transportPort;
+
+   @Override
+   public void init() throws Exception {
+      super.init();
+      validateProperties();
+      transportPort = getTransport().getBindPort();
+      if(transportPort <= 0) {
+         log.warn("Unable to discover transport port. This may prevent members from being discovered.");
+      }
+      if(dns_Resolver == null) {
+         dns_Resolver = new DefaultDNSResolver(dns_context_factory, dns_address);
+      }
+   }
+
+   protected void validateProperties() {
+      if(dns_query == null) {
+         throw new IllegalArgumentException("dns_query can not be null or empty");
+      }
+      if(dns_address == null) {
+         throw new IllegalArgumentException("dns_query can not be null or empty");
+      }
+   }
+
+   @Override
+   public boolean isDynamic() {
+      return true;
+   }
+
+   @Override
+   public Object down(Event evt) {
+      Object retval = super.down(evt);
+      switch (evt.getType()) {
+         case Event.VIEW_CHANGE:
+            for (Address logical_addr : view.getMembersRaw()) {
+               PhysicalAddress physical_addr = (PhysicalAddress) down_prot.down(new Event(Event.GET_PHYSICAL_ADDRESS, logical_addr));
+               if (physical_addr != null) {
+                  discovered_hosts.addIfAbsent(physical_addr);
+               }
+            }
+            break;
+         case Event.SUSPECT:
+            Address address = evt.getArg();
+            discovered_hosts.remove(address);
+            break;
+         case Event.ADD_PHYSICAL_ADDRESS:
+            Tuple<Address, PhysicalAddress> tuple = evt.getArg();
+            PhysicalAddress physical_addr = tuple.getVal2();
+            if (physical_addr != null)
+               discovered_hosts.addIfAbsent(physical_addr);
+            break;
+      }
+      return retval;
+   }
+
+   public void discoveryRequestReceived(Address sender, String logical_name, PhysicalAddress physical_addr) {
+      super.discoveryRequestReceived(sender, logical_name, physical_addr);
+      log.debug("Received discovery from: %s, IP: %s", sender.toString(), physical_addr.printIpAddress());
+      if (physical_addr != null)
+         discovered_hosts.addIfAbsent(sender);
+   }
+
+   @Override
+   public void findMembers(List<Address> members, boolean initial_discovery, Responses responses) {
+      PingData data = null;
+      PhysicalAddress physical_addr = null;
+
+      if (!use_ip_addrs || !initial_discovery) {
+         log.debug("Performing initial discovery");
+         physical_addr = (PhysicalAddress) down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
+
+         // https://issues.jboss.org/browse/JGRP-1670
+         data = new PingData(local_addr, false, NameCache.get(local_addr), physical_addr);
+         if (members != null && members.size() <= max_members_in_discovery_request)
+            data.mbrs(members);
+      }
+
+      List<Address> dns_discovery_members = dns_Resolver.resolveIps(dns_query, DNSResolver.DNSRecordType.valueOf(dns_record_type));
+      log.debug("Entries collected from DNS: %s", dns_discovery_members.toString());
+      if(dns_discovery_members != null) {
+         for(Address address : dns_discovery_members) {
+            if (physical_addr != null && address.equals(physical_addr)) {
+               // no need to send the request to myself
+               continue;
+            }
+
+            Address addressToBeAdded = address;
+            if(address instanceof IpAddress) {
+               IpAddress ip = ((IpAddress) address);
+               if(ip.getPort() == 0) {
+                  log.debug("Discovered IP Address with port 0 (%s). Replacing with default Transport port: %d", ip.printIpAddress(), transportPort);
+                  addressToBeAdded = new IpAddress(ip.getIpAddress(), transportPort);
+               }
+            }
+            discovered_hosts.addIfAbsent(addressToBeAdded);
+         }
+      }
+
+      log.debug("Performing discovery of the following hosts %s", discovered_hosts.toString());
+
+      PingHeader hdr = new PingHeader(PingHeader.GET_MBRS_REQ).clusterName(cluster_name).initialDiscovery(initial_discovery);
+      for (final Address addr : discovered_hosts) {
+
+
+         // the message needs to be DONT_BUNDLE, see explanation above
+         final Message msg = new Message(addr).setFlag(Message.Flag.INTERNAL, Message.Flag.DONT_BUNDLE, Message.Flag.OOB)
+               .putHeader(this.id, hdr);
+         if (data != null)
+            msg.setBuffer(marshal(data));
+
+         if (async_discovery_use_separate_thread_per_request)
+            timer.execute(() -> sendDiscoveryRequest(msg), sends_can_block);
+         else
+            sendDiscoveryRequest(msg);
+      }
+   }
+
+   protected void sendDiscoveryRequest(Message req) {
+      try {
+         log.debug("%s: sending discovery request to %s", local_addr, req.getDest());
+         down_prot.down(req);
+      } catch (Throwable t) {
+         log.debug("sending discovery request to %s failed: %s", req.dest(), t);
+      }
+   }
+}

--- a/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
@@ -1,0 +1,73 @@
+package org.jgroups.protocols.dns;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+
+import org.jgroups.Address;
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+import org.jgroups.stack.IpAddress;
+
+class DefaultDNSResolver implements DNSResolver {
+
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   final String dnsContextFactory;
+   final String dnsAddress;
+   final DirContext dnsContext;
+
+   public DefaultDNSResolver(String dnsContextFactory, String dnsAddress) {
+      this.dnsContextFactory = dnsContextFactory;
+      this.dnsAddress = dnsAddress;
+      dnsContext = getDnsContext();
+   }
+
+   private final DirContext getDnsContext() {
+      try {
+         log.trace("Initializing DNS Context with factory: %s and url: %s" + dnsContextFactory, dnsAddress);
+         Hashtable env = new Hashtable();
+         env.put("java.naming.factory.initial", dnsContextFactory);
+         env.put("java.naming.provider.url", "dns://" + dnsAddress);
+         return new InitialDirContext(env);
+      } catch (NamingException e) {
+         throw new IllegalStateException("Wrong DNS Context", e);
+      }
+   }
+
+
+   @Override
+   public List<Address> resolveIps(String dnsQuery, DNSRecordType recordType) {
+      List<Address> addresses = new ArrayList<>();
+      log.trace("Resolving DNS Query: %s of a type: %s", dnsQuery, recordType.toString());
+
+      try {
+         // We are parsing this kind of structure:
+         // {a=A: 172.17.0.2, 172.17.0.7}
+         // The frst attribute is the type of record. We are not interested in this. Next are addresses.
+         Attributes attributes = dnsContext.getAttributes(dnsQuery, new String[]{recordType.toString()});
+         if(attributes != null && attributes.getAll().hasMoreElements()) {
+            NamingEnumeration<?> namingEnumeration = attributes.get(recordType.toString()).getAll();
+            while (namingEnumeration.hasMoreElements()) {
+               try {
+                  addresses.add(new IpAddress(namingEnumeration.nextElement().toString()));
+               } catch (Exception e) {
+                  log.trace("Non critical DNS resolution error", e);
+                  continue;
+               }
+            }
+         }
+      } catch (NamingException e) {
+         log.trace("No DNS records for query: " + dnsQuery);
+      }
+
+      return addresses;
+   }
+}

--- a/tests/junit-functional/org/jgroups/protocols/dns/DNSDiscoveryTester.java
+++ b/tests/junit-functional/org/jgroups/protocols/dns/DNSDiscoveryTester.java
@@ -1,0 +1,91 @@
+package org.jgroups.protocols.dns;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jgroups.Address;
+import org.jgroups.JChannel;
+import org.jgroups.ReceiverAdapter;
+import org.jgroups.View;
+import org.jgroups.protocols.TCP;
+import org.jgroups.protocols.UNICAST3;
+import org.jgroups.protocols.pbcast.GMS;
+import org.jgroups.protocols.pbcast.NAKACK2;
+import org.jgroups.protocols.pbcast.STABLE;
+import org.jgroups.stack.Protocol;
+
+public class DNSDiscoveryTester {
+
+   private final MockDNSResolverBuilder dnsResolverBuilder = MockDNSResolverBuilder.newDefault();
+   private final int numberOfTestedInstances;
+   private final int timeout;
+   private final TimeUnit unit;
+   private final int portStart;
+
+   public DNSDiscoveryTester(int numberOfTestedInstances, int portStart, int timeout, TimeUnit unit) {
+      this.numberOfTestedInstances = numberOfTestedInstances;
+      this.timeout = timeout;
+      this.unit = unit;
+      this.portStart = portStart;
+   }
+
+   public DNSDiscoveryTester add(String dnsRecord, DNSResolver.DNSRecordType recordType, Address address) {
+      dnsResolverBuilder.add(dnsRecord, recordType, address);
+      return this;
+   }
+
+   public boolean runTestAndCheckIfViewWasReceived(String dnsQuery, String recordType) throws Exception {
+      List<JChannel> channels = new ArrayList<>();
+
+      CountDownLatch waitForViewToForm = new CountDownLatch(1);
+
+      for(int i = 0; i < numberOfTestedInstances; ++i) {
+         DNS_PING ping = new DNS_PING();
+         ping.dns_Resolver = dnsResolverBuilder.build();
+         ping.dns_query = dnsQuery;
+         ping.dns_record_type = recordType;
+         ping.dns_address = "fake.com";
+
+         Protocol[] protocols={
+               new TCP().setValue("bind_addr", InetAddress.getLoopbackAddress()).setValue("bind_port", portStart + i),
+               ping,
+               new NAKACK2(),
+               new UNICAST3(),
+               new STABLE(),
+               new GMS().joinTimeout(timeout)
+         };
+
+         JChannel c = new JChannel(protocols).name(UUID.randomUUID().toString());
+         channels.add(c);
+
+         c.setReceiver(new ReceiverAdapter() {
+            @Override
+            public void viewAccepted(View view) {
+               if(view.getMembers().size() == numberOfTestedInstances) {
+                  waitForViewToForm.countDown();
+               }
+            }
+         });
+
+         c.connect("TEST");
+      }
+
+      boolean viewReceived = waitForViewToForm.await(timeout, unit);
+      channels.forEach(JChannel::close);
+
+      return viewReceived;
+   }
+
+   private int findUnusedPort() throws IOException {
+      ServerSocket s = new ServerSocket(0);
+      int port = s.getLocalPort();
+      s.close();
+      return port;
+   }
+}

--- a/tests/junit-functional/org/jgroups/protocols/dns/DNS_PINGTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/dns/DNS_PINGTest.java
@@ -1,0 +1,97 @@
+package org.jgroups.protocols.dns;
+
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jgroups.stack.IpAddress;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class DNS_PINGTest {
+
+   private static final int PORT_START = 1234;
+
+   private static final boolean FORCE_DEBUG_LOGGING = false;
+
+   @BeforeClass
+   public static void beforeClass() {
+      if (FORCE_DEBUG_LOGGING) {
+         Logger rootLog = Logger.getLogger("");
+         rootLog.setLevel(Level.FINE);
+         rootLog.getHandlers()[0].setLevel(Level.FINE);
+      }
+   }
+
+   @Test
+   public void test_failing_on_no_dns_query() throws Exception {
+      //given
+      DNS_PING ping = new DNS_PING();
+      ping.dns_address = "fake.com";
+
+      //when
+      try {
+         ping.validateProperties();
+         Assert.fail();
+      } catch (IllegalArgumentException e) {
+         //then
+      }
+   }
+
+   @Test
+   public void test_failing_on_no_dns_address() throws Exception {
+      //given
+      DNS_PING ping = new DNS_PING();
+      ping.dns_query = "fake";
+
+      //when
+      try {
+         ping.validateProperties();
+         Assert.fail();
+      } catch (IllegalArgumentException e) {
+         //then
+      }
+   }
+
+   @Test
+   public void test_valid_dns_response() throws Exception {
+      //given
+      DNSDiscoveryTester dns_discovery_tester = new DNSDiscoveryTester(2, PORT_START, 10, TimeUnit.SECONDS)
+            .add("test", DNSResolver.DNSRecordType.A, new IpAddress(InetAddress.getLoopbackAddress(), PORT_START))
+            .add("test", DNSResolver.DNSRecordType.A, new IpAddress(InetAddress.getLoopbackAddress(), PORT_START + 1));
+
+      //when
+      boolean was_view_received = dns_discovery_tester.runTestAndCheckIfViewWasReceived("test", "A");
+
+      //then
+      Assert.assertTrue(was_view_received);
+   }
+
+   @Test
+   public void test_empty_dns_response() throws Exception {
+      //given
+      DNSDiscoveryTester dns_discovery_tester = new DNSDiscoveryTester(2, PORT_START, 1, TimeUnit.SECONDS);
+
+      //when
+      boolean was_view_received = dns_discovery_tester.runTestAndCheckIfViewWasReceived("test", "A");
+
+      //then
+      Assert.assertFalse(was_view_received);
+   }
+
+   @Test
+   public void test_not_matching_dns_response() throws Exception {
+      //given
+      DNSDiscoveryTester dns_discovery_tester = new DNSDiscoveryTester(2, PORT_START, 1, TimeUnit.SECONDS)
+            .add("test", DNSResolver.DNSRecordType.A, new IpAddress(InetAddress.getLoopbackAddress(), 6666));
+
+      //when
+      boolean was_view_received = dns_discovery_tester.runTestAndCheckIfViewWasReceived("test", "A");
+
+      //then
+      Assert.assertFalse(was_view_received);
+   }
+
+}

--- a/tests/junit-functional/org/jgroups/protocols/dns/MockDNSResolverBuilder.java
+++ b/tests/junit-functional/org/jgroups/protocols/dns/MockDNSResolverBuilder.java
@@ -1,0 +1,59 @@
+package org.jgroups.protocols.dns;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jgroups.Address;
+
+public class MockDNSResolverBuilder {
+
+   private Map<DNSResolverKey, List<Address>> resolutionMap = new HashMap<>();
+
+   private MockDNSResolverBuilder() {
+
+   }
+
+   public static MockDNSResolverBuilder newDefault() {
+      return new MockDNSResolverBuilder();
+   }
+
+   public MockDNSResolverBuilder add(String dnsRecord, DNSResolver.DNSRecordType recordType, Address address) {
+      List<Address> physicalAddresses = resolutionMap.computeIfAbsent(new DNSResolverKey(dnsRecord, recordType), k -> new ArrayList<>());
+      physicalAddresses.add(address);
+      return this;
+   }
+
+   public DNSResolver build() {
+      return (dnsQuery, recordType) -> resolutionMap.get(new DNSResolverKey(dnsQuery, recordType));
+   }
+
+   private static class DNSResolverKey {
+      final String hostName;
+      final DNSResolver.DNSRecordType recordType;
+
+      public DNSResolverKey(String hostName, DNSResolver.DNSRecordType recordType) {
+         this.hostName = hostName;
+         this.recordType = recordType;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         DNSResolverKey that = (DNSResolverKey) o;
+
+         if (hostName != null ? !hostName.equals(that.hostName) : that.hostName != null) return false;
+         return recordType == that.recordType;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = hostName != null ? hostName.hashCode() : 0;
+         result = 31 * result + (recordType != null ? recordType.hashCode() : 0);
+         return result;
+      }
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2139

At this point please consider this PR as a draft. There is still some work to be done including:

* documentation
* DNS SRV entries

However, this is a running implementation of DNS PING that operates on [Headless Services](http://kubernetes.io/docs/user-guide/services/#headless-services) in Kubernetes (or OpenShift). In Kubernetes, a Headless Service is responsible for creating DNS entries for Containers. It creates multiple `A` entries for each host and multiple `SRV` entries for each port. Here's an example:

```
sh-4.2$ dig +search jgroups

; <<>> DiG 9.9.4-RedHat-9.9.4-38.el7_3 <<>> +search jgroups
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 38901
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;jgroups.			IN	A

;; Query time: 0 msec
;; SERVER: 192.168.0.17#53(192.168.0.17)
;; WHEN: Wed Dec 21 12:37:53 UTC 2016
;; MSG SIZE  rcvd: 25

sh-4.2$ dig +search jgroups-dns-ping.myproject.svc.cluster.local

; <<>> DiG 9.9.4-RedHat-9.9.4-38.el7_3 <<>> +search jgroups-dns-ping.myproject.svc.cluster.local
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40178
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;jgroups-dns-ping.myproject.svc.cluster.local. IN A

;; ANSWER SECTION:
jgroups-dns-ping.myproject.svc.cluster.local. 30 IN A 172.17.0.10
jgroups-dns-ping.myproject.svc.cluster.local. 30 IN A 172.17.0.3
jgroups-dns-ping.myproject.svc.cluster.local. 30 IN A 172.17.0.5
jgroups-dns-ping.myproject.svc.cluster.local. 30 IN A 172.17.0.6
jgroups-dns-ping.myproject.svc.cluster.local. 30 IN A 172.17.0.7

;; Query time: 0 msec
;; SERVER: 192.168.0.17#53(192.168.0.17)
;; WHEN: Wed Dec 21 12:38:13 UTC 2016
;; MSG SIZE  rcvd: 142
```

Unfortunately DNS `A` entries have no port assigned, so I'm assuming that all instances have the same configuration and reusing `TP`'s port.

A working example that uses this protocol can be found here: https://github.com/slaskawi/jgroups-dns-ping-example