### PR TITLE
Allow SSL Sockets to be configured with SSL Parameters

### DIFF
--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -382,12 +382,12 @@ public class StompConnection implements Runnable {
         for (String dest : server_destinations) {
             try {
                 connectToSingleDestination(dest);
-                log.info("Connected to " + destination);
+                log.info("Connected to " + dest);
                 break;
             }
             catch(IOException ex) {
                 if(log.isErrorEnabled())
-                    log.error(Util.getMessage("FailedConnectingTo") + destination + ":" + ex);
+                    log.error(Util.getMessage("FailedConnectingTo") + dest + ":" + ex);
             }
         }
 

--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -8,7 +8,9 @@ import org.jgroups.util.Util;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLSocket;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -63,6 +65,8 @@ public class StompConnection implements Runnable {
 
     protected final Log log=LogFactory.getLog(getClass());
 
+    protected SSLParameters sslParameters;
+
     /**
      * @param dest IP address + ':' + port, e.g. "192.168.1.5:8787"
      */
@@ -87,6 +91,7 @@ public class StompConnection implements Runnable {
             socket_factory = SSLSocketFactory.getDefault();
         else
             socket_factory = SocketFactory.getDefault();
+        this.sslParameters = null;
     }
 
     public StompConnection(String dest, String userid, String password, boolean reconnect, SSLContext sslcontext) {;
@@ -95,6 +100,17 @@ public class StompConnection implements Runnable {
         this.password = password;
         this.reconnect = reconnect;
         socket_factory = sslcontext.getSocketFactory();
+        this.sslParameters = null;
+    }
+
+    public StompConnection(String dest, String userid, String password, boolean reconnect, SSLContext sslcontext,
+                           SSLParameters sslParameters) {;
+        server_destinations.add(dest);
+        this.userid = userid;
+        this.password = password;
+        this.reconnect = reconnect;
+        socket_factory = sslcontext.getSocketFactory();
+        this.sslParameters = sslParameters;
     }
 
     public String getSessionId() {return session_id;}
@@ -127,7 +143,7 @@ public class StompConnection implements Runnable {
         }
     }
 
-    protected void sendConnect() {
+    protected void sendConnect() throws IOException {
         StringBuilder sb=new StringBuilder();
         sb.append(STOMP.ClientVerb.CONNECT.name()).append("\n");
         if(userid != null)
@@ -145,6 +161,7 @@ public class StompConnection implements Runnable {
         }
         catch(IOException ex) {
             log.error(Util.getMessage("FailedToSendConnectMessage"), ex);
+            throw ex;
         }
     }
 
@@ -375,13 +392,27 @@ public class StompConnection implements Runnable {
         startRunner();
     }
 
+    protected Socket buildSocket(String host, int port) throws IOException {
+        // both SocketFactory and SSLSocketFactory return abstract class Socket
+        // on createSocket calls, unfortunately we need to configure
+        // SSLSocket with SSLParameters, so we need to check if the socket is
+        // and instance of SSLSocket or not before we cast and modify
+        sock=socket_factory.createSocket(host, port);
+
+        if (sock instanceof SSLSocket && this.sslParameters != null) {
+            ((SSLSocket) sock).setSSLParameters(this.sslParameters);
+        }
+
+        return sock;
+    }
+
     protected void connectToDestination(String dest) throws IOException {
         // parse destination
         int index=dest.lastIndexOf(':');
         String host=dest.substring(0, index);
         int port=Integer.parseInt(dest.substring(index+1));
 
-        sock=socket_factory.createSocket(host, port);
+        sock = buildSocket(host, port);
 
         in=new DataInputStream(sock.getInputStream());
         out=new DataOutputStream(sock.getOutputStream());

--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -363,22 +363,31 @@ public class StompConnection implements Runnable {
         }
     }
 
+    public void connectToSingleDestination(String destination) throws IOException {
+        try {
+            synchronized(this) {
+                connectToDestination(destination);
+                sendConnect();
+            }
+            subscriptions.forEach(this::sendSubscribe);
+        }
+        catch(IOException ex) {
+            closeConnections();
+            throw ex;
+        }
+
+    }
+
     public void connect() throws IOException{
         for (String dest : server_destinations) {
             try {
-                synchronized(this) {
-                    connectToDestination(dest);
-                    sendConnect();
-                }
-                subscriptions.forEach(this::sendSubscribe);
-
-                log.info("Connected to " + dest);
+                connectToSingleDestination(dest);
+                log.info("Connected to " + destination);
                 break;
             }
-            catch(IOException ex) {
+            catch(IOException ex){
                 if(log.isErrorEnabled())
-                    log.error(Util.getMessage("FailedConnectingTo") + dest + ":" + ex);
-                closeConnections();
+                    log.error(Util.getMessage("FailedConnectingTo") + destination + ":" + ex);
             }
         }
 

--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -385,7 +385,7 @@ public class StompConnection implements Runnable {
                 log.info("Connected to " + destination);
                 break;
             }
-            catch(IOException ex){
+            catch(IOException ex) {
                 if(log.isErrorEnabled())
                     log.error(Util.getMessage("FailedConnectingTo") + destination + ":" + ex);
             }
@@ -421,7 +421,7 @@ public class StompConnection implements Runnable {
         String host=dest.substring(0, index);
         int port=Integer.parseInt(dest.substring(index+1));
 
-        sock = buildSocket(host, port);
+        sock=buildSocket(host, port);
 
         in=new DataInputStream(sock.getInputStream());
         out=new DataOutputStream(sock.getOutputStream());


### PR DESCRIPTION
This pull request is specifically aimed at allowing TLS subject validation in the StompConnection https://tools.ietf.org/html/rfc6125#section-2.3

The short version is this:
1) Certificates are encouraged to have either an IP or DNS subject name that can be validated against the host that is serving the certificate, if it matches then the client will trust it, if not then the client may be subject to a man in the middle attack.
2) By default, Java sockets do not perform this validation.  If you google around a bit, you'll find that it is configured via SSLParameters set on each SSLSocket object via the setEndpointIdentificationAlgorithm in the SSLParameters ex:
```
     SSLSocket sock = ...;
     var sslParameters = sslContext.getDefaultSSLParameters();
     sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
     sock.setSSLParameters(sslParameters);
...
```

3) Because of this, I now allow SSLParameters to be optionally specified via the constructor, and on Socket creation will optionally apply those parameters.
4) I separated the "what" (connect to a destination) from the "how" (loop over a list of destinations).  I convinced myself that this was a reasonable separation of responsibilities, but moreover, the looping over destinations was preventing the bubble up of important IOExceptions that my application wanted to be able to inspect and alert the user on (i.e. "It appears as if your specified Certificate does not have a valid Subject why don't you do this...." as opposed to "Something went wrong, go check the logs because the details are swallowed by the JGroups stomp connector".)

I have attempted to be as minimally invasive as possible in these changes.

I have extensive tests in my application consuming this library validating this behavior, but I do not see a good suite of unit tests for this particular class inside of this JGroups library for me to add this too (moreover I actually am not writing Java, I'm consuming this with JVM language which makes it trickier for me to port my tests over, although I can help supply some information if needed).

Rejected ideas that I considered:
I looked at allowing a user to pass a SocketFactory that would produce properly configured sockets.  This would reduce the amount of state carried around and the need for a cast.  I do not see a way to configure the Java SSLFactory object to properly use SSLParameters for each SSLSocket produced, so I rejected that approach as infeasible.