### PR TITLE
JGRP-2139 SRV entries parsing for DNS_PING

### DIFF
--- a/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
@@ -4,6 +4,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -17,6 +19,8 @@ import org.jgroups.logging.LogFactory;
 import org.jgroups.stack.IpAddress;
 
 class DefaultDNSResolver implements DNSResolver {
+
+   private static final Pattern SRV_REGEXP = Pattern.compile("\\d+ \\d+ \\d+ ([\\w+.-]+)\\.");
 
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
@@ -45,16 +49,60 @@ class DefaultDNSResolver implements DNSResolver {
 
    @Override
    public List<Address> resolveIps(String dnsQuery, DNSRecordType recordType) {
-      List<Address> addresses = new ArrayList<>();
+
       log.trace("Resolving DNS Query: %s of a type: %s", dnsQuery, recordType.toString());
 
+      switch (recordType) {
+         case A:
+            return resolveAEntries(dnsQuery);
+         case SRV:
+            return resolveSRVEntries(dnsQuery);
+         default:
+            throw new IllegalStateException("Not implemented");
+      }
+   }
+
+   private List<Address> resolveSRVEntries(String dnsQuery) {
+      List<Address> addresses = new ArrayList<>();
+      try {
+         // We are parsing this kind of structure:
+         // {srv=SRV: 10 100 8888 9089f34a.jgroups-dns-ping.myproject.svc.cluster.local.}
+         // The frst attribute is the type of record. We are not interested in this. Next are addresses.
+         Attributes attributes = dnsContext.getAttributes(dnsQuery, new String[]{DNSRecordType.SRV.toString()});
+         if(attributes != null && attributes.getAll().hasMoreElements()) {
+            NamingEnumeration<?> namingEnumeration = attributes.get(DNSRecordType.SRV.toString()).getAll();
+            while (namingEnumeration.hasMoreElements()) {
+               try {
+                  String srvEntry = namingEnumeration.nextElement().toString();
+                  Matcher matcher = SRV_REGEXP.matcher(srvEntry);
+                  if(matcher.find()) {
+                     String srcDNSRecord = matcher.group(1);
+                     // The implementation here is not optimal but it's easy to read. SRV discovery will be performed
+                     // extremely rare only when a fine grained discovery using ports is needed.
+                     addresses.addAll(resolveAEntries(srcDNSRecord));
+                  }
+               } catch (Exception e) {
+                  log.trace("Non critical DNS resolution error", e);
+                  continue;
+               }
+            }
+         }
+      } catch (NamingException e) {
+         log.trace("No DNS records for query: " + dnsQuery);
+      }
+
+      return addresses;
+   }
+
+   private List<Address> resolveAEntries(String dnsQuery) {
+      List<Address> addresses = new ArrayList<>();
       try {
          // We are parsing this kind of structure:
          // {a=A: 172.17.0.2, 172.17.0.7}
          // The frst attribute is the type of record. We are not interested in this. Next are addresses.
-         Attributes attributes = dnsContext.getAttributes(dnsQuery, new String[]{recordType.toString()});
+         Attributes attributes = dnsContext.getAttributes(dnsQuery, new String[]{DNSRecordType.A.toString()});
          if(attributes != null && attributes.getAll().hasMoreElements()) {
-            NamingEnumeration<?> namingEnumeration = attributes.get(recordType.toString()).getAll();
+            NamingEnumeration<?> namingEnumeration = attributes.get(DNSRecordType.A.toString()).getAll();
             while (namingEnumeration.hasMoreElements()) {
                try {
                   addresses.add(new IpAddress(namingEnumeration.nextElement().toString()));
@@ -67,7 +115,6 @@ class DefaultDNSResolver implements DNSResolver {
       } catch (NamingException e) {
          log.trace("No DNS records for query: " + dnsQuery);
       }
-
       return addresses;
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2139

This PR introduces DNS discovery based on [`SRV` entries](https://www.ietf.org/rfc/rfc2782.txt). 

In Kubernetes/OpenShift this allows fine grained discovery (coarse grained is based on Headless Services) upon exposed ports. In order to get this working, one needs to expose a port with a **name** as shows in [this example](https://github.com/slaskawi/jgroups-dns-ping-example/blob/master/service.yaml#L19). An obtained `SRV` entry is used for a standard `A` discovery.