### PR TITLE
Message delivered up the stack and throwing an exception: a warning with

### DIFF
--- a/src/org/jgroups/protocols/UNICAST2.java
+++ b/src/org/jgroups/protocols/UNICAST2.java
@@ -712,7 +712,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
         xmit_reqs_sent.addAndGet(missing.size());
     }
 
-    
+
     /**
      * Called by AgeOutCache, to removed expired connections
      * @param key
@@ -741,7 +741,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
             sb.append(')');
             log.trace(sb);
         }
-        
+
         ReceiverEntry entry=getReceiverEntry(sender, seqno, first, conn_id);
         if(entry == null)
             return false;
@@ -766,7 +766,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
                 up_prot.up(evt);
             }
             catch(Throwable t) {
-                log.error("couldn't deliver OOB message " + msg, t);
+                log.error("couldn't deliver OOB message " + msg + ": " + t);
             }
         }
 
@@ -798,7 +798,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
                         up_prot.up(new Event(Event.MSG, m));
                     }
                     catch(Throwable t) {
-                        log.error("couldn't deliver message " + m, t);
+                        log.error("couldn't deliver message " + m + ": " + t);
                     }
                 }
             }
@@ -887,7 +887,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
                     }
                     continue;
                 }
-                
+
                 down_prot.down(new Event(Event.MSG, msg));
                 xmit_rsps_sent.incrementAndGet();
             }
@@ -945,7 +945,7 @@ public class UNICAST2 extends Protocol implements AgeOutCache.Handler<Address> {
             xmit_task=null;
         }
     }
-    
+
 
 
     protected synchronized short getNewConnectionId() {


### PR DESCRIPTION
the exception name rather than the entire stack trace is logged
(https://issues.jboss.org/browse/JGRP-1958)

This is a manual backport of
https://github.com/belaban/JGroups/commit/03d7c93145f6a9314c2380f5ad66bdc8ec4209f0
for EAP 6.4 https://bugzilla.redhat.com/show_bug.cgi?id=1399195

@belaban  could you please review if I backported correctly?