### PR TITLE
BPING: error out with meaningful message if socket cannot be created

### DIFF
--- a/src/org/jgroups/protocols/BPING.java
+++ b/src/org/jgroups/protocols/BPING.java
@@ -73,6 +73,9 @@ public class BPING extends PING implements Runnable {
             }
         }
 
+        if (null == sock)
+            throw new RuntimeException("failed to open a port in range [" + bind_port + " - " + (bind_port+port_range) + "]");
+
         sock.setBroadcast(true);
         startReceiver();
         super.start();


### PR DESCRIPTION
When BPING cannot create socket in the configured set of ports, it logs NPE.
```
Caught: java.lang.NullPointerException
java.lang.NullPointerException
        at org.jgroups.protocols.BPING.start(BPING.java:76)
        at org.jgroups.stack.ProtocolStack.startStack(ProtocolStack.java:861)
        at org.jgroups.JChannel.startStack(JChannel.java:993)
        at org.jgroups.JChannel._preConnect(JChannel.java:862)
        at org.jgroups.JChannel.connect(JChannel.java:366)
        at org.jgroups.JChannel.connect(JChannel.java:360)
```