### PR TITLE
Fixed some log warnings and argument inconsistencies

### DIFF
--- a/src/org/jgroups/logging/CustomLogFactory.java
+++ b/src/org/jgroups/logging/CustomLogFactory.java
@@ -5,7 +5,7 @@ package org.jgroups.logging;
  */
 public interface CustomLogFactory {
 
-    Log getLog(Class clazz);
+    Log getLog(Class<?> clazz);
 
     Log getLog(String category);
 }

--- a/src/org/jgroups/logging/JDKLogImpl.java
+++ b/src/org/jgroups/logging/JDKLogImpl.java
@@ -19,8 +19,8 @@ public class JDKLogImpl implements Log {
         logger=Logger.getLogger(category);
     }
 
-    public JDKLogImpl(Class category) {
-        logger=Logger.getLogger(category.getName()); // fix for https://jira.jboss.org/browse/JGRP-1224
+    public JDKLogImpl(Class<?> clazz) {
+        logger=Logger.getLogger(clazz.getName()); // fix for https://jira.jboss.org/browse/JGRP-1224
     }
 
 
@@ -50,113 +50,139 @@ public class JDKLogImpl implements Log {
         }
     }
     
+    @Override
     public boolean isTraceEnabled() {
         return logger.isLoggable(Level.FINER);
     }
 
+    @Override
     public boolean isDebugEnabled() {
         return logger.isLoggable(Level.FINE);
     }
 
+    @Override
     public boolean isInfoEnabled() {
         return logger.isLoggable(Level.INFO);
     }
 
+    @Override
     public boolean isWarnEnabled() {
         return logger.isLoggable(Level.WARNING);
     }
 
+    @Override
     public boolean isErrorEnabled() {
         return logger.isLoggable(Level.SEVERE);
     }
 
+    @Override
     public boolean isFatalEnabled() {
         return logger.isLoggable(Level.SEVERE);
     }
 
+    @Override
     public void trace(String msg) {
         log(Level.FINER, msg);
     }
 
-    public void trace(String msg, Object... args) {
+    @Override
+    public void trace(String format, Object... args) {
         if(isTraceEnabled())
-            log(Level.FINER, format(msg, args));
+            log(Level.FINER, format(format, args));
     }
 
+    @Override
     public void trace(Object msg) {
         log(Level.FINER, msg.toString());
     }
 
+    @Override
     public void trace(String msg, Throwable t) {
         log(Level.FINER, msg, t);
     }
 
+    @Override
     public void debug(String msg) {
         log(Level.FINE, msg);
     }
 
-    public void debug(String msg, Object... args) {
+    @Override
+    public void debug(String format, Object... args) {
         if(isDebugEnabled())
-            log(Level.FINE, format(msg, args));
+            log(Level.FINE, format(format, args));
     }
 
+    @Override
     public void debug(String msg, Throwable t) {
         log(Level.FINE, msg, t);
     }
 
+    @Override
     public void info(String msg) {
         log(Level.INFO, msg);
     }
 
-    public void info(String msg, Object... args) {
+    @Override
+    public void info(String format, Object... args) {
         if(isInfoEnabled())
-            log(Level.INFO, format(msg, args));
+            log(Level.INFO, format(format, args));
     }
 
+    @Override
     public void warn(String msg) {
         log(Level.WARNING, msg);
     }
 
-    public void warn(String msg, Object... args) {
+    @Override
+    public void warn(String format, Object... args) {
         if(isWarnEnabled())
-            log(Level.WARNING, format(msg, args));
+            log(Level.WARNING, format(format, args));
     }
 
+    @Override
     public void warn(String msg, Throwable t) {
         log(Level.WARNING, msg, t);
     }
 
+    @Override
     public void error(String msg) {
         log(Level.SEVERE, msg);
     }
 
+    @Override
     public void error(String format, Object... args) {
         if(isErrorEnabled())
             log(Level.SEVERE, format(format, args));
     }
 
+    @Override
     public void error(String msg, Throwable t) {
         log(Level.SEVERE, msg, t);
     }
 
+    @Override
     public void fatal(String msg) {
         log(Level.SEVERE, msg);
     }
 
-    public void fatal(String msg, Object... args) {
+    @Override
+    public void fatal(String format, Object... args) {
         if(isFatalEnabled())
-            log(Level.SEVERE, format(msg, args));
+            log(Level.SEVERE, format(format, args));
     }
 
+    @Override
     public void fatal(String msg, Throwable t) {
         log(Level.SEVERE, msg, t);
     }
 
+    @Override
     public String getLevel() {
         Level level=logger.getLevel();
         return level != null? level.toString() : "off";
     }
 
+    @Override
     public void setLevel(String level) {
         Level new_level=strToLevel(level);
         if(new_level != null)

--- a/src/org/jgroups/logging/Log.java
+++ b/src/org/jgroups/logging/Log.java
@@ -18,7 +18,7 @@ public interface Log {
 
 
     void fatal(String msg);
-    void fatal(String msg, Object ... args);
+    void fatal(String format, Object ... args);
     void fatal(String msg, Throwable throwable);
 
     void error(String msg);
@@ -26,19 +26,19 @@ public interface Log {
     void error(String msg, Throwable throwable);
 
     void warn(String msg);
-    void warn(String msg, Object ... args);
+    void warn(String format, Object ... args);
     void warn(String msg, Throwable throwable);
 
     void info(String msg);
-    void info(String msg, Object ... args);
+    void info(String format, Object ... args);
 
     void debug(String msg);
-    void debug(String msg, Object ... args);
+    void debug(String format, Object ... args);
     void debug(String msg, Throwable throwable);
 
-    void trace(Object msg);
+    void trace(Object obj);
     void trace(String msg);
-    void trace(String msg, Object ... args);
+    void trace(String format, Object ... args);
     void trace(String msg, Throwable throwable);
 
 

--- a/src/org/jgroups/logging/Log4J2LogImpl.java
+++ b/src/org/jgroups/logging/Log4J2LogImpl.java
@@ -26,83 +26,107 @@ public class Log4J2LogImpl implements Log {
         logger = LogManager.getFormatterLogger(category);
     }
 
+    @Override
     public boolean isFatalEnabled() {return logger.isFatalEnabled();}
+    @Override
     public boolean isErrorEnabled() {return logger.isErrorEnabled();}
+    @Override
     public boolean isWarnEnabled()  {return logger.isWarnEnabled();}
+    @Override
     public boolean isInfoEnabled()  {return logger.isInfoEnabled();}
+    @Override
     public boolean isDebugEnabled() {return logger.isDebugEnabled();}
+    @Override
     public boolean isTraceEnabled() {return logger.isTraceEnabled();}
 
 
 
+    @Override
     public void trace(Object msg) {
         logger.trace(msg);
     }
 
+    @Override
     public void trace(String msg) {
         logger.trace(msg);
     }
 
-    public void trace(String msg, Object... args) {
-        logger.trace(msg, args);
+    @Override
+    public void trace(String format, Object... args) {
+        logger.trace(format, args);
     }
 
+    @Override
     public void trace(String msg, Throwable throwable) {
         logger.trace(msg, throwable);
     }
 
+    @Override
     public void debug(String msg) {
         logger.debug(msg);
     }
 
-    public void debug(String msg, Object... args) {
-        logger.debug(msg, args);
+    @Override
+    public void debug(String format, Object... args) {
+        logger.debug(format, args);
     }
 
+    @Override
     public void debug(String msg, Throwable throwable) {
         logger.debug(msg, throwable);
     }
 
+    @Override
     public void info(String msg) {
         logger.info(msg);
     }
 
-    public void info(String msg, Object... args) {
-        logger.info(msg, args);
+    @Override
+    public void info(String format, Object... args) {
+        logger.info(format, args);
     }
 
+    @Override
     public void warn(String msg) {
         logger.warn(msg);
     }
 
-    public void warn(String msg, Object... args) {
-        logger.warn(msg, args);
+    @Override
+    public void warn(String format, Object... args) {
+        logger.warn(format, args);
     }
 
+    @Override
     public void warn(String msg, Throwable throwable) {
         logger.warn(msg, throwable);
     }
 
+    @Override
     public void error(String msg) {
         logger.error(msg);
     }
 
+    @Override
     public void error(String format, Object... args) {
         logger.error(format, args);
     }
 
+    @Override
     public void error(String msg, Throwable throwable) {
         logger.error(msg, throwable);
     }
 
+    @Override
     public void fatal(String msg) {
         logger.fatal(msg);
     }
 
-    public void fatal(String msg, Object... args) {
-        logger.fatal(msg, args);
+    @Override
+    public void fatal(String format, Object... args) {
+        logger.fatal(format, args);
     }
 
+    @Override
     public void fatal(String msg, Throwable throwable) {
         logger.fatal(msg, throwable);
     }
@@ -112,6 +136,7 @@ public class Log4J2LogImpl implements Log {
 
 
 
+    @Override
     public String getLevel() {
         for(Level level: levels)
             if(logger.isEnabled(level))
@@ -119,6 +144,7 @@ public class Log4J2LogImpl implements Log {
         return "n/a";
     }
 
+    @Override
     public void setLevel(String level) {
         Level new_level=strToLevel(level);
         if(new_level == null)

--- a/src/org/jgroups/logging/LogFactory.java
+++ b/src/org/jgroups/logging/LogFactory.java
@@ -78,7 +78,7 @@ public final class LogFactory {
         }
     }
 
-    public static Log getLog(Class clazz) {
+    public static Log getLog(Class<?> clazz) {
         if(custom_log_factory != null)
             return custom_log_factory.getLog(clazz);
 
@@ -128,8 +128,10 @@ public final class LogFactory {
         return new JDKLogImpl(category);
     }
 
-    protected static Constructor<? extends Log> findConstructor(String classname, Class arg) throws Exception {
-        Class<?> clazz=Util.loadClass(classname, (Class)null);
-        return (Constructor<? extends Log>)clazz.getDeclaredConstructor(arg);
+    protected static Constructor<? extends Log> findConstructor(String classname, Class<?> arg) throws Exception {
+        Class<?> clazz=Util.loadClass(classname, (Class<?>)null);
+        @SuppressWarnings("unchecked")
+        Constructor<? extends Log> constructor = (Constructor<? extends Log>)clazz.getDeclaredConstructor(arg);
+        return constructor;
     }
 }


### PR DESCRIPTION
In implementing some log workarounds I found a number of warnings and some argument inconsistencies that I thought should be fixed in the master.