### PR TITLE
Remove elements of cluster when coordinator stops

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -110,6 +110,11 @@ public class JDBC_PING extends FILE_PING {
         attemptSchemaInitialization();
     }
 
+    @Override
+    public void stop() {
+        super.stop();
+        if (is_coord) removeAll(cluster_name);
+    }
 
     protected void write(List<PingData> list, String clustername) {
         for(PingData data: list)

--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -113,7 +113,7 @@ public class JDBC_PING extends FILE_PING {
     @Override
     public void stop() {
         super.stop();
-        if (is_coord) removeAll(cluster_name);
+        removeAll(cluster_name);
     }
 
     protected void write(List<PingData> list, String clustername) {


### PR DESCRIPTION
Currently, the JDBC_PING fails to clean up the database table like the FILE_PING cleans up its cluster file when the coordinator shuts down, this creates confusion when bringing the cluster back up sometimes as the new host will get stuck trying to delete a coordinator that no long exists in the database table.

This fix attempts to align the JDBC_PING functionality more closely with FILE_PING.