### PR TITLE
Fix NAKACK2#log_not_found_msgs description

### DIFF
--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -83,7 +83,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
     @Property(description="discards warnings about promiscuous traffic")
     protected boolean log_discard_msgs=true;
 
-    @Property(description="If true, trashes warnings about retransmission messages not found in the xmit_table (used for testing)")
+    @Property(description="If false, trashes warnings about retransmission messages not found in the xmit_table (used for testing)")
     protected boolean log_not_found_msgs=true;
 
     @Property(description="Interval (in milliseconds) at which missing messages (from all retransmit buffers) " +


### PR DESCRIPTION
Looks like a typo? The actual condition is:

```
                if(log.isWarnEnabled() && log_not_found_msgs && !local_addr.equals(xmit_requester) && i > buf.getLow())
                    log.warn(Util.getMessage("MessageNotFound"), local_addr, original_sender, i);
```