### PR TITLE
JGRP-2221 TUNNEL does not close its sock in #destroy()

### DIFF
--- a/src/org/jgroups/protocols/TUNNEL.java
+++ b/src/org/jgroups/protocols/TUNNEL.java
@@ -144,6 +144,7 @@ public class TUNNEL extends TP implements RouterStub.StubReceiver {
     
     public void destroy() {        
         stubManager.destroyStubs();
+        if (sock != null) sock.close();
         super.destroy();
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2221