### PR TITLE
Narrow set of thrown exceptions in Streamable and Marshaller method signatures.

### DIFF
--- a/src/org/jgroups/AnycastAddress.java
+++ b/src/org/jgroups/AnycastAddress.java
@@ -124,7 +124,7 @@ public class AnycastAddress implements Address, Constructable<AnycastAddress> {
 
     @Override
     public void readFrom(DataInput in) throws Exception {
-        destinations = (Collection<Address>) Util.readAddresses(in, ArrayList.class);
+        destinations = Util.readAddresses(in, ArrayList::new);
     }
 
 }

--- a/src/org/jgroups/AnycastAddress.java
+++ b/src/org/jgroups/AnycastAddress.java
@@ -65,6 +65,7 @@ public class AnycastAddress implements Address, Constructable<AnycastAddress> {
         }
     }
 
+    @Override
     public int serializedSize() {
         if (destinations == null) {
             return Global.INT_SIZE;
@@ -118,12 +119,12 @@ public class AnycastAddress implements Address, Constructable<AnycastAddress> {
     }
 
     @Override
-    public void writeTo(DataOutput out) throws Exception {
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeAddresses(destinations, out);
     }
 
     @Override
-    public void readFrom(DataInput in) throws Exception {
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         destinations = Util.readAddresses(in, ArrayList::new);
     }
 

--- a/src/org/jgroups/MergeView.java
+++ b/src/org/jgroups/MergeView.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -102,8 +103,8 @@ public class MergeView extends View {
         return sb.toString();
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         super.writeTo(out);
 
         // write subgroups
@@ -131,7 +132,8 @@ public class MergeView extends View {
         }
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         super.readFrom(in);
         short len=in.readShort();
         if(len > 0) {
@@ -155,6 +157,7 @@ public class MergeView extends View {
         }
     }
 
+    @Override
     public int serializedSize() {
         int retval=super.serializedSize();
         retval+=Global.SHORT_SIZE; // for size of subgroups vector

--- a/src/org/jgroups/Message.java
+++ b/src/org/jgroups/Message.java
@@ -7,6 +7,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -618,7 +619,8 @@ public class Message implements Streamable, Constructable<Message> {
      * @param out
      * @throws Exception
      */
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         byte leading=0;
 
         if(dest_addr != null)
@@ -717,8 +719,8 @@ public class Message implements Streamable, Constructable<Message> {
         }
     }
 
-
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
 
         // 1. read the leading byte first
         byte leading=in.readByte();
@@ -856,7 +858,7 @@ public class Message implements Streamable, Constructable<Message> {
         return sb.toString();
     }
 
-    protected static void writeHeader(Header hdr, DataOutput out) throws Exception {
+    protected static void writeHeader(Header hdr, DataOutput out) throws IOException {
         short magic_number=hdr.getMagicId();
         out.writeShort(magic_number);
         hdr.writeTo(out);
@@ -864,7 +866,7 @@ public class Message implements Streamable, Constructable<Message> {
 
 
 
-    protected static Header readHeader(DataInput in) throws Exception {
+    protected static Header readHeader(DataInput in) throws IOException, ClassNotFoundException {
         short magic_number=in.readShort();
         Header hdr=ClassConfigurator.create(magic_number);
         hdr.readFrom(in);

--- a/src/org/jgroups/View.java
+++ b/src/org/jgroups/View.java
@@ -9,6 +9,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -192,19 +193,20 @@ public class View implements Comparable<View>, SizeStreamable, Iterable<Address>
         return sb.toString();
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         view_id.writeTo(out);
         Util.writeAddresses(members,out);
     }
 
-    @SuppressWarnings("unchecked") 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         view_id=new ViewId();
         view_id.readFrom(in);
         members=Util.readAddresses(in);
     }
 
+    @Override
     public int serializedSize() {
         return (int)(view_id.serializedSize() + Util.size(members));
     }

--- a/src/org/jgroups/ViewId.java
+++ b/src/org/jgroups/ViewId.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -105,17 +106,19 @@ public class ViewId implements Comparable<ViewId>, SizeStreamable, Constructable
         return (int)(creator.hashCode() + id);
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeAddress(creator, out);
         Bits.writeLong(id,out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         creator=Util.readAddress(in);
         id=Bits.readLong(in);
     }
 
+    @Override
     public int serializedSize() {
         return Bits.size(id) + Util.size(creator);
     }

--- a/src/org/jgroups/auth/ChallengeResponseHeader.java
+++ b/src/org/jgroups/auth/ChallengeResponseHeader.java
@@ -6,6 +6,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 /**
@@ -37,7 +38,8 @@ public class ChallengeResponseHeader extends Header {
         return ChallengeResponseHeader::new;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         switch(type) {
             case CHALLENGE:
@@ -49,7 +51,8 @@ public class ChallengeResponseHeader extends Header {
         }
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         type=in.readByte();
         switch(type) {
             case CHALLENGE:
@@ -61,6 +64,7 @@ public class ChallengeResponseHeader extends Header {
         }
     }
 
+    @Override
     public int serializedSize() {
         int retval=Global.BYTE_SIZE; // type
         switch(type) {

--- a/src/org/jgroups/auth/ChallengeResponseToken.java
+++ b/src/org/jgroups/auth/ChallengeResponseToken.java
@@ -88,8 +88,10 @@ public class ChallengeResponseToken extends AuthToken implements AUTH.UpHandler 
         }
     }
 
-    public void writeTo(DataOutput out) throws Exception {}
-    public void readFrom(DataInput in) throws Exception {}
+    @Override
+    public void writeTo(DataOutput out) {}
+    @Override
+    public void readFrom(DataInput in) {}
     public int  size() {return 0;}
 
 

--- a/src/org/jgroups/auth/FixedMembershipToken.java
+++ b/src/org/jgroups/auth/FixedMembershipToken.java
@@ -10,6 +10,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -110,11 +111,13 @@ public class FixedMembershipToken extends AuthToken {
         }
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Bits.writeString(this.token,out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         this.token = Bits.readString(in);
     }
 

--- a/src/org/jgroups/auth/Krb5Token.java
+++ b/src/org/jgroups/auth/Krb5Token.java
@@ -105,7 +105,8 @@ public class Krb5Token extends AuthToken {
         
         return false;
     }
-    
+
+    @Override
     public void writeTo(DataOutput out) throws IOException {
         if (isAuthenticated()) {
             generateServiceTicket();
@@ -113,7 +114,8 @@ public class Krb5Token extends AuthToken {
         }
     }
 
-    public void readFrom(DataInput in) throws IOException, IllegalAccessException, InstantiationException {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
 
         // This method is called from within a temporary token so it has not authenticated to a client principal
         // This token is passed to the authenticate

--- a/src/org/jgroups/auth/MD5Token.java
+++ b/src/org/jgroups/auth/MD5Token.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * <p>
@@ -105,11 +106,13 @@ public class MD5Token extends AuthToken {
         return false;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Bits.writeString(this.auth_value,out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         this.auth_value = Bits.readString(in);
     }
 

--- a/src/org/jgroups/auth/RegexMembership.java
+++ b/src/org/jgroups/auth/RegexMembership.java
@@ -84,19 +84,12 @@ public class RegexMembership extends AuthToken {
         return false;
     }
 
-   
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) {
     }
 
-    /**
-     * Required to deserialize the object when read in from the wire
-     *
-     *
-     * @param in
-     * @throws Exception
-     */
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) {
     }
 
     public int size() {

--- a/src/org/jgroups/auth/SimpleToken.java
+++ b/src/org/jgroups/auth/SimpleToken.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * <p>
@@ -73,30 +74,16 @@ public class SimpleToken extends AuthToken {
         return false;
     }
 
-    /**
-     * Required to serialize the object to pass across the wire
-     * 
-     *
-     *
-     * @param out
-     * @throws Exception
-     */
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("SimpleToken writeTo()");
         }
         Bits.writeString(this.auth_value,out);
     }
 
-    /**
-     * Required to deserialize the object when read in from the wire
-     * 
-     *
-     *
-     * @param in
-     * @throws Exception
-     */
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("SimpleToken readFrom()");
         }

--- a/src/org/jgroups/auth/X509Token.java
+++ b/src/org/jgroups/auth/X509Token.java
@@ -123,11 +123,13 @@ public class X509Token extends AuthToken {
         return false;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeByteBuffer(this.encryptedToken, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         this.encryptedToken = Util.readByteBuffer(in);
         this.valueSet = true;
     }

--- a/src/org/jgroups/blocks/GridFile.java
+++ b/src/org/jgroups/blocks/GridFile.java
@@ -365,14 +365,16 @@ public class GridFile extends File {
             return sb.toString();
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(length);
             out.writeLong(modification_time);
             out.writeInt(chunk_size);
             out.writeByte(flags);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             length=in.readInt();
             modification_time=in.readLong();
             chunk_size=in.readInt();

--- a/src/org/jgroups/blocks/Marshaller.java
+++ b/src/org/jgroups/blocks/Marshaller.java
@@ -2,6 +2,7 @@ package org.jgroups.blocks;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * Performs serialization and de-serialization of RPC call arguments and return values (including exceptions)
@@ -26,15 +27,16 @@ public interface Marshaller {
      * Serializes an object to an output stream
      * @param obj the object to be serialized
      * @param out the output stream, created taking {@link #estimatedSize(Object)} into account
-     * @throws Exception thrown if serialization failed
+     * @throws IOException thrown if serialization failed
      */
-    void objectToStream(Object obj, DataOutput out) throws Exception;
+    void objectToStream(Object obj, DataOutput out) throws IOException;
 
     /**
      * Creates an object from a stream
      * @param in the input stream
      * @return an object read from the input stream
-     * @throws Exception thrown if deserialization failed
+     * @throws IOException thrown if deserialization failed
+     * @throws ClassNotFoundException if a requisite class was not found
      */
-    Object objectFromStream(DataInput in) throws Exception;
+    Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException;
 }

--- a/src/org/jgroups/blocks/MethodCall.java
+++ b/src/org/jgroups/blocks/MethodCall.java
@@ -206,13 +206,12 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
         return ret.toString();
     }
 
-
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         writeTo(out, null);
     }
 
-    public void writeTo(DataOutput out, Marshaller marshaller) throws Exception {
+    public void writeTo(DataOutput out, Marshaller marshaller) throws IOException {
         out.write(mode);
 
         switch(mode) {
@@ -233,14 +232,12 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
         writeArgs(out, marshaller);
     }
 
-
-
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
        readFrom(in, null);
     }
 
-
-    public void readFrom(DataInput in, Marshaller marshaller) throws Exception {
+    public void readFrom(DataInput in, Marshaller marshaller) throws IOException, ClassNotFoundException {
         switch(mode=in.readByte()) {
             case METHOD:
                 method_name=Bits.readString(in);
@@ -296,7 +293,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
         return null;
     }
 
-    protected void writeArgs(DataOutput out, Marshaller marshaller) throws Exception {
+    protected void writeArgs(DataOutput out, Marshaller marshaller) throws IOException {
         int args_len=args != null? args.length : 0;
         out.write(args_len);
         if(args_len == 0)
@@ -309,7 +306,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
         }
     }
 
-    protected void readArgs(DataInput in, Marshaller marshaller) throws Exception {
+    protected void readArgs(DataInput in, Marshaller marshaller) throws IOException, ClassNotFoundException {
         int args_len=in.readByte();
         if(args_len == 0)
             return;
@@ -319,7 +316,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
     }
 
 
-    protected void writeTypes(DataOutput out) throws Exception {
+    protected void writeTypes(DataOutput out) throws IOException {
         int types_len=types != null? types.length : 0;
         out.write(types_len);
         if(types_len > 0)
@@ -327,7 +324,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
                 Util.objectToStream(type, out);
     }
 
-    protected void readTypes(DataInput in) throws Exception {
+    protected void readTypes(DataInput in) throws IOException, ClassNotFoundException {
         int types_len=in.readByte();
         if(types_len > 0) {
             types=new Class<?>[types_len];
@@ -336,7 +333,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
         }
     }
 
-    protected void writeMethod(DataOutput out) throws Exception {
+    protected void writeMethod(DataOutput out) throws IOException {
         if(method != null) {
             out.write(1);
             Util.objectToStream(method.getParameterTypes(),out);
@@ -346,7 +343,7 @@ public class MethodCall implements Streamable, Constructable<MethodCall> {
             out.write(0);
     }
 
-    protected void readMethod(DataInput in) throws Exception {
+    protected void readMethod(DataInput in) throws IOException, ClassNotFoundException {
         if(in.readByte() == 1) {
             Class[] parametertypes=Util.objectFromStream(in);
             Class   declaringclass=Util.objectFromStream(in);

--- a/src/org/jgroups/blocks/PartitionedHashMap.java
+++ b/src/org/jgroups/blocks/PartitionedHashMap.java
@@ -14,6 +14,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -488,8 +489,8 @@ public class PartitionedHashMap<K,V> implements MembershipListener {
         static final byte OBJ         = 2;
         static final byte VALUE       = 3;
 
-
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             if(obj == null) {
                 out.write(NULL);
                 return;
@@ -506,7 +507,8 @@ public class PartitionedHashMap<K,V> implements MembershipListener {
             }
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             byte type=in.readByte();
             if(type == NULL)
                 return null;

--- a/src/org/jgroups/blocks/ReplCache.java
+++ b/src/org/jgroups/blocks/ReplCache.java
@@ -849,8 +849,8 @@ public class ReplCache<K,V> implements MembershipListener, Cache.ChangeListener 
         static final byte OBJ         = 2;
         static final byte VALUE       = 3;
 
-
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             if(obj == null) {
                 out.write(NULL);
                 return;
@@ -867,7 +867,8 @@ public class ReplCache<K,V> implements MembershipListener, Cache.ChangeListener 
             }
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             byte type=in.readByte();
             if(type == NULL)
                 return null;

--- a/src/org/jgroups/blocks/RequestCorrelator.java
+++ b/src/org/jgroups/blocks/RequestCorrelator.java
@@ -13,6 +13,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.io.NotSerializableException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -547,19 +548,21 @@ public class RequestCorrelator {
             return ret.toString();
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Bits.writeLong(req_id, out);
             out.writeShort(corrId);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             req_id=Bits.readLong(in);
             corrId=in.readShort();
         }
 
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE  // type
               + Bits.size(req_id)    // req_id
@@ -585,16 +588,19 @@ public class RequestCorrelator {
             return MultiDestinationHeader::new;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Util.writeAddresses(exclusion_list, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             exclusion_list=Util.readAddresses(in);
         }
 
+        @Override
         public int serializedSize() {
             return (int)(super.serializedSize() + Util.size(exclusion_list));
         }

--- a/src/org/jgroups/blocks/executor/ExecutionService.java
+++ b/src/org/jgroups/blocks/executor/ExecutionService.java
@@ -715,51 +715,17 @@ public class ExecutionService extends AbstractExecutorService {
             return result;
         }
         @Override
-        public void writeTo(DataOutput out) throws Exception {
-            try {
-                Util.writeObject(task, out);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException("Exception encountered while writing execution runnable", e);
-            }
-            
-            try {
-                Util.writeObject(result, out);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException("Exception encountered while writing execution result", e);
-            }
+        public void writeTo(DataOutput out) throws IOException {
+            Util.writeObject(task, out);
+            Util.writeObject(result, out);
         }
         @SuppressWarnings("unchecked")
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             // We can't use Util.readObject since it's size is limited to 2^15-1
             // The runner could be larger than that possibly
-            try {
-                task = (Runnable)Util.readObject(in);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException("Exception encountered while reading execution runnable", e);
-            }
-            
-            try {
-                result = (T)Util.readObject(in);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException("Exception encountered while reading execution result", e);
-            }
+            task = (Runnable)Util.readObject(in);
+            result = (T)Util.readObject(in);
         }
     }
 

--- a/src/org/jgroups/blocks/executor/Executions.java
+++ b/src/org/jgroups/blocks/executor/Executions.java
@@ -135,7 +135,7 @@ public final class Executions {
         }
 
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             out.writeUTF(_classCallable.getName());
             out.writeByte(_constructorNumber);
             out.writeByte(_args.length);
@@ -149,16 +149,10 @@ public final class Executions {
             }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public void readFrom(DataInput in) throws Exception {
-            try {
-                String classname=in.readUTF();
-                _classCallable=ClassConfigurator.get(classname);
-            }
-            catch (ClassNotFoundException e) {
-                throw new IOException("failed to read class from classname", e);
-            }
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
+            String classname=in.readUTF();
+            _classCallable=ClassConfigurator.get(classname);
             _constructorNumber = in.readByte();
             short numberOfArgs = in.readByte();
             _args = new Object[numberOfArgs];

--- a/src/org/jgroups/conf/ClassConfigurator.java
+++ b/src/org/jgroups/conf/ClassConfigurator.java
@@ -111,12 +111,19 @@ public class ClassConfigurator {
     }
 
 
-    public static <T extends Object> T create(short id) throws Exception {
+    public static <T extends Object> T create(short id) throws ClassNotFoundException {
         if(id >= MIN_CUSTOM_MAGIC_NUMBER) {
             Object val=magicMapUser.get(id);
             if(val == null)
                 throw new ClassNotFoundException("Class for magic number " + id + " cannot be found");
-            return (T) ((val instanceof Supplier)? ((Supplier)val).get() : ((Class)val).newInstance());
+            if (val instanceof Supplier) {
+                return ((Supplier<T>) val).get();
+            }
+            try {
+                return ((Class<T>) val).newInstance();
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new IllegalStateException(e);
+            }
         }
         Supplier<?> supplier=magicMap[id];
         if(supplier == null)

--- a/src/org/jgroups/demos/Draw.java
+++ b/src/org/jgroups/demos/Draw.java
@@ -256,7 +256,7 @@ public class Draw extends ReceiverAdapter implements ActionListener, ChannelList
         }
 
         try {
-            DrawCommand comm=Util.streamableFromByteBuffer(DrawCommand.class, buf, msg.getOffset(), msg.getLength());
+            DrawCommand comm=Util.streamableFromByteBuffer(DrawCommand::new, buf, msg.getOffset(), msg.getLength());
             switch(comm.mode) {
                 case DrawCommand.DRAW:
                     if(panel != null)

--- a/src/org/jgroups/demos/DrawCommand.java
+++ b/src/org/jgroups/demos/DrawCommand.java
@@ -5,6 +5,7 @@ import org.jgroups.util.Streamable;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * Encapsulates information about a draw command.
@@ -33,15 +34,16 @@ public class DrawCommand implements Streamable {
         this.rgb=rgb;
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(mode);
         out.writeInt(x);
         out.writeInt(y);
         out.writeInt(rgb);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         mode=in.readByte();
         x=in.readInt();
         y=in.readInt();

--- a/src/org/jgroups/demos/ExecutionServiceDemo.java
+++ b/src/org/jgroups/demos/ExecutionServiceDemo.java
@@ -156,8 +156,7 @@ public class ExecutionServiceDemo {
 
         @Override
         public void readFrom(DataInput in) throws Exception {
-            buffer = ((ByteBufferStreamable)Util.readStreamable(
-                ByteBufferStreamable.class, in)).buffer;
+            buffer = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
         }
     }
     
@@ -214,11 +213,8 @@ public class ExecutionServiceDemo {
 
         @Override
         public void readFrom(DataInput in) throws Exception {
-            bytes1 = ((ByteBufferStreamable)Util.readStreamable(
-                ByteBufferStreamable.class, in)).buffer;
-            
-            bytes2 = ((ByteBufferStreamable)Util.readStreamable(
-                ByteBufferStreamable.class, in)).buffer;
+            bytes1 = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
+            bytes2 = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
         }
     }
     

--- a/src/org/jgroups/demos/ExecutionServiceDemo.java
+++ b/src/org/jgroups/demos/ExecutionServiceDemo.java
@@ -2,6 +2,7 @@ package org.jgroups.demos;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -93,14 +94,14 @@ public class ExecutionServiceDemo {
         }
 
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             int sizeLocal = buffer.limit() - buffer.position();
             out.writeInt(sizeLocal);
             out.write(buffer.array(), buffer.position(), sizeLocal);
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             buffer = ByteBuffer.allocate(in.readInt());
             in.readFully(buffer.array());
         }
@@ -150,12 +151,12 @@ public class ExecutionServiceDemo {
 
         // We copy over as a single array with no offset
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             Util.writeStreamable(new ByteBufferStreamable(buffer), out);
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             buffer = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
         }
     }
@@ -206,13 +207,13 @@ public class ExecutionServiceDemo {
         }
         
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             Util.writeStreamable(new ByteBufferStreamable(bytes1), out);
             Util.writeStreamable(new ByteBufferStreamable(bytes2), out);
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             bytes1 = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
             bytes2 = Util.readStreamable(ByteBufferStreamable::new, in).buffer;
         }

--- a/src/org/jgroups/demos/StompDraw.java
+++ b/src/org/jgroups/demos/StompDraw.java
@@ -237,7 +237,7 @@ public class StompDraw implements StompConnection.Listener, ActionListener {
         }
 
         try {
-            DrawCommand comm=(DrawCommand)Util.streamableFromByteBuffer(DrawCommand.class, buf, offset, length);
+            DrawCommand comm=Util.streamableFromByteBuffer(DrawCommand::new, buf, offset, length);
             switch(comm.mode) {
                 case DrawCommand.DRAW:
                     if(panel != null)

--- a/src/org/jgroups/protocols/ABP.java
+++ b/src/org/jgroups/protocols/ABP.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -188,13 +189,13 @@ public class ABP extends Protocol {
         }
 
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type.ordinal());
             out.writeByte(bit);
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             type=Type.values()[in.readByte()];
             bit=in.readByte();
         }

--- a/src/org/jgroups/protocols/ASYM_ENCRYPT.java
+++ b/src/org/jgroups/protocols/ASYM_ENCRYPT.java
@@ -233,7 +233,7 @@ public class ASYM_ENCRYPT extends Encrypt<KeyStore.PrivateKeyEntry> {
         switch(hdr.getType()) {
             case GMS.GmsHeader.JOIN_RSP:
                 try {
-                    JoinRsp join_rsp=Util.streamableFromBuffer(JoinRsp.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                    JoinRsp join_rsp=Util.streamableFromBuffer(JoinRsp::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                     View new_view=join_rsp != null? join_rsp.getView() : null;
                     return new_view != null? new_view.getCoord() : null;
                 }

--- a/src/org/jgroups/protocols/COMPRESS.java
+++ b/src/org/jgroups/protocols/COMPRESS.java
@@ -11,6 +11,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.Supplier;
@@ -195,15 +196,18 @@ public class COMPRESS extends Protocol {
             return CompressHeader::new;
         }
 
+        @Override
         public int serializedSize() {
             return Global.INT_SIZE;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(original_size);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             original_size=in.readInt();
         }
     }

--- a/src/org/jgroups/protocols/COUNTER.java
+++ b/src/org/jgroups/protocols/COUNTER.java
@@ -587,7 +587,7 @@ public class COUNTER extends Protocol {
     }
 
 
-    protected static void writeReconciliation(DataOutput out, String[] names, long[] values, long[] versions) throws Exception {
+    protected static void writeReconciliation(DataOutput out, String[] names, long[] values, long[] versions) throws IOException {
         if(names == null) {
             out.writeInt(0);
             return;
@@ -601,14 +601,14 @@ public class COUNTER extends Protocol {
             Bits.writeLong(version, out);
     }
 
-    protected static String[] readReconciliationNames(DataInput in, int len) throws Exception {
+    protected static String[] readReconciliationNames(DataInput in, int len) throws IOException {
         String[] retval=new String[len];
         for(int i=0; i < len; i++)
             retval[i]=Bits.readString(in);
         return retval;
     }
 
-    protected static long[] readReconciliationLongs(DataInput in, int len) throws Exception {
+    protected static long[] readReconciliationLongs(DataInput in, int len) throws IOException {
         long[] retval=new long[len];
         for(int i=0; i < len; i++)
             retval[i]=Bits.readLong(in);
@@ -771,12 +771,14 @@ public class COUNTER extends Protocol {
             this.name=name;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             owner.writeTo(out);
             Bits.writeString(name,out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             owner=new Owner();
             owner.readFrom(in);
             name=Bits.readString(in);
@@ -788,8 +790,10 @@ public class COUNTER extends Protocol {
     }
 
     protected static class ResendPendingRequests implements Request {
-        public void writeTo(DataOutput out) throws Exception {}
-        public void readFrom(DataInput in) throws Exception {}
+        @Override
+        public void writeTo(DataOutput out) throws IOException {}
+        @Override
+        public void readFrom(DataInput in) throws IOException {}
         public String toString() {return "ResendPendingRequests";}
     }
 
@@ -803,12 +807,14 @@ public class COUNTER extends Protocol {
             this.initial_value=initial_value;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             initial_value=Bits.readLong(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Bits.writeLong(initial_value, out);
         }
@@ -849,12 +855,14 @@ public class COUNTER extends Protocol {
             this.value=value;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             value=Bits.readLong(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Bits.writeLong(value, out);
         }
@@ -874,13 +882,15 @@ public class COUNTER extends Protocol {
             this.update=update;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             expected=Bits.readLong(in);
             update=Bits.readLong(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Bits.writeLong(expected, out);
             Bits.writeLong(update, out);
@@ -903,11 +913,13 @@ public class COUNTER extends Protocol {
             this.versions=versions;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             writeReconciliation(out, names, values, versions);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             int len=in.readInt();
             names=readReconciliationNames(in, len);
             values=readReconciliationLongs(in, len);
@@ -931,13 +943,15 @@ public class COUNTER extends Protocol {
             this.version=version;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeString(name,out);
             Bits.writeLong(value, out);
             Bits.writeLong(version, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             name=Bits.readString(in);
             value=Bits.readLong(in);
             version=Bits.readLong(in);
@@ -963,13 +977,15 @@ public class COUNTER extends Protocol {
             this.version=version;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             owner=new Owner();
             owner.readFrom(in);
             version=Bits.readLong(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             owner.writeTo(out);
             Bits.writeLong(version, out);
         }
@@ -988,12 +1004,14 @@ public class COUNTER extends Protocol {
             this.result=result;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             result=in.readBoolean();
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             out.writeBoolean(result);
         }
@@ -1011,12 +1029,14 @@ public class COUNTER extends Protocol {
             this.result=result;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             result=Bits.readLong(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Bits.writeLong(result, out);
         }
@@ -1046,12 +1066,14 @@ public class COUNTER extends Protocol {
             this.error_message=error_message;
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             error_message=Bits.readString(in);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             Bits.writeString(error_message,out);
         }
@@ -1074,11 +1096,13 @@ public class COUNTER extends Protocol {
             this.versions=versions;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             writeReconciliation(out,names,values,versions);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             int len=in.readInt();
             names=readReconciliationNames(in, len);
             values=readReconciliationLongs(in, len);
@@ -1096,9 +1120,12 @@ public class COUNTER extends Protocol {
     public static class CounterHeader extends Header {
         public Supplier<? extends Header> create() {return CounterHeader::new;}
         public short getMagicId() {return 74;}
+        @Override
         public int serializedSize() {return 0;}
-        public void writeTo(DataOutput out) throws Exception {}
-        public void readFrom(DataInput in) throws Exception {}
+        @Override
+        public void writeTo(DataOutput out) {}
+        @Override
+        public void readFrom(DataInput in) {}
     }
     
 

--- a/src/org/jgroups/protocols/DAISYCHAIN.java
+++ b/src/org/jgroups/protocols/DAISYCHAIN.java
@@ -11,6 +11,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
@@ -194,15 +195,18 @@ public class DAISYCHAIN extends Protocol {
 
         public Supplier<? extends Header> create() {return DaisyHeader::new;}
 
+        @Override
         public int serializedSize() {
             return Global.SHORT_SIZE;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeShort(ttl);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             ttl=in.readShort();
         }
 

--- a/src/org/jgroups/protocols/DH_KEY_EXCHANGE.java
+++ b/src/org/jgroups/protocols/DH_KEY_EXCHANGE.java
@@ -13,6 +13,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.security.*;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.function.Supplier;
@@ -284,6 +285,7 @@ public class DH_KEY_EXCHANGE extends KeyExchange {
         public byte[]                     encryptedSecret() {return encrypted_secret_key;}
         public byte[]                     version()         {return secret_key_version;}
 
+        @Override
         public int serializedSize() {
             switch(type) {
                 case SECRET_KEY_REQ:
@@ -298,7 +300,8 @@ public class DH_KEY_EXCHANGE extends KeyExchange {
             }
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type.ordinal());
             switch(type) {
                 case SECRET_KEY_REQ:
@@ -324,7 +327,8 @@ public class DH_KEY_EXCHANGE extends KeyExchange {
             }
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             byte ordinal=in.readByte();
             type=Type.values()[ordinal];
 

--- a/src/org/jgroups/protocols/Discovery.java
+++ b/src/org/jgroups/protocols/Discovery.java
@@ -528,7 +528,7 @@ public abstract class Discovery extends Protocol {
     }
 
     protected static PingData deserialize(final byte[] data) throws Exception {
-        return (PingData)Util.streamableFromByteBuffer(PingData.class, data);
+        return Util.streamableFromByteBuffer(PingData::new, data);
     }
 
     public static Buffer marshal(PingData data) {
@@ -537,7 +537,7 @@ public abstract class Discovery extends Protocol {
 
     protected PingData readPingData(byte[] buffer, int offset, int length) {
         try {
-            return buffer != null? Util.streamableFromBuffer(PingData.class, buffer, offset, length) : null;
+            return buffer != null? Util.streamableFromBuffer(PingData::new, buffer, offset, length) : null;
         }
         catch(Exception ex) {
             log.error("%s: failed reading PingData from message: %s", local_addr, ex);

--- a/src/org/jgroups/protocols/EXAMPLE.java
+++ b/src/org/jgroups/protocols/EXAMPLE.java
@@ -9,6 +9,7 @@ import org.jgroups.util.MessageBatch;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -81,11 +82,13 @@ public class EXAMPLE extends Protocol {
             return "[EXAMPLE: <variables> ]";
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             // write variables to stream
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             // initialize variables from stream
         }
     }

--- a/src/org/jgroups/protocols/Encrypt.java
+++ b/src/org/jgroups/protocols/Encrypt.java
@@ -319,7 +319,7 @@ public abstract class Encrypt<E extends KeyStore.Entry> extends Protocol {
             return msg;
         }
 
-        Message ret=Util.streamableFromBuffer(Message.class,decrypted_msg,0,decrypted_msg.length);
+        Message ret=Util.streamableFromBuffer(Message::new,decrypted_msg,0,decrypted_msg.length);
         if(ret.getDest() == null)
             ret.setDest(msg.getDest());
         if(ret.getSrc() == null)

--- a/src/org/jgroups/protocols/EncryptHeader.java
+++ b/src/org/jgroups/protocols/EncryptHeader.java
@@ -6,6 +6,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 /**
@@ -41,22 +42,26 @@ public class EncryptHeader extends Header {
         return EncryptHeader::new;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         Util.writeByteBuffer(version, 0, version != null? version.length : 0, out);
         Util.writeByteBuffer(signature, 0, signature != null? signature.length : 0, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         type=in.readByte();
         version=Util.readByteBuffer(in);
         signature=Util.readByteBuffer(in);
     }
 
+    @Override
     public String toString() {
         return String.format("%s [version=%s]", typeToString(type), (version != null? Util.byteArrayToHexString(version) : "null"));
     }
 
+    @Override
     public int serializedSize() {return Global.BYTE_SIZE + Util.size(version) + Util.size(signature) /*+ Util.size(payload) */;}
 
     protected static String typeToString(byte type) {

--- a/src/org/jgroups/protocols/Executing.java
+++ b/src/org/jgroups/protocols/Executing.java
@@ -951,7 +951,8 @@ abstract public class Executing extends Protocol {
             return Request::new;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type.ordinal());
             // We can't use Util.writeObject since it's size is limited to 2^15-1
             try {
@@ -974,7 +975,8 @@ abstract public class Executing extends Protocol {
             out.writeLong(request);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=Type.values()[in.readByte()];
             // We can't use Util.readObject since it's size is limited to 2^15-1
             try {
@@ -1024,13 +1026,13 @@ abstract public class Executing extends Protocol {
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             super.readFrom(in);
             threadId = in.readLong();
         }
         
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             super.writeTo(out);
             out.writeLong(threadId);
         }
@@ -1053,10 +1055,12 @@ abstract public class Executing extends Protocol {
 
         public Supplier<? extends Header> create() {return ExecutorHeader::new;}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         }
     }
     

--- a/src/org/jgroups/protocols/FD.java
+++ b/src/org/jgroups/protocols/FD.java
@@ -436,7 +436,7 @@ public class FD extends Protocol {
 
         public void readFrom(DataInput in) throws Exception {
             type=in.readByte();
-            mbrs=(Collection<Address>)Util.readAddresses(in, ArrayList.class);
+            mbrs=Util.readAddresses(in, ArrayList::new);
             from=Util.readAddress(in);
         }
 

--- a/src/org/jgroups/protocols/FD.java
+++ b/src/org/jgroups/protocols/FD.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -418,7 +419,7 @@ public class FD extends Protocol {
             }
         }
 
-
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // type
             retval+=Util.size(mbrs);
@@ -426,15 +427,15 @@ public class FD extends Protocol {
             return retval;
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeAddresses(mbrs, out);
             Util.writeAddress(from, out);
         }
 
-
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             mbrs=Util.readAddresses(in, ArrayList::new);
             from=Util.readAddress(in);

--- a/src/org/jgroups/protocols/FD_ALL.java
+++ b/src/org/jgroups/protocols/FD_ALL.java
@@ -394,9 +394,12 @@ public class FD_ALL extends Protocol {
         public String toString() {return "heartbeat";}
         public short getMagicId() {return 62;}
         public Supplier<? extends Header> create() {return HeartbeatHeader::new;}
+        @Override
         public int serializedSize() {return 0;}
-        public void writeTo(DataOutput out) throws Exception {}
-        public void readFrom(DataInput in) throws Exception {}
+        @Override
+        public void writeTo(DataOutput out) {}
+        @Override
+        public void readFrom(DataInput in) {}
     }
 
 

--- a/src/org/jgroups/protocols/FD_ALL2.java
+++ b/src/org/jgroups/protocols/FD_ALL2.java
@@ -371,9 +371,12 @@ public class FD_ALL2 extends Protocol {
         public short getMagicId() {return 63;}
         public Supplier<? extends Header> create() {return HeartbeatHeader::new;}
         public String toString() {return "heartbeat";}
+        @Override
         public int serializedSize() {return 0;}
-        public void writeTo(DataOutput out) throws Exception {}
-        public void readFrom(DataInput in) throws Exception {}
+        @Override
+        public void writeTo(DataOutput out) {}
+        @Override
+        public void readFrom(DataInput in) {}
     }
 
 

--- a/src/org/jgroups/protocols/FD_SOCK.java
+++ b/src/org/jgroups/protocols/FD_SOCK.java
@@ -792,7 +792,7 @@ public class FD_SOCK extends Protocol implements Runnable {
                 addrs=new HashMap<>(size);
                 for(int i=0; i < size; i++) {
                     Address key=Util.readAddress(in);
-                    IpAddress val=Util.readStreamable(IpAddress.class, in);
+                    IpAddress val=Util.readStreamable(IpAddress::new, in);
                     addrs.put(key, val);
                 }
             }
@@ -930,7 +930,7 @@ public class FD_SOCK extends Protocol implements Runnable {
         public void readFrom(DataInput in) throws Exception {
             type=in.readByte();
             mbr=Util.readAddress(in);
-            sock_addr=Util.readStreamable(IpAddress.class, in);
+            sock_addr=Util.readStreamable(IpAddress::new, in);
             int size=in.readInt();
             if(size > 0) {
                 mbrs=new HashSet<>();

--- a/src/org/jgroups/protocols/FD_SOCK.java
+++ b/src/org/jgroups/protocols/FD_SOCK.java
@@ -897,7 +897,7 @@ public class FD_SOCK extends Protocol implements Runnable {
             }
         }
 
-
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // type
             retval+=Util.size(mbr);
@@ -916,7 +916,8 @@ public class FD_SOCK extends Protocol implements Runnable {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeAddress(mbr, out);
             Util.writeStreamable(sock_addr, out);
@@ -927,7 +928,8 @@ public class FD_SOCK extends Protocol implements Runnable {
                     Util.writeAddress(address, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             mbr=Util.readAddress(in);
             sock_addr=Util.readStreamable(IpAddress::new, in);

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -370,14 +370,17 @@ public class FORK extends Protocol {
             this.fork_channel_id=fork_channel_id;
         }
 
+        @Override
         public int serializedSize() {return Util.size(fork_stack_id) + Util.size(fork_channel_id);}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeString(fork_stack_id,out);
             Bits.writeString(fork_channel_id,out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             fork_stack_id=Bits.readString(in);
             fork_channel_id=Bits.readString(in);
         }

--- a/src/org/jgroups/protocols/FORWARD_TO_COORD.java
+++ b/src/org/jgroups/protocols/FORWARD_TO_COORD.java
@@ -9,6 +9,7 @@ import org.jgroups.util.ForwardQueue;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -204,14 +205,17 @@ public class FORWARD_TO_COORD extends Protocol {
         public short getMagicId() {return 81;}
         public long getId()   {return id;}
         public byte getType() {return type;}
+        @Override
         public int serializedSize()    {return Global.BYTE_SIZE + Bits.size(id);}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Bits.writeLong(id,out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type=in.readByte();
             id=Bits.readLong(in);
         }

--- a/src/org/jgroups/protocols/FcHeader.java
+++ b/src/org/jgroups/protocols/FcHeader.java
@@ -5,6 +5,7 @@ import org.jgroups.Header;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 /**
@@ -31,15 +32,18 @@ public class FcHeader extends Header {
 
     public short getMagicId() {return 59;}
 
+    @Override
     public int serializedSize() {
         return Global.BYTE_SIZE;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         type=in.readByte();
     }
 

--- a/src/org/jgroups/protocols/Frag3Header.java
+++ b/src/org/jgroups/protocols/Frag3Header.java
@@ -5,6 +5,7 @@ import org.jgroups.util.Bits;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -48,8 +49,8 @@ public class Frag3Header extends Header {
                              id, frag_id, num_frags, original_length, offset);
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Bits.writeInt(id,out);
         Bits.writeInt(frag_id, out);
         Bits.writeInt(num_frags, out);
@@ -57,11 +58,13 @@ public class Frag3Header extends Header {
         Bits.writeInt(offset, out);
     }
 
+    @Override
     public int serializedSize() {
         return Bits.size(id) + Bits.size(frag_id) + Bits.size(num_frags) + Bits.size(original_length) + Bits.size(offset);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         id=Bits.readInt(in);
         frag_id=Bits.readInt(in);
         num_frags=Bits.readInt(in);

--- a/src/org/jgroups/protocols/FragHeader.java
+++ b/src/org/jgroups/protocols/FragHeader.java
@@ -5,6 +5,7 @@ import org.jgroups.util.Bits;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -36,18 +37,20 @@ public class FragHeader extends Header {
         return "[id=" + id + ", frag_id=" + frag_id + ", num_frags=" + num_frags + ']';
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Bits.writeLong(id,out);
         Bits.writeInt(frag_id, out);
         Bits.writeInt(num_frags, out);
     }
 
+    @Override
     public int serializedSize() {
         return Bits.size(id) + Bits.size(frag_id) + Bits.size(num_frags);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         id=Bits.readLong(in);
         frag_id=Bits.readInt(in);
         num_frags=Bits.readInt(in);

--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -233,7 +233,7 @@ abstract public class Locking extends Protocol {
 
         Request req=null;
         try {
-            req=Util.streamableFromBuffer(Request.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+            req=Util.streamableFromBuffer(Request::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
         }
         catch(Exception ex) {
             log.error("failed deserializng request", ex);
@@ -1346,7 +1346,7 @@ abstract public class Locking extends Protocol {
             type=Type.values()[in.readByte()];
             lock_name=Bits.readString(in);
             lock_id=in.readInt();
-            owner=Util.readStreamable(Owner.class, in);
+            owner=Util.readStreamable(Owner::new, in);
             timeout=in.readLong();
             is_trylock=in.readBoolean();
         }

--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -16,6 +16,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -1333,7 +1334,8 @@ abstract public class Locking extends Protocol {
         public Request lockId(int lock_id) {this.lock_id=lock_id; return this;}
         public int lockId()                {return lock_id;}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type.ordinal());
             Bits.writeString(lock_name,out);
             out.writeInt(lock_id);
@@ -1342,7 +1344,8 @@ abstract public class Locking extends Protocol {
             out.writeBoolean(is_trylock);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=Type.values()[in.readByte()];
             lock_name=Bits.readString(in);
             lock_id=in.readInt();
@@ -1402,14 +1405,17 @@ abstract public class Locking extends Protocol {
             return LockingHeader::new;
         }
 
+        @Override
         public int serializedSize() {
             return 0;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         }
     }
 

--- a/src/org/jgroups/protocols/MERGE3.java
+++ b/src/org/jgroups/protocols/MERGE3.java
@@ -314,7 +314,7 @@ public class MERGE3 extends Protocol {
 
     protected View readView(byte[] buffer, int offset, int length) {
         try {
-            return buffer != null? Util.streamableFromBuffer(View.class, buffer, offset, length) : null;
+            return buffer != null? Util.streamableFromBuffer(View::new, buffer, offset, length) : null;
         }
         catch(Exception ex) {
             log.error("%s: failed reading View from message: %s", local_addr, ex);

--- a/src/org/jgroups/protocols/MERGE3.java
+++ b/src/org/jgroups/protocols/MERGE3.java
@@ -12,6 +12,7 @@ import org.jgroups.util.UUID;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Future;
@@ -556,6 +557,7 @@ public class MERGE3 extends Protocol {
         public short getMagicId() {return 75;}
         public Supplier<? extends Header> create() {return MergeHeader::new;}
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // for the type
             retval+=Util.size(view_id);
@@ -566,15 +568,16 @@ public class MERGE3 extends Protocol {
             return retval;
         }
 
-        public void writeTo(DataOutput outstream) throws Exception {
+        @Override
+        public void writeTo(DataOutput outstream) throws IOException {
             outstream.writeByte(type.ordinal()); // a byte if ok as we only have 3 types anyway
             Util.writeViewId(view_id,outstream);
             Bits.writeString(logical_name,outstream);
             Util.writeAddress(physical_addr, outstream);
         }
 
-        @SuppressWarnings("unchecked")
-        public void readFrom(DataInput instream) throws Exception {
+        @Override
+        public void readFrom(DataInput instream) throws IOException, ClassNotFoundException {
             type=Type.values()[instream.readByte()];
             view_id=Util.readViewId(instream);
             logical_name=Bits.readString(instream);

--- a/src/org/jgroups/protocols/NAMING.java
+++ b/src/org/jgroups/protocols/NAMING.java
@@ -11,6 +11,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -174,22 +175,26 @@ public class NAMING extends Protocol {
         public short                                  getMagicId() {return 89;}
 
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeShort(type.ordinal());
             Util.writeAddress(addr, out);
             Bits.writeString(name, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=Type.values()[in.readShort()];
             addr=Util.readAddress(in);
             name=Bits.readString(in);
         }
 
+        @Override
         public String toString() {
             return String.format("%s addr=%s name=%s", type, addr, name);
         }
 
+        @Override
         public int serializedSize() {
             return Global.SHORT_SIZE + Util.size(addr) + Util.size(name);
         }

--- a/src/org/jgroups/protocols/PDC.java
+++ b/src/org/jgroups/protocols/PDC.java
@@ -300,13 +300,15 @@ public class PDC extends Protocol {
         public Address  getPhysicalAddr() {return physical_addr;}
         public String   getLogicalName()  {return logical_name;}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Util.writeAddress(logical_addr, out);
             Util.writeAddress(physical_addr, out);
             Bits.writeString(logical_name,out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             logical_addr=Util.readAddress(in);
             physical_addr=Util.readAddress(in);
             logical_name=Bits.readString(in);

--- a/src/org/jgroups/protocols/PERF.java
+++ b/src/org/jgroups/protocols/PERF.java
@@ -10,6 +10,7 @@ import org.jgroups.util.MessageBatch;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 /**
@@ -105,15 +106,18 @@ public class PERF extends Protocol {
             return PerfHeader::new;
         }
 
+        @Override
         public int serializedSize() {
             return Global.LONG_SIZE;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeLong(start_time);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             start_time=in.readLong();
         }
     }

--- a/src/org/jgroups/protocols/PingData.java
+++ b/src/org/jgroups/protocols/PingData.java
@@ -141,13 +141,12 @@ public class PingData implements SizeStreamable, Constructable<PingData> {
         Util.writeAddresses(mbrs, outstream);
     }
 
-    @SuppressWarnings("unchecked")
     public void readFrom(DataInput instream) throws Exception {
         sender=Util.readAddress(instream);
         flags=instream.readByte();
         logical_name=Bits.readString(instream);
         physical_addr=(PhysicalAddress)Util.readAddress(instream);
-        mbrs=Util.readAddresses(instream, ArrayList.class);
+        mbrs=Util.readAddresses(instream, ArrayList::new);
     }
 
 

--- a/src/org/jgroups/protocols/PingData.java
+++ b/src/org/jgroups/protocols/PingData.java
@@ -11,6 +11,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -122,6 +123,7 @@ public class PingData implements SizeStreamable, Constructable<PingData> {
         return sb.toString();
     }
 
+    @Override
     public int serializedSize() {
         int retval=Global.BYTE_SIZE; // for is_server
         retval+=Util.size(sender);
@@ -133,7 +135,8 @@ public class PingData implements SizeStreamable, Constructable<PingData> {
         return retval;
     }
 
-    public void writeTo(DataOutput outstream) throws Exception {
+    @Override
+    public void writeTo(DataOutput outstream) throws IOException {
         Util.writeAddress(sender, outstream);
         outstream.writeByte(flags);
         Bits.writeString(logical_name,outstream);
@@ -141,7 +144,8 @@ public class PingData implements SizeStreamable, Constructable<PingData> {
         Util.writeAddresses(mbrs, outstream);
     }
 
-    public void readFrom(DataInput instream) throws Exception {
+    @Override
+    public void readFrom(DataInput instream) throws IOException, ClassNotFoundException {
         sender=Util.readAddress(instream);
         flags=instream.readByte();
         logical_name=Bits.readString(instream);

--- a/src/org/jgroups/protocols/PingHeader.java
+++ b/src/org/jgroups/protocols/PingHeader.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Bits;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -35,6 +36,7 @@ public class PingHeader extends Header {
 
     public Supplier<? extends Header> create() {return PingHeader::new;}
 
+    @Override
     public int serializedSize() {
         int retval=Global.BYTE_SIZE *3; // type, cluster_name presence and initial_discovery
         if(cluster_name != null)
@@ -54,14 +56,15 @@ public class PingHeader extends Header {
         }
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         Bits.writeString(cluster_name,out);
         out.writeBoolean(initial_discovery);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         type=in.readByte();
         cluster_name=Bits.readString(in);
         initial_discovery=in.readBoolean();

--- a/src/org/jgroups/protocols/RELAY.java
+++ b/src/org/jgroups/protocols/RELAY.java
@@ -296,7 +296,7 @@ public class RELAY extends Protocol {
 
     protected Object installView(byte[] buf, int offset, int length) {
         try {
-            ViewData data=Util.streamableFromByteBuffer(ViewData.class, buf, offset, length);
+            ViewData data=Util.streamableFromByteBuffer(ViewData::new, buf, offset, length);
             if(data.uuids != null)
                 NameCache.add(data.uuids);
 
@@ -434,7 +434,7 @@ public class RELAY extends Protocol {
 
     protected void sendOnLocalCluster(byte[] buf, int offset, int length) {
         try {
-            Message msg=Util.streamableFromByteBuffer(Message.class, buf, offset, length);
+            Message msg=Util.streamableFromByteBuffer(Message::new, buf, offset, length);
             Address sender=msg.getSrc();
             Address dest=msg.getDest();
 
@@ -536,7 +536,7 @@ public class RELAY extends Protocol {
                     break;
                 case VIEW:
                     try {
-                        ViewData data=Util.streamableFromByteBuffer(ViewData.class, msg.getRawBuffer(),
+                        ViewData data=Util.streamableFromByteBuffer(ViewData::new, msg.getRawBuffer(),
                                                                     msg.getOffset(), msg.getLength());
                         // replace addrs with proxies
                         if(data.remote_view != null) {

--- a/src/org/jgroups/protocols/RELAY.java
+++ b/src/org/jgroups/protocols/RELAY.java
@@ -11,6 +11,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -630,6 +631,7 @@ public class RELAY extends Protocol {
             return RelayHeader::new;
         }
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // type
             switch(type) {
@@ -644,7 +646,8 @@ public class RELAY extends Protocol {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type.ordinal());
             switch(type) {
                 case DISSEMINATE:
@@ -657,7 +660,8 @@ public class RELAY extends Protocol {
             }
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=Type.values()[in.readByte()];
             switch(type) {
                 case DISSEMINATE:
@@ -705,8 +709,8 @@ public class RELAY extends Protocol {
             return new ViewData(remote_view, global_view, tmp);
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Util.writeView(remote_view, out);
             Util.writeView(global_view, out);
             out.writeInt(uuids.size());
@@ -716,7 +720,8 @@ public class RELAY extends Protocol {
             }
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             remote_view=Util.readView(in);
             global_view=Util.readView(in);
             int size=in.readInt();

--- a/src/org/jgroups/protocols/RSVP.java
+++ b/src/org/jgroups/protocols/RSVP.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
@@ -384,16 +385,19 @@ public class RSVP extends Protocol {
         public short getMagicId() {return 76;}
         public Supplier<? extends Header> create() {return RsvpHeader::new;}
 
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE + Global.SHORT_SIZE;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             out.writeShort(id);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type=in.readByte();
             id=in.readShort();
         }

--- a/src/org/jgroups/protocols/SEQUENCER.java
+++ b/src/org/jgroups/protocols/SEQUENCER.java
@@ -452,7 +452,7 @@ public class SEQUENCER extends Protocol {
      */
     protected void unwrapAndDeliver(final Message msg, boolean flush_ack) {
         try {
-            Message msg_to_deliver=Util.streamableFromBuffer(Message.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+            Message msg_to_deliver=Util.streamableFromBuffer(Message::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
             SequencerHeader hdr=msg_to_deliver.getHeader(this.id);
             if(flush_ack)
                 hdr.flush_ack=true;

--- a/src/org/jgroups/protocols/SEQUENCER.java
+++ b/src/org/jgroups/protocols/SEQUENCER.java
@@ -11,6 +11,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -635,19 +636,21 @@ public class SEQUENCER extends Protocol {
             }
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Bits.writeLong(seqno,out);
             out.writeBoolean(flush_ack);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type=in.readByte();
             seqno=Bits.readLong(in);
             flush_ack=in.readBoolean();
         }
 
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE + Bits.size(seqno) + Global.BYTE_SIZE; // type + seqno + flush_ack
         }

--- a/src/org/jgroups/protocols/SEQUENCER2.java
+++ b/src/org/jgroups/protocols/SEQUENCER2.java
@@ -14,6 +14,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
@@ -459,19 +460,22 @@ public class SEQUENCER2 extends Protocol {
             }
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Bits.writeLong(seqno,out);
             out.writeShort(num_seqnos);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type=in.readByte();
             seqno=Bits.readLong(in);
             num_seqnos=in.readUnsignedShort();
         }
 
         // type + seqno + localSeqno + flush_ack
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE + Bits.size(seqno) + Global.SHORT_SIZE;
         }

--- a/src/org/jgroups/protocols/STOMP.java
+++ b/src/org/jgroups/protocols/STOMP.java
@@ -646,8 +646,7 @@ public class STOMP extends Protocol implements Runnable {
             return retval;
         }
 
-
-
+        @Override
         public int serializedSize() {
             int retval=Global.INT_SIZE *2; // type + size of hashmap
             for(Map.Entry<String,String> entry: headers.entrySet()) {
@@ -657,7 +656,8 @@ public class STOMP extends Protocol implements Runnable {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(type.ordinal());
             out.writeInt(headers.size());
             for(Map.Entry<String,String> entry: headers.entrySet()) {
@@ -666,7 +666,8 @@ public class STOMP extends Protocol implements Runnable {
             }
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type=Type.values()[in.readInt()];
             int size=in.readInt();
             for(int i=0; i < size; i++) {

--- a/src/org/jgroups/protocols/SaslHeader.java
+++ b/src/org/jgroups/protocols/SaslHeader.java
@@ -5,6 +5,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 public class SaslHeader extends Header {
@@ -58,13 +59,13 @@ public class SaslHeader extends Header {
     }
 
     @Override
-    public void writeTo(DataOutput out) throws Exception {
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type.ordinal());
         Util.writeByteBuffer(payload, out);
     }
 
     @Override
-    public void readFrom(DataInput in) throws Exception {
+    public void readFrom(DataInput in) throws IOException {
         type = Type.values()[in.readByte()];
         payload = Util.readByteBuffer(in);
     }

--- a/src/org/jgroups/protocols/TpHeader.java
+++ b/src/org/jgroups/protocols/TpHeader.java
@@ -7,6 +7,7 @@ import org.jgroups.util.AsciiString;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -45,18 +46,21 @@ public class TpHeader extends Header {
 
     public byte[] getClusterName() {return cluster_name;}
 
+    @Override
     public int serializedSize() {
         return cluster_name != null? Global.SHORT_SIZE + cluster_name.length : Global.SHORT_SIZE;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         int length=cluster_name != null? cluster_name.length : -1;
         out.writeShort(length);
         if(cluster_name != null)
             out.write(cluster_name, 0, cluster_name.length);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         int len=in.readShort();
         if(len >= 0) {
             cluster_name=new byte[len];

--- a/src/org/jgroups/protocols/UNICAST3.java
+++ b/src/org/jgroups/protocols/UNICAST3.java
@@ -402,7 +402,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
                     handleResendingOfFirstMessage(sender, hdr.timestamp());
                     break;
                 case UnicastHeader3.XMIT_REQ:  // received ACK for previously sent message
-                    handleXmitRequest(sender, Util.streamableFromBuffer(SeqnoList.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength()));
+                    handleXmitRequest(sender, Util.streamableFromBuffer(SeqnoList::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength()));
                     break;
                 case UnicastHeader3.CLOSE:
                     log.trace(local_addr + "%s <-- CLOSE(%s: conn-id=%s)", local_addr, sender, hdr.conn_id);

--- a/src/org/jgroups/protocols/UnicastHeader3.java
+++ b/src/org/jgroups/protocols/UnicastHeader3.java
@@ -6,6 +6,7 @@ import org.jgroups.util.Bits;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 /**
@@ -133,7 +134,8 @@ public class UnicastHeader3 extends Header {
      * | CLOSE | conn_id |
      * </pre>
      */
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         switch(type) {
             case DATA:
@@ -157,7 +159,8 @@ public class UnicastHeader3 extends Header {
         }
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         type=in.readByte();
         switch(type) {
             case DATA:

--- a/src/org/jgroups/protocols/VERIFY_SUSPECT.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.*;
@@ -348,17 +349,19 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
             }
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeShort(type);
             Util.writeAddress(from, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readShort();
             from=Util.readAddress(in);
         }
 
+        @Override
         public int serializedSize() {
             return Global.SHORT_SIZE + Util.size(from);
         }

--- a/src/org/jgroups/protocols/pbcast/DeltaView.java
+++ b/src/org/jgroups/protocols/pbcast/DeltaView.java
@@ -8,6 +8,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -53,7 +54,7 @@ public class DeltaView extends View {
     public Address[] getLeftMembers()   {return left_members;}
     public Address[] getNewMembers()    {return new_members;}
 
-
+    @Override
     public int serializedSize() {
         int retval=view_id.serializedSize() + ref_view_id.serializedSize();
         retval+=Util.size(left_members);
@@ -61,15 +62,16 @@ public class DeltaView extends View {
         return retval;
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         view_id.writeTo(out);
         ref_view_id.writeTo(out);
         Util.writeAddresses(left_members, out);
         Util.writeAddresses(new_members, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         view_id=new ViewId();
         view_id.readFrom(in);
         ref_view_id=new ViewId();

--- a/src/org/jgroups/protocols/pbcast/FLUSH.java
+++ b/src/org/jgroups/protocols/pbcast/FLUSH.java
@@ -946,8 +946,8 @@ public class FLUSH extends Protocol {
         if(buffer == null) return null;
         try {
             DataInput in=new ByteArrayDataInputStream(buffer, offset, length);
-            Collection<? extends Address> participants=Util.readAddresses(in, ArrayList.class);
-            Digest digest=Util.readStreamable(Digest.class, in);
+            Collection<Address> participants=Util.readAddresses(in, ArrayList::new);
+            Digest digest=Util.readStreamable(Digest::new, in);
             return new Tuple<>(participants, digest);
         }
         catch(Exception ex) {

--- a/src/org/jgroups/protocols/pbcast/FLUSH.java
+++ b/src/org/jgroups/protocols/pbcast/FLUSH.java
@@ -7,6 +7,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1039,14 +1040,14 @@ public class FLUSH extends Protocol {
             }
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             out.writeLong(viewID);
         }
 
-        @SuppressWarnings("unchecked")
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             type = in.readByte();
             viewID = in.readLong();
         }

--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -1214,7 +1214,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
 
     protected JoinRsp readJoinRsp(byte[] buffer, int offset, int length) {
         try {
-            return buffer != null? Util.streamableFromBuffer(JoinRsp.class, buffer, offset, length) : null;
+            return buffer != null? Util.streamableFromBuffer(JoinRsp::new, buffer, offset, length) : null;
         }
         catch(Exception ex) {
             log.error("%s: failed reading JoinRsp from message: %s", local_addr, ex);
@@ -1226,7 +1226,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
         if(buffer == null) return null;
         try {
             DataInput in=new ByteArrayDataInputStream(buffer, offset, length);
-            return Util.readAddresses(in, ArrayList.class);
+            return Util.readAddresses(in, ArrayList::new);
         }
         catch(Exception ex) {
             log.error("%s: failed reading members from message: %s", local_addr, ex);

--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -16,6 +16,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
@@ -1424,7 +1425,8 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
 
         public Supplier<? extends Header> create() {return GmsHeader::new;}
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             short flags=determineFlags();
             out.writeShort(flags);
@@ -1433,7 +1435,8 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
                 merge_id.writeTo(out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             short flags=in.readShort();
             mbr=Util.readAddress(in);
@@ -1445,6 +1448,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
             useFlushIfPresent=(flags & USE_FLUSH) == USE_FLUSH;
         }
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE  // type
               + Global.SHORT_SIZE       // flags

--- a/src/org/jgroups/protocols/pbcast/JoinRsp.java
+++ b/src/org/jgroups/protocols/pbcast/JoinRsp.java
@@ -10,6 +10,7 @@ import org.jgroups.util.SizeStreamable;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -45,8 +46,8 @@ public class JoinRsp implements SizeStreamable, Constructable<JoinRsp> {
     public String  getFailReason()         {return fail_reason;}
     public JoinRsp setFailReason(String r) {fail_reason=r; return this;}
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         byte flags=0;
         if(view != null)
             flags|=VIEW_PRESENT;
@@ -69,7 +70,8 @@ public class JoinRsp implements SizeStreamable, Constructable<JoinRsp> {
             out.writeUTF(fail_reason);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         byte flags=in.readByte();
 
         // 1. view
@@ -89,6 +91,7 @@ public class JoinRsp implements SizeStreamable, Constructable<JoinRsp> {
             fail_reason=in.readUTF();
     }
 
+    @Override
     public int serializedSize() {
         int retval=Global.BYTE_SIZE; // flags
 

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -612,7 +612,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
 
             case NakAckHeader2.XMIT_REQ:
                 try {
-                    SeqnoList missing=Util.streamableFromBuffer(SeqnoList.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                    SeqnoList missing=Util.streamableFromBuffer(SeqnoList::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                     if(missing != null)
                         handleXmitReq(msg.getSrc(), missing, hdr.sender);
                 }
@@ -660,7 +660,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
                     break;
                 case NakAckHeader2.XMIT_REQ:
                     try {
-                        SeqnoList missing=Util.streamableFromBuffer(SeqnoList.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                        SeqnoList missing=Util.streamableFromBuffer(SeqnoList::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                         if(missing != null)
                             handleXmitReq(msg.getSrc(), missing, hdr.sender);
                     }

--- a/src/org/jgroups/protocols/pbcast/NakAckHeader2.java
+++ b/src/org/jgroups/protocols/pbcast/NakAckHeader2.java
@@ -9,6 +9,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 
@@ -70,8 +71,8 @@ public class NakAckHeader2 extends Header {
     public long      getSeqno()   {return seqno;}
     public Address   getSender()  {return sender;}
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         switch(type) {
             case MSG:
@@ -85,7 +86,8 @@ public class NakAckHeader2 extends Header {
         }
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         type=in.readByte();
         switch(type) {
             case MSG:
@@ -98,8 +100,8 @@ public class NakAckHeader2 extends Header {
                 break;
         }
     }
-    
 
+    @Override
     public int serializedSize() {
         int retval=Global.BYTE_SIZE; // type
         switch(type) {

--- a/src/org/jgroups/protocols/pbcast/STABLE.java
+++ b/src/org/jgroups/protocols/pbcast/STABLE.java
@@ -691,7 +691,7 @@ public class STABLE extends Protocol {
 
     protected Digest readDigest(byte[] buffer, int offset, int length) {
         try {
-            return buffer != null? Util.streamableFromBuffer(Digest.class, buffer, offset, length) : null;
+            return buffer != null? Util.streamableFromBuffer(Digest::new, buffer, offset, length) : null;
         }
         catch(Exception ex) {
             log.error("%s: failed reading Digest from message: %s", local_addr, ex);

--- a/src/org/jgroups/protocols/pbcast/STABLE.java
+++ b/src/org/jgroups/protocols/pbcast/STABLE.java
@@ -9,6 +9,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -789,17 +790,20 @@ public class STABLE extends Protocol {
             return String.format("[%s] view-id= %s", type2String(type), view_id);
         }
 
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE // type
               + Util.size(view_id);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeViewId(view_id, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             view_id=Util.readViewId(in);
         }

--- a/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
@@ -448,7 +448,7 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
 
         public void readFrom(DataInput in) throws Exception {
             type=in.readByte();
-            my_digest=Util.readStreamable(Digest.class, in);
+            my_digest=Util.readStreamable(Digest::new, in);
         }
 
         public int serializedSize() {

--- a/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
@@ -14,6 +14,7 @@ import org.jgroups.util.Util;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.EOFException;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
@@ -440,17 +441,19 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
             }
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeStreamable(my_digest, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             my_digest=Util.readStreamable(Digest::new, in);
         }
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // type
             retval+=Global.BYTE_SIZE;    // presence byte for my_digest

--- a/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
@@ -578,8 +578,8 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
 
         public void readFrom(DataInput in) throws Exception {
             type=in.readByte();
-            digest=Util.readStreamable(Digest.class, in);
-            bind_addr=Util.readStreamable(IpAddress.class, in);
+            digest=Util.readStreamable(Digest::new, in);
+            bind_addr=Util.readStreamable(IpAddress::new, in);
         }
 
         public int serializedSize() {

--- a/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
@@ -9,6 +9,7 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
@@ -569,19 +570,21 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
             }
         }
 
-
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeStreamable(digest, out);
             Util.writeStreamable(bind_addr, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             digest=Util.readStreamable(Digest::new, in);
             bind_addr=Util.readStreamable(IpAddress::new, in);
         }
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE; // type
             retval+=Global.BYTE_SIZE;    // presence byte for my_digest

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -13,6 +13,7 @@ import org.w3c.dom.Node;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -763,17 +764,20 @@ public class RELAY2 extends Protocol {
         public short getMagicId() {return 80;}
         public Supplier<? extends Header> create() {return Relay2Header::new;}
 
+        @Override
         public int serializedSize() {
             return Global.BYTE_SIZE + Util.size(final_dest) + Util.size(original_sender);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             Util.writeAddress(final_dest, out);
             Util.writeAddress(original_sender, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             type=in.readByte();
             final_dest=Util.readAddress(in);
             original_sender=Util.readAddress(in);

--- a/src/org/jgroups/protocols/tom/MessageID.java
+++ b/src/org/jgroups/protocols/tom/MessageID.java
@@ -7,6 +7,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 
 /**
@@ -77,18 +78,19 @@ public class MessageID implements Comparable<MessageID>, Cloneable, SizeStreamab
         return result;
     }
 
+    @Override
     public int serializedSize() {
         return Bits.size(id) + Util.size(address);
     }
 
     @Override
-    public void writeTo(DataOutput out) throws Exception {
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeAddress(address, out);
         Bits.writeLong(id, out);
     }
 
     @Override
-    public void readFrom(DataInput in) throws Exception {
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         address = Util.readAddress(in);
         id = Bits.readLong(in);
     }

--- a/src/org/jgroups/protocols/tom/ToaHeader.java
+++ b/src/org/jgroups/protocols/tom/ToaHeader.java
@@ -91,7 +91,7 @@ public class ToaHeader extends Header {
         messageID.readFrom(in);
         sequencerNumber = Bits.readLong(in);
         if (type == DATA_MESSAGE) {
-            destinations = (Collection<Address>) Util.readAddresses(in, ArrayList.class);
+            destinations = Util.readAddresses(in, ArrayList::new);
         }
     }
 

--- a/src/org/jgroups/protocols/tom/ToaHeader.java
+++ b/src/org/jgroups/protocols/tom/ToaHeader.java
@@ -8,6 +8,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +76,7 @@ public class ToaHeader extends Header {
     }
 
     @Override
-    public void writeTo(DataOutput out) throws Exception {
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type);
         messageID.writeTo(out);
         Bits.writeLong(sequencerNumber, out);
@@ -85,7 +86,7 @@ public class ToaHeader extends Header {
     }
 
     @Override
-    public void readFrom(DataInput in) throws Exception {
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         type = in.readByte();
         messageID = new MessageID();
         messageID.readFrom(in);

--- a/src/org/jgroups/stack/GossipData.java
+++ b/src/org/jgroups/stack/GossipData.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -138,8 +139,8 @@ public class GossipData implements SizeStreamable {
         return retval;
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeByte(type.ordinal());
         Bits.writeString(group, out);
         Util.writeAddress(addr, out);
@@ -160,12 +161,13 @@ public class GossipData implements SizeStreamable {
             out.write(buffer, offset, length);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         readFrom(in, true);
     }
 
 
-    protected void readFrom(DataInput in, boolean read_type) throws Exception {
+    protected void readFrom(DataInput in, boolean read_type) throws IOException, ClassNotFoundException {
         if(read_type)
             type=GossipType.values()[in.readByte()];
         group=Bits.readString(in);

--- a/src/org/jgroups/stack/IpAddress.java
+++ b/src/org/jgroups/stack/IpAddress.java
@@ -151,7 +151,8 @@ public class IpAddress implements PhysicalAddress, Constructable<IpAddress> {
     }
 
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         if(ip_addr != null) {
             byte[] address=ip_addr.getAddress();  // 4 bytes (IPv4) or 16 bytes (IPv6)
             out.writeByte(address.length); // 1 byte
@@ -165,7 +166,8 @@ public class IpAddress implements PhysicalAddress, Constructable<IpAddress> {
         out.writeShort(port);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         int len=in.readByte();
         if(len > 0 && (len != Global.IPV4_SIZE && len != Global.IPV6_SIZE))
             throw new IOException("length has to be " + Global.IPV4_SIZE + " or " + Global.IPV6_SIZE + " bytes (was " +
@@ -184,6 +186,7 @@ public class IpAddress implements PhysicalAddress, Constructable<IpAddress> {
         port=in.readUnsignedShort();
     }
 
+    @Override
     public int serializedSize() {
         // length (1 bytes) + 4 bytes for port
         int tmp_size=Global.BYTE_SIZE+ Global.SHORT_SIZE;

--- a/src/org/jgroups/stack/IpAddressUUID.java
+++ b/src/org/jgroups/stack/IpAddressUUID.java
@@ -7,6 +7,7 @@ import org.jgroups.util.UUID;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -110,18 +111,21 @@ public class IpAddressUUID extends IpAddress {
             (high >> 16) ^ high);
     }*/
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         super.writeTo(out);
         out.writeLong(low);
         out.writeInt(high);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         super.readFrom(in);
         low=in.readLong();
         high=in.readInt();
     }
 
+    @Override
     public int serializedSize() {
         return super.serializedSize() + Global.LONG_SIZE + Global.INT_SIZE;
     }

--- a/src/org/jgroups/util/Average.java
+++ b/src/org/jgroups/util/Average.java
@@ -2,6 +2,7 @@ package org.jgroups.util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * Maintains an approximation of an average of values. Done by keeping track of the number of samples, and computing
@@ -62,12 +63,14 @@ public class Average implements Streamable {
         return String.valueOf(getAverage());
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeDouble(avg);
         Bits.writeLong(count, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         avg=in.readDouble();
         count=Bits.readLong(in);
     }

--- a/src/org/jgroups/util/AverageMinMax.java
+++ b/src/org/jgroups/util/AverageMinMax.java
@@ -2,6 +2,7 @@ package org.jgroups.util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -78,13 +79,13 @@ public class AverageMinMax extends Average {
         return count == 0? "n/a" : String.format("min/avg/max=%,d/%,.2f/%,d", min, getAverage(), max);
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    public void writeTo(DataOutput out) throws IOException {
         super.writeTo(out);
         Bits.writeLong(min, out);
         Bits.writeLong(max, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    public void readFrom(DataInput in) throws IOException {
         super.readFrom(in);
         min=Bits.readLong(in);
         max=Bits.readLong(in);

--- a/src/org/jgroups/util/Digest.java
+++ b/src/org/jgroups/util/Digest.java
@@ -7,6 +7,7 @@ import org.jgroups.annotations.Immutable;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -143,11 +144,12 @@ public class Digest implements SizeStreamable, Iterable<Digest.Entry>, Construct
         return new Digest(members, Arrays.copyOf(seqnos, seqnos.length));
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         writeTo(out, true);
     }
 
-    public void writeTo(DataOutput out, boolean write_addrs) throws Exception {
+    public void writeTo(DataOutput out, boolean write_addrs) throws IOException {
         if(write_addrs)
             Util.writeAddresses(members, out);
         else
@@ -156,11 +158,12 @@ public class Digest implements SizeStreamable, Iterable<Digest.Entry>, Construct
             Bits.writeLongSequence(seqnos[i * 2], seqnos[i * 2 +1], out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         readFrom(in, true);
     }
 
-    public void readFrom(DataInput in, boolean read_addrs) throws Exception {
+    public void readFrom(DataInput in, boolean read_addrs) throws IOException, ClassNotFoundException {
         if(read_addrs) {
             members=Util.readAddresses(in);
             seqnos=new long[capacity() * 2];
@@ -172,6 +175,7 @@ public class Digest implements SizeStreamable, Iterable<Digest.Entry>, Construct
             Bits.readLongSequence(in, seqnos, i*2);
     }
 
+    @Override
     public int serializedSize() {
         return (int)serializedSize(true);
     }

--- a/src/org/jgroups/util/ExtendedUUID.java
+++ b/src/org/jgroups/util/ExtendedUUID.java
@@ -149,20 +149,20 @@ public class ExtendedUUID extends FlagsUUID {
         return (T)this;
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         super.writeTo(out);
         write(out);
     }
 
-
-
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         super.readFrom(in);
         read(in);
     }
 
     /** The number of bytes required to serialize this instance */
+    @Override
     public int serializedSize() {
         return super.serializedSize() + Global.BYTE_SIZE + sizeofHashMap();
     }

--- a/src/org/jgroups/util/FlagsUUID.java
+++ b/src/org/jgroups/util/FlagsUUID.java
@@ -61,19 +61,20 @@ public class FlagsUUID extends UUID {
         return (T)this;
     }
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         super.writeTo(out);
         Bits.writeInt(flags, out);
     }
 
-
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         super.readFrom(in);
         flags=Bits.readInt(in);
     }
 
     /** The number of bytes required to serialize this instance */
+    @Override
     public int serializedSize()     {return super.serializedSize() + Bits.size(flags);}
     public String toString() {return String.format("%s (flags=%d)", super.toString(), flags);}
 

--- a/src/org/jgroups/util/MergeId.java
+++ b/src/org/jgroups/util/MergeId.java
@@ -5,6 +5,7 @@ import org.jgroups.Global;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /** ID to uniquely identify a merge
  * @author Bela Ban
@@ -41,12 +42,14 @@ public class MergeId implements Streamable {
         return Util.size(initiator) + Global.INT_SIZE;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeAddress(initiator, out);
         out.writeInt(id);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         initiator=Util.readAddress(in);
         id=in.readInt();
     }

--- a/src/org/jgroups/util/Owner.java
+++ b/src/org/jgroups/util/Owner.java
@@ -5,6 +5,7 @@ import org.jgroups.Address;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 
 /**
@@ -31,12 +32,14 @@ public class Owner implements Streamable {
         return thread_id;
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Util.writeAddress(address, out);
         Bits.writeLong(thread_id, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
         address=Util.readAddress(in);
         thread_id=Bits.readLong(in);
     }

--- a/src/org/jgroups/util/Range.java
+++ b/src/org/jgroups/util/Range.java
@@ -4,6 +4,7 @@ package org.jgroups.util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 
 public class Range implements SizeStreamable, Comparable<Range> {
@@ -42,18 +43,20 @@ public class Range implements SizeStreamable, Comparable<Range> {
     }
 
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         Bits.writeLongSequence(low, high, out);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         long[] seqnos={0,0};
         Bits.readLongSequence(in, seqnos, 0);
         low=seqnos[0];
         high=seqnos[1];
     }
 
+    @Override
     public int serializedSize() {
         return Bits.size(low, high);
     }

--- a/src/org/jgroups/util/SeqnoList.java
+++ b/src/org/jgroups/util/SeqnoList.java
@@ -5,6 +5,7 @@ import org.jgroups.Global;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
@@ -77,19 +78,22 @@ public class SeqnoList extends FixedSizeBitSet implements SizeStreamable, Iterab
         return index == -1? -1 : seqno(index);
     }
 
+    @Override
     public int serializedSize() {
         return Global.INT_SIZE // number of words
           + (words.length+1) * Global.LONG_SIZE; // words + offset
     }
 
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeInt(size);
         out.writeLong(offset);
         for(long word: words)
             out.writeLong(word);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         size=in.readInt();
         offset=in.readLong();
         words=new long[wordIndex(size - 1) + 1];

--- a/src/org/jgroups/util/Streamable.java
+++ b/src/org/jgroups/util/Streamable.java
@@ -2,6 +2,7 @@ package org.jgroups.util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 
 /**
  * Implementations of Streamable can add their state directly to the output stream, enabling them to bypass costly
@@ -12,9 +13,9 @@ public interface Streamable {
 
     /** Write the entire state of the current object (including superclasses) to outstream.
      * Note that the output stream <em>must not</em> be closed */
-    void writeTo(DataOutput out) throws Exception;
+    void writeTo(DataOutput out) throws IOException;
 
     /** Read the state of the current object (including superclasses) from instream
      * Note that the input stream <em>must not</em> be closed */
-    void readFrom(DataInput in) throws Exception;
+    void readFrom(DataInput in) throws IOException, ClassNotFoundException;
 }

--- a/src/org/jgroups/util/UUID.java
+++ b/src/org/jgroups/util/UUID.java
@@ -6,6 +6,7 @@ import org.jgroups.Global;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.function.Supplier;
 
@@ -204,18 +205,19 @@ public class UUID implements Address, Constructable<UUID> {
     }
 
 
-
-    public void writeTo(DataOutput out) throws Exception {
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
         out.writeLong(leastSigBits);
         out.writeLong(mostSigBits);
     }
 
-    public void readFrom(DataInput in) throws Exception {
+    @Override
+    public void readFrom(DataInput in) throws IOException {
         leastSigBits=in.readLong();
         mostSigBits=in.readLong();
     }
 
-
+    @Override
     public int serializedSize() {
         return SIZE;
     }

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -31,6 +31,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -783,9 +785,13 @@ public class Util {
         }
     }
 
-
+    @Deprecated
     public static <T extends Streamable> T streamableFromByteBuffer(Class<? extends Streamable> cl,byte[] buffer) throws Exception {
         return streamableFromByteBuffer(cl,buffer,0,buffer.length);
+    }
+
+    public static <T extends Streamable> T streamableFromByteBuffer(Supplier<T> factory, byte[] buffer) throws Exception {
+        return streamableFromByteBuffer(factory, buffer, 0, buffer.length);
     }
 
     /**
@@ -947,7 +953,7 @@ public class Util {
         }
     }
 
-
+    @Deprecated
     public static <T extends Streamable> T streamableFromByteBuffer(Class<? extends Streamable> cl,byte[] buffer,int offset,int length) throws Exception {
         if(buffer == null) return null;
         DataInput in=new ByteArrayDataInputStream(buffer,offset,length);
@@ -956,12 +962,24 @@ public class Util {
         return retval;
     }
 
+    public static <T extends Streamable> T streamableFromByteBuffer(Supplier<T> factory, byte[] buffer, int offset, int length) throws Exception {
+        if(buffer == null) return null;
+        DataInput in=new ByteArrayDataInputStream(buffer,offset,length);
+        T retval=factory.get();
+        retval.readFrom(in);
+        return retval;
+    }
 
+    @Deprecated
     public static <T extends Streamable> T streamableFromBuffer(Class<T> clazz,byte[] buffer,int offset,int length) throws Exception {
         DataInput in=new ByteArrayDataInputStream(buffer,offset,length);
         return Util.readStreamable(clazz, in);
     }
 
+    public static <T extends Streamable> T streamableFromBuffer(Supplier<T> factory, byte[] buffer, int offset, int length) throws Exception {
+        DataInput in=new ByteArrayDataInputStream(buffer,offset,length);
+        return Util.readStreamable(factory, in);
+    }
 
     public static byte[] streamableToByteBuffer(Streamable obj) throws Exception {
         int expected_size=obj instanceof SizeStreamable? ((SizeStreamable)obj).serializedSize() : 512;
@@ -1467,10 +1485,29 @@ public class Util {
      * @return Collection of Address objects
      * @throws Exception
      */
+    @Deprecated
     public static Collection<? extends Address> readAddresses(DataInput in,Class cl) throws Exception {
         short length=in.readShort();
         if(length < 0) return null;
         Collection<Address> retval=(Collection<Address>)cl.newInstance();
+        Address addr;
+        for(int i=0; i < length; i++) {
+            addr=Util.readAddress(in);
+            retval.add(addr);
+        }
+        return retval;
+    }
+
+    /**
+     * @param in
+     * @param factory a factory for creating the returned collection, parameterized by size
+     * @return Collection of Address objects
+     * @throws Exception
+     */
+    public static <T extends Collection<Address>> T readAddresses(DataInput in, IntFunction<T> factory) throws Exception {
+        short length=in.readShort();
+        if(length < 0) return null;
+        T retval = factory.apply(length);
         Address addr;
         for(int i=0; i < length; i++) {
             addr=Util.readAddress(in);
@@ -1525,7 +1562,7 @@ public class Util {
         obj.writeTo(out);
     }
 
-
+    @Deprecated
     public static <T extends Streamable> T readStreamable(Class<T> clazz,DataInput in) throws Exception {
         T retval=null;
         if(!in.readBoolean())
@@ -1535,6 +1572,14 @@ public class Util {
         return retval;
     }
 
+    public static <T extends Streamable> T readStreamable(Supplier<T> factory, DataInput in) throws Exception {
+        T retval=null;
+        if(!in.readBoolean())
+            return null;
+        retval=factory.get();
+        retval.readFrom(in);
+        return retval;
+    }
 
     public static void writeGenericStreamable(Streamable obj, DataOutput out) throws Exception {
         short magic_number;

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -468,17 +468,17 @@ public class Util {
     /**
      * Creates an object from a byte buffer
      */
-    public static <T extends Object> T objectFromByteBuffer(byte[] buffer) throws Exception {
+    public static <T extends Object> T objectFromByteBuffer(byte[] buffer) throws IOException, ClassNotFoundException {
         if(buffer == null) return null;
         return objectFromByteBuffer(buffer,0,buffer.length);
     }
 
-    public static <T extends Object> T objectFromByteBuffer(byte[] buffer,int offset,int length) throws Exception {
+    public static <T extends Object> T objectFromByteBuffer(byte[] buffer,int offset,int length) throws IOException, ClassNotFoundException {
         return objectFromByteBuffer(buffer, offset, length, null);
     }
 
 
-    public static <T extends Object> T objectFromByteBuffer(byte[] buffer,int offset,int length, ClassLoader loader) throws Exception {
+    public static <T extends Object> T objectFromByteBuffer(byte[] buffer,int offset,int length, ClassLoader loader) throws IOException, ClassNotFoundException {
         if(buffer == null) return null;
         byte type=buffer[offset++];
         length--;
@@ -521,7 +521,7 @@ public class Util {
      * Serializes/Streams an object into a byte buffer.
      * The object has to implement interface Serializable or Externalizable or Streamable.
      */
-    public static byte[] objectToByteBuffer(Object obj) throws Exception {
+    public static byte[] objectToByteBuffer(Object obj) throws IOException {
         if(obj == null)
             return TYPE_NULL_ARRAY;
 
@@ -557,7 +557,7 @@ public class Util {
     }
 
 
-    public static Buffer objectToBuffer(Object obj) throws Exception {
+    public static Buffer objectToBuffer(Object obj) throws IOException {
         if(obj == null)
             return new Buffer(TYPE_NULL_ARRAY);
 
@@ -656,7 +656,7 @@ public class Util {
 
 
 
-    public static void objectToStream(Object obj, DataOutput out) throws Exception {
+    public static void objectToStream(Object obj, DataOutput out) throws IOException {
         if(obj == null) {
             out.write(TYPE_NULL);
             return;
@@ -738,11 +738,11 @@ public class Util {
         }
     }
 
-    public static <T extends Object> T objectFromStream(DataInput in) throws Exception {
+    public static <T extends Object> T objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
         return objectFromStream(in, null);
     }
 
-    public static <T extends Object> T objectFromStream(DataInput in, ClassLoader loader) throws Exception {
+    public static <T extends Object> T objectFromStream(DataInput in, ClassLoader loader) throws IOException, ClassNotFoundException {
         if(in == null) return null;
         byte b=in.readByte();
 
@@ -797,12 +797,12 @@ public class Util {
     /**
      * Poor man's serialization of an exception. Serializes only the message, stack trace and cause (not suppressed exceptions)
      */
-    public static void exceptionToStream(Throwable t, DataOutput out) throws Exception {
+    public static void exceptionToStream(Throwable t, DataOutput out) throws IOException {
         Set<Throwable> causes=new HashSet<>();
         exceptionToStream(causes, t, out);
     }
 
-    protected static void exceptionToStream(Set<Throwable> causes, Throwable t, DataOutput out) throws Exception {
+    protected static void exceptionToStream(Set<Throwable> causes, Throwable t, DataOutput out) throws IOException {
         // 1. null check
         if( t == null) {
             out.writeBoolean(true);
@@ -828,12 +828,12 @@ public class Util {
     }
 
 
-    public static Throwable exceptionFromStream(DataInput in) throws Exception {
+    public static Throwable exceptionFromStream(DataInput in) throws IOException, ClassNotFoundException {
         return exceptionFromStream(in, 0);
     }
 
 
-    protected static Throwable exceptionFromStream(DataInput in, int recursion_count) throws Exception {
+    protected static Throwable exceptionFromStream(DataInput in, int recursion_count) throws IOException, ClassNotFoundException {
         // 1. null check
         if(in.readBoolean())
             return null;
@@ -844,7 +844,7 @@ public class Util {
         return readException(in, recursion_count);
     }
 
-    protected static void writeException(Set<Throwable> causes, Throwable t, DataOutput out) throws Exception {
+    protected static void writeException(Set<Throwable> causes, Throwable t, DataOutput out) throws IOException {
         // 3. classname
         Bits.writeString(t.getClass().getName(), out);
 
@@ -874,7 +874,7 @@ public class Util {
     }
 
 
-    protected static Throwable readException(DataInput in, int recursion_count) throws Exception {
+    protected static Throwable readException(DataInput in, int recursion_count) throws IOException, ClassNotFoundException {
         // 3. classname
         String classname=Bits.readString(in);
         Class<? extends Throwable> clazz=(Class<? extends Throwable>)Util.loadClass(classname, (ClassLoader)null);
@@ -896,10 +896,15 @@ public class Util {
         catch(Throwable t) {
         }
 
-        if(retval == null)
-            retval=clazz.newInstance();
+        if(retval == null) {
+            try {
+                retval=clazz.newInstance();
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new IllegalStateException(e);
+            }
+        }
 
-        // 5. stack trace
+    // 5. stack trace
         int depth=in.readShort();
         if(depth > 0) {
             StackTraceElement[] stack_trace=new StackTraceElement[depth];
@@ -1282,7 +1287,7 @@ public class Util {
     }
 
 
-    public static void writeView(View view,DataOutput out) throws Exception {
+    public static void writeView(View view,DataOutput out) throws IOException {
         if(view == null) {
             out.writeBoolean(false);
             return;
@@ -1293,7 +1298,7 @@ public class Util {
     }
 
 
-    public static View readView(DataInput in) throws Exception {
+    public static View readView(DataInput in) throws IOException, ClassNotFoundException {
         if(!in.readBoolean())
             return null;
         boolean isMergeView=in.readBoolean();
@@ -1306,7 +1311,7 @@ public class Util {
         return view;
     }
 
-    public static void writeViewId(ViewId vid,DataOutput out) throws Exception {
+    public static void writeViewId(ViewId vid,DataOutput out) throws IOException {
         if(vid == null) {
             out.writeBoolean(false);
             return;
@@ -1315,7 +1320,7 @@ public class Util {
         vid.writeTo(out);
     }
 
-    public static ViewId readViewId(DataInput in) throws Exception {
+    public static ViewId readViewId(DataInput in) throws IOException, ClassNotFoundException {
         if(!in.readBoolean())
             return null;
         ViewId retval=new ViewId();
@@ -1324,7 +1329,7 @@ public class Util {
     }
 
 
-    public static void writeAddress(Address addr,DataOutput out) throws Exception {
+    public static void writeAddress(Address addr,DataOutput out) throws IOException {
         byte flags=0;
         boolean streamable_addr=true;
 
@@ -1358,7 +1363,7 @@ public class Util {
             writeOtherAddress(addr,out);
     }
 
-    public static Address readAddress(DataInput in) throws Exception {
+    public static Address readAddress(DataInput in) throws IOException, ClassNotFoundException {
         byte flags=in.readByte();
         if(Util.isFlagSet(flags,Address.NULL))
             return null;
@@ -1434,14 +1439,14 @@ public class Util {
         return buf == null? Global.BYTE_SIZE : Global.BYTE_SIZE + Global.INT_SIZE + buf.length;
     }
 
-    private static Address readOtherAddress(DataInput in) throws Exception {
+    private static Address readOtherAddress(DataInput in) throws IOException, ClassNotFoundException {
         short magic_number=in.readShort();
         Address addr=ClassConfigurator.create(magic_number);
         addr.readFrom(in);
         return addr;
     }
 
-    private static void writeOtherAddress(Address addr,DataOutput out) throws Exception {
+    private static void writeOtherAddress(Address addr,DataOutput out) throws IOException {
         short magic_number=ClassConfigurator.getMagicNumber(addr.getClass());
 
         // write the class info
@@ -1458,7 +1463,7 @@ public class Util {
      * @param out
      * @throws Exception
      */
-    public static void writeAddresses(Collection<? extends Address> v,DataOutput out) throws Exception {
+    public static void writeAddresses(Collection<? extends Address> v,DataOutput out) throws IOException {
         if(v == null) {
             out.writeShort(-1);
             return;
@@ -1469,7 +1474,7 @@ public class Util {
         }
     }
 
-    public static void writeAddresses(final Address[] addrs,DataOutput out) throws Exception {
+    public static void writeAddresses(final Address[] addrs,DataOutput out) throws IOException {
         if(addrs == null) {
             out.writeShort(-1);
             return;
@@ -1502,9 +1507,10 @@ public class Util {
      * @param in
      * @param factory a factory for creating the returned collection, parameterized by size
      * @return Collection of Address objects
+     * @throws ClassNotFoundException 
      * @throws Exception
      */
-    public static <T extends Collection<Address>> T readAddresses(DataInput in, IntFunction<T> factory) throws Exception {
+    public static <T extends Collection<Address>> T readAddresses(DataInput in, IntFunction<T> factory) throws IOException, ClassNotFoundException {
         short length=in.readShort();
         if(length < 0) return null;
         T retval = factory.apply(length);
@@ -1517,7 +1523,7 @@ public class Util {
     }
 
 
-    public static Address[] readAddresses(DataInput in) throws Exception {
+    public static Address[] readAddresses(DataInput in) throws IOException, ClassNotFoundException {
         short length=in.readShort();
         if(length < 0) return null;
         Address[] retval=new Address[length];
@@ -1553,7 +1559,7 @@ public class Util {
     }
 
 
-    public static void writeStreamable(Streamable obj,DataOutput out) throws Exception {
+    public static void writeStreamable(Streamable obj,DataOutput out) throws IOException {
         if(obj == null) {
             out.writeBoolean(false);
             return;
@@ -1572,7 +1578,7 @@ public class Util {
         return retval;
     }
 
-    public static <T extends Streamable> T readStreamable(Supplier<T> factory, DataInput in) throws Exception {
+    public static <T extends Streamable> T readStreamable(Supplier<T> factory, DataInput in) throws IOException, ClassNotFoundException {
         T retval=null;
         if(!in.readBoolean())
             return null;
@@ -1581,7 +1587,7 @@ public class Util {
         return retval;
     }
 
-    public static void writeGenericStreamable(Streamable obj, DataOutput out) throws Exception {
+    public static void writeGenericStreamable(Streamable obj, DataOutput out) throws IOException {
         short magic_number;
         String classname;
 
@@ -1600,11 +1606,11 @@ public class Util {
         obj.writeTo(out); // write the contents
     }
 
-    public static <T extends Streamable> T readGenericStreamable(DataInput in) throws Exception {
+    public static <T extends Streamable> T readGenericStreamable(DataInput in) throws IOException, ClassNotFoundException {
         return readGenericStreamable(in, null);
     }
 
-    public static <T extends Streamable> T readGenericStreamable(DataInput in, ClassLoader loader) throws Exception {
+    public static <T extends Streamable> T readGenericStreamable(DataInput in, ClassLoader loader) throws IOException, ClassNotFoundException {
         T retval=null;
         int b=in.readByte();
         if(b == 0)
@@ -1619,7 +1625,11 @@ public class Util {
         else {
             String classname=in.readUTF();
             clazz=ClassConfigurator.get(classname, loader);
-            retval=(T)clazz.newInstance();
+            try {
+                retval=(T)clazz.newInstance();
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new IllegalStateException(e);
+            }
         }
 
         retval.readFrom(in);
@@ -1650,7 +1660,7 @@ public class Util {
 
 
 
-    public static void writeObject(Object obj,DataOutput out) throws Exception {
+    public static void writeObject(Object obj,DataOutput out) throws IOException {
         if(obj instanceof Streamable) {
             out.writeInt(-1);
             writeGenericStreamable((Streamable)obj,out);
@@ -1662,7 +1672,7 @@ public class Util {
         }
     }
 
-    public static Object readObject(DataInput in) throws Exception {
+    public static Object readObject(DataInput in) throws IOException, ClassNotFoundException {
         int len=in.readInt();
         if(len == -1)
             return readGenericStreamable(in);
@@ -1770,11 +1780,11 @@ public class Util {
     }
 
 
-    public static void writeByteBuffer(byte[] buf,DataOutput out) throws Exception {
+    public static void writeByteBuffer(byte[] buf,DataOutput out) throws IOException {
         writeByteBuffer(buf,0,buf.length,out);
     }
 
-    public static void writeByteBuffer(byte[] buf,int offset,int length,DataOutput out) throws Exception {
+    public static void writeByteBuffer(byte[] buf,int offset,int length,DataOutput out) throws IOException {
         if(buf != null) {
             out.write(1);
             out.writeInt(length);
@@ -1784,7 +1794,7 @@ public class Util {
             out.write(0);
     }
 
-    public static byte[] readByteBuffer(DataInput in) throws Exception {
+    public static byte[] readByteBuffer(DataInput in) throws IOException {
         int b=in.readByte();
         if(b == 1) {
             b=in.readInt();

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
@@ -142,7 +142,7 @@ public class NAKACK2_RetransmissionTest {
             if(hdr.getType() == NakAckHeader2.XMIT_REQ) {
                 SeqnoList seqnos=null;
                 try {
-                    seqnos=Util.streamableFromBuffer(SeqnoList.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                    seqnos=Util.streamableFromBuffer(SeqnoList::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                     System.out.println("-- XMIT-REQ: request retransmission for " + seqnos);
                     for(Long seqno: seqnos)
                         xmit_requests.add(seqno);

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_REBROADCAST_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_REBROADCAST_Test.java
@@ -88,7 +88,7 @@ public class NAKACK_REBROADCAST_Test {
             NakAckHeader2 hdr=msg.getHeader(NAKACK_ID);
             if(hdr != null && hdr.getType() == NakAckHeader2.XMIT_REQ) {
                 try {
-                    this.range=Util.streamableFromBuffer(SeqnoList.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                    this.range=Util.streamableFromBuffer(SeqnoList::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                 }
                 catch(Exception e) {
                     e.printStackTrace();

--- a/tests/junit-functional/org/jgroups/tests/DeltaViewTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DeltaViewTest.java
@@ -134,7 +134,7 @@ public class DeltaViewTest {
             int count=1;
             for(Message msg: join_rsps) {
                 try {
-                    JoinRsp join_rsp=Util.streamableFromBuffer(JoinRsp.class, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
+                    JoinRsp join_rsp=Util.streamableFromBuffer(JoinRsp::new, msg.getRawBuffer(), msg.getOffset(), msg.getLength());
                     System.out.printf("join-rsp #%d to %s: %s\n", count++, msg.dest(), join_rsp.getView());
                 }
                 catch(Throwable t) {
@@ -164,7 +164,7 @@ public class DeltaViewTest {
             join_rsp_msg=join_rsps.remove(0);
             JoinRsp join_rsp=null;
             try {
-                join_rsp=Util.streamableFromBuffer(JoinRsp.class, join_rsp_msg.getRawBuffer(), join_rsp_msg.getOffset(), join_rsp_msg.getLength());
+                join_rsp=Util.streamableFromBuffer(JoinRsp::new, join_rsp_msg.getRawBuffer(), join_rsp_msg.getOffset(), join_rsp_msg.getLength());
             }
             catch(Exception e) {
                 throw new RuntimeException(e);

--- a/tests/junit-functional/org/jgroups/tests/DigestTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DigestTest.java
@@ -83,7 +83,7 @@ public class DigestTest {
 
     public void testViewId() throws Exception {
         byte[] buf=Util.streamableToByteBuffer(d);
-        Digest digest=(Digest)Util.streamableFromByteBuffer(Digest.class,buf);
+        Digest digest=Util.streamableFromByteBuffer(Digest::new,buf);
         System.out.println("digest = " + digest);
     }
 
@@ -401,7 +401,7 @@ public class DigestTest {
 
     public void testViewBasedMarshalling() throws Exception {
         byte[] buf=Util.streamableToByteBuffer(d);
-        Digest new_digest=(Digest)Util.streamableFromByteBuffer(Digest.class,buf);
+        Digest new_digest=Util.streamableFromByteBuffer(Digest::new,buf);
         System.out.println("new_digest = " + new_digest);
         assert new_digest.equals(d);
     }
@@ -425,7 +425,7 @@ public class DigestTest {
         byte[] buf1=Util.streamableToByteBuffer(digest);
         System.out.println("buf1: " + buf1.length + " bytes");
 
-        Digest digest1=(Digest)Util.streamableFromByteBuffer(Digest.class,buf1);
+        Digest digest1=Util.streamableFromByteBuffer(Digest::new,buf1);
 
         System.out.println("digest1 = " + digest1);
         assert digest.equals(digest1);

--- a/tests/junit-functional/org/jgroups/tests/ExtendedUUIDTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ExtendedUUIDTest.java
@@ -47,7 +47,7 @@ public class ExtendedUUIDTest {
         assert !uuid.isFlagSet((short)2);
 
         byte[] buf=Util.streamableToByteBuffer(uuid);
-        FlagsUUID uuid2=Util.streamableFromByteBuffer(FlagsUUID.class, buf, 0, buf.length);
+        FlagsUUID uuid2=Util.streamableFromByteBuffer(FlagsUUID::new, buf, 0, buf.length);
         assert uuid.equals(uuid2);
     }
 
@@ -142,7 +142,7 @@ public class ExtendedUUIDTest {
         int size=uuid.serializedSize();
         byte[] buffer=Util.streamableToByteBuffer(uuid);
         assert size == buffer.length : "expected size of " + size + ", but got " + buffer.length;
-        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID.class, buffer);
+        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID::new, buffer);
         assert uuid2.isFlagSet((short)16);
         assert uuid2.isFlagSet((short)32);
         for(String key: Arrays.asList("name", "age", "bool"))
@@ -155,7 +155,7 @@ public class ExtendedUUIDTest {
         int size=uuid.serializedSize();
         byte[] buffer=Util.streamableToByteBuffer(uuid);
         assert size == buffer.length : "expected size of " + size + ", but got " + buffer.length;
-        Util.streamableFromByteBuffer(ExtendedUUID.class, buffer);
+        Util.streamableFromByteBuffer(ExtendedUUID::new, buffer);
     }
 
     public void testMarshallingLargeValues() throws Exception {
@@ -166,7 +166,7 @@ public class ExtendedUUIDTest {
         int size=uuid.serializedSize();
         byte[] buffer=Util.streamableToByteBuffer(uuid);
         assert size == buffer.length : "expected size of " + size + ", but got " + buffer.length;
-        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID.class, buffer);
+        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID::new, buffer);
         System.out.println("uuid2 = " + uuid2);
         for(int i=1; i <= 5; i++) {
             byte[] val=uuid.get(String.valueOf(i));
@@ -182,7 +182,7 @@ public class ExtendedUUIDTest {
         int size=uuid.serializedSize();
         byte[] buffer=Util.streamableToByteBuffer(uuid);
         assert size == buffer.length : "expected size of " + size + ", but got " + buffer.length;
-        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID.class, buffer);
+        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID::new, buffer);
         for(int i=1; i <= 5; i++) {
             byte[] val=uuid.get(String.valueOf(i));
             boolean null_val=i % 2 != 0;
@@ -209,7 +209,7 @@ public class ExtendedUUIDTest {
         int size=uuid.serializedSize();
         byte[] buffer=Util.streamableToByteBuffer(uuid);
         assert size == buffer.length : "expected size of " + size + ", but got " + buffer.length;
-        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID.class, buffer);
+        ExtendedUUID uuid2=Util.streamableFromByteBuffer(ExtendedUUID::new, buffer);
         assert uuid2.length() == 5;
 
         for(int i=1; i <= 10; i++) {

--- a/tests/junit-functional/org/jgroups/tests/HeadersTest.java
+++ b/tests/junit-functional/org/jgroups/tests/HeadersTest.java
@@ -158,12 +158,15 @@ public class HeadersTest {
             return MyHeader::new;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) {
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) {
         }
 
+        @Override
         public int serializedSize() {
             return 0;
         }

--- a/tests/junit-functional/org/jgroups/tests/MessageTest.java
+++ b/tests/junit-functional/org/jgroups/tests/MessageTest.java
@@ -492,14 +492,17 @@ public class MessageTest {
             return num;
         }
 
+        @Override
         public int serializedSize() {
             return 0;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) {
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) {
         }
 
         public String toString() {

--- a/tests/junit-functional/org/jgroups/tests/SeqnoListTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SeqnoListTest.java
@@ -113,7 +113,7 @@ public class SeqnoListTest {
         System.out.println("list.size()=" + list.size()  + "\nlist = " + list);
         int expected_size=list.serializedSize();
         byte[] buf=Util.streamableToByteBuffer(list);
-        SeqnoList list2=Util.streamableFromByteBuffer(SeqnoList.class, buf);
+        SeqnoList list2=Util.streamableFromByteBuffer(SeqnoList::new, buf);
         System.out.println("list2.size()=" + list2.size() + "\nlist2 = " + list2);
         assert list.size() == list2.size();
 

--- a/tests/junit-functional/org/jgroups/tests/SizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SizeTest.java
@@ -726,7 +726,7 @@ public class SizeTest {
         System.out.println("\nlen=" + len + ", serialized length=" + buf.length);
         assert len == buf.length;
         DataInputStream in=new DataInputStream(new ByteArrayInputStream(buf));
-        Collection<? extends Address> new_list=Util.readAddresses(in, ArrayList.class);
+        Collection<Address> new_list=Util.readAddresses(in, ArrayList::new);
         System.out.println("old list=" + list + "\nnew list=" + new_list);
         assert list.equals(new_list);
     }
@@ -740,7 +740,7 @@ public class SizeTest {
 
         uuid=org.jgroups.util.UUID.randomUUID();
         byte[] buf=Util.streamableToByteBuffer(uuid);
-        org.jgroups.util.UUID uuid2=Util.streamableFromByteBuffer(UUID.class, buf);
+        org.jgroups.util.UUID uuid2=Util.streamableFromByteBuffer(UUID::new, buf);
         System.out.println("uuid:  " + uuid);
         System.out.println("uuid2: " + uuid2);
         assert uuid.equals(uuid2);
@@ -823,14 +823,14 @@ public class SizeTest {
         byte[] buf=Util.streamableToByteBuffer(hdr);
         assert buf.length == expected_size;
 
-        DH_KEY_EXCHANGE.DhHeader hdr2=Util.streamableFromByteBuffer(DH_KEY_EXCHANGE.DhHeader.class, buf, 0, buf.length);
+        DH_KEY_EXCHANGE.DhHeader hdr2=Util.streamableFromByteBuffer(DH_KEY_EXCHANGE.DhHeader::new, buf, 0, buf.length);
         assert Arrays.equals(hdr.dhKey(), hdr2.dhKey());
     }
 
 
     private static void _testMarshalling(UnicastHeader3 hdr) throws Exception {
         byte[] buf=Util.streamableToByteBuffer(hdr);
-        UnicastHeader3 hdr2=Util.streamableFromByteBuffer(UnicastHeader3.class, buf);
+        UnicastHeader3 hdr2=Util.streamableFromByteBuffer(UnicastHeader3::new, buf);
 
         assert hdr.type()       == hdr2.type();
         assert hdr.seqno()      == hdr2.seqno();
@@ -913,7 +913,7 @@ public class SizeTest {
         System.out.println("size=" + size + ", serialized size=" + serialized_form.length);
         Assert.assertEquals(serialized_form.length, size);
 
-        JoinRsp rsp2=Util.streamableFromByteBuffer(JoinRsp.class, serialized_form);
+        JoinRsp rsp2=Util.streamableFromByteBuffer(JoinRsp::new, serialized_form);
         assert Util.match(rsp.getDigest(), rsp2.getDigest());
         assert Util.match(rsp.getView(), rsp2.getView());
         assert Util.match(rsp.getFailReason(), rsp2.getFailReason());

--- a/tests/junit-functional/org/jgroups/tests/StreamableTest.java
+++ b/tests/junit-functional/org/jgroups/tests/StreamableTest.java
@@ -149,7 +149,7 @@ public class StreamableTest {
         assert buf != null;
         assert buf.length > 0;
 
-        MergeView merge_view=(MergeView)Util.streamableFromByteBuffer(MergeView.class, buf);
+        MergeView merge_view=Util.streamableFromByteBuffer(MergeView::new, buf);
         assert merge_view != null;
         System.out.println("MergeView: " + merge_view);
         for(View v: merge_view.getSubgroups()) {

--- a/tests/junit-functional/org/jgroups/tests/UtilTest.java
+++ b/tests/junit-functional/org/jgroups/tests/UtilTest.java
@@ -701,7 +701,7 @@ public class UtilTest {
         DataInputStream dis=new DataInputStream(instream);
         View v2=Util.readGenericStreamable(dis);
         Assert.assertEquals(v, v2);
-        v2=Util.readStreamable(View.class, dis);
+        v2=Util.readStreamable(View::new, dis);
         Assert.assertEquals(v, v2);
     }
 

--- a/tests/junit/org/jgroups/blocks/RpcDispatcherSerializationTest.java
+++ b/tests/junit/org/jgroups/blocks/RpcDispatcherSerializationTest.java
@@ -110,7 +110,8 @@ public class RpcDispatcherSerializationTest extends ChannelTestBase {
         static final byte LONG   = 2;
         static final byte OBJ    = 3;
 
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             if(obj == null)
                 out.writeByte(NULL);
             else if(obj instanceof Boolean) {
@@ -128,7 +129,8 @@ public class RpcDispatcherSerializationTest extends ChannelTestBase {
             }
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             int type=in.readByte();
             switch(type) {
                 case NULL:

--- a/tests/junit/org/jgroups/blocks/executor/ExecutingServiceTest.java
+++ b/tests/junit/org/jgroups/blocks/executor/ExecutingServiceTest.java
@@ -201,12 +201,12 @@ public class ExecutingServiceTest extends ChannelTestBase {
         }
 
         @Override
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             out.writeLong(millis);
         }
 
         @Override
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             millis = in.readLong();
         }
 
@@ -255,30 +255,14 @@ public class ExecutingServiceTest extends ChannelTestBase {
         }
 
         @Override
-        public void writeTo(DataOutput out) throws Exception {
-            try {
-                Util.writeObject(_object, out);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException(e);
-            }
+        public void writeTo(DataOutput out) throws IOException {
+            Util.writeObject(_object, out);
         }
 
         @SuppressWarnings("unchecked")
         @Override
-        public void readFrom(DataInput in) throws Exception {
-            try {
-                _object = (V)Util.readObject(in);
-            }
-            catch (IOException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new IOException(e);
-            }
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
+            _object = (V)Util.readObject(in);
         }
     }
     

--- a/tests/other/org/jgroups/tests/UnicastTestRpc.java
+++ b/tests/other/org/jgroups/tests/UnicastTestRpc.java
@@ -12,6 +12,7 @@ import javax.management.MBeanServer;
 import java.io.BufferedReader;
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -366,11 +367,13 @@ public class UnicastTestRpc extends ReceiverAdapter {
             return 50;
         }
 
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             Util.objectToStream(obj, out);
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             return Util.objectFromStream(in);
         }
     }

--- a/tests/perf/org/jgroups/tests/perf/MPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/MPerf.java
@@ -608,12 +608,14 @@ public class MPerf extends ReceiverAdapter {
             return Util.size(attr_name) + Util.size(attr_value);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeString(attr_name,out);
             Util.writeByteBuffer(attr_value, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             attr_name=Bits.readString(in);
             attr_value=Util.readByteBuffer(in);
         }
@@ -640,13 +642,13 @@ public class MPerf extends ReceiverAdapter {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(changes.size());
             for(ConfigChange change: changes)
                 change.writeTo(out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             int len=in.readInt();
             for(int i=0; i < len; i++) {
                 ConfigChange change=new ConfigChange();
@@ -706,12 +708,12 @@ public class MPerf extends ReceiverAdapter {
             return Bits.size(time) + Bits.size(msgs);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeLong(time,out);
             Bits.writeLong(msgs,out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             time=Bits.readLong(in);
             msgs=Bits.readLong(in);
         }
@@ -746,6 +748,7 @@ public class MPerf extends ReceiverAdapter {
             return MPerfHeader::new;
         }
 
+        @Override
         public int serializedSize() {
             int retval=Global.BYTE_SIZE;
             if(type == DATA)
@@ -753,13 +756,13 @@ public class MPerf extends ReceiverAdapter {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        public void writeTo(DataOutput out) throws IOException {
             out.writeByte(type);
             if(type == DATA)
                 Bits.writeLong(seqno, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        public void readFrom(DataInput in) throws IOException {
             type=in.readByte();
             if(type == DATA)
                 seqno=Bits.readLong(in);

--- a/tests/perf/org/jgroups/tests/perf/MPerfRpc.java
+++ b/tests/perf/org/jgroups/tests/perf/MPerfRpc.java
@@ -532,12 +532,14 @@ public class MPerfRpc extends ReceiverAdapter {
             return Util.size(attr_name) + Util.size(attr_value);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeString(attr_name,out);
             Util.writeByteBuffer(attr_value, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             attr_name=Bits.readString(in);
             attr_value=Util.readByteBuffer(in);
         }
@@ -564,13 +566,15 @@ public class MPerfRpc extends ReceiverAdapter {
             return retval;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(changes.size());
             for(ConfigChange change: changes)
                 change.writeTo(out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             int len=in.readInt();
             for(int i=0; i < len; i++) {
                 ConfigChange change=new ConfigChange();
@@ -630,12 +634,14 @@ public class MPerfRpc extends ReceiverAdapter {
             return Bits.size(time) + Bits.size(msgs);
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeLong(time, out);
             Bits.writeLong(msgs, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException {
             time=Bits.readLong(in);
             msgs=Bits.readLong(in);
         }
@@ -654,11 +660,13 @@ public class MPerfRpc extends ReceiverAdapter {
             return 50;
         }
 
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             Util.objectToStream(obj, out);
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             return Util.objectFromStream(in);
         }
 

--- a/tests/perf/org/jgroups/tests/perf/UPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/UPerf.java
@@ -589,8 +589,8 @@ public class UPerf extends ReceiverAdapter {
             num_gets=Bits.readLong(in);
             num_puts=Bits.readLong(in);
             time=Bits.readLong(in);
-            avg_gets=Util.readStreamable(AverageMinMax.class, in);
-            avg_puts=Util.readStreamable(AverageMinMax.class, in);
+            avg_gets=Util.readStreamable(AverageMinMax::new, in);
+            avg_puts=Util.readStreamable(AverageMinMax::new, in);
         }
 
         public String toString() {

--- a/tests/perf/org/jgroups/tests/perf/UPerf.java
+++ b/tests/perf/org/jgroups/tests/perf/UPerf.java
@@ -13,6 +13,7 @@ import org.jgroups.util.*;
 import javax.management.MBeanServer;
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -462,11 +463,13 @@ public class UPerf extends ReceiverAdapter {
             return 50;
         }
 
-        public void objectToStream(Object obj, DataOutput out) throws Exception {
+        @Override
+        public void objectToStream(Object obj, DataOutput out) throws IOException {
             Util.objectToStream(obj, out);
         }
 
-        public Object objectFromStream(DataInput in) throws Exception {
+        @Override
+        public Object objectFromStream(DataInput in) throws IOException, ClassNotFoundException {
             return Util.objectFromStream(in);
         }
     }
@@ -577,7 +580,8 @@ public class UPerf extends ReceiverAdapter {
             this.avg_puts=avg_puts;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             Bits.writeLong(num_gets, out);
             Bits.writeLong(num_puts, out);
             Bits.writeLong(time, out);
@@ -585,7 +589,8 @@ public class UPerf extends ReceiverAdapter {
             Util.writeStreamable(avg_puts, out);
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             num_gets=Bits.readLong(in);
             num_puts=Bits.readLong(in);
             time=Bits.readLong(in);
@@ -614,7 +619,8 @@ public class UPerf extends ReceiverAdapter {
             return this;
         }
 
-        public void writeTo(DataOutput out) throws Exception {
+        @Override
+        public void writeTo(DataOutput out) throws IOException {
             out.writeInt(values.size());
             for(Map.Entry<String,Object> entry: values.entrySet()) {
                 Bits.writeString(entry.getKey(),out);
@@ -622,7 +628,8 @@ public class UPerf extends ReceiverAdapter {
             }
         }
 
-        public void readFrom(DataInput in) throws Exception {
+        @Override
+        public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
             int size=in.readInt();
             for(int i=0; i < size; i++) {
                 String key=Bits.readString(in);


### PR DESCRIPTION
This removes the need for consumers of these methods to consistently handle a non-specific java.lang.Exception - particularly useful when adapting to other marshalling frameworks.
Also, eliminates unnecessary use of reflection when reading objects of a known type from a stream.