### PR TITLE
[3.6] JGRP-2153 Encrypt protocols transform empty buffer into null buffer when encrypt_entire_message is disabled

### DIFF
--- a/src/org/jgroups/protocols/EncryptBase.java
+++ b/src/org/jgroups/protocols/EncryptBase.java
@@ -345,8 +345,7 @@ public abstract class EncryptBase extends Protocol {
 
         // copy neeeded because same message (object) may be retransmitted -> prevent double encryption
         Message msgEncrypted=msg.copy(false).putHeader(this.id, hdr);
-        if(msg.getLength() > 0)
-            msgEncrypted.setBuffer(code(msg.getRawBuffer(),msg.getOffset(),msg.getLength(),false));
+        msgEncrypted.setBuffer(code(msg.getRawBuffer(),msg.getOffset(),msg.getLength(),false));
         down_prot.down(new Event(Event.MSG,msgEncrypted));
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2153