### PR TITLE
Fix MULTI_PING JavaDoc

### DIFF
--- a/src/org/jgroups/protocols/MULTI_PING.java
+++ b/src/org/jgroups/protocols/MULTI_PING.java
@@ -12,16 +12,16 @@ import java.util.stream.Collectors;
 /**
  * Protocol to invoke multiple discovery protocols in the same stack. All discovery protocols needs to be _below_ this
  * one, e.g.
- * <pre>
-     <TCP.../>
-     <TCPPING initial_hosts="127.0.0.1[7800]"/>
-     <PING />
-     <MPING/>
-     <FILE_PING/>
-     <MULTI_PING async_discovery="true"/>
-     <MERGE3 .../>
-      ...
- * </pre>
+ * <pre>{@code
+ *   <TCP.../>
+ *   <TCPPING initial_hosts="127.0.0.1[7800]"/>
+ *   <PING />
+ *   <MPING/>
+ *   <FILE_PING/>
+ *   <MULTI_PING async_discovery="true"/>
+ *   <MERGE3 .../>
+ *   ...
+ * }</pre>
  * @author Bela Ban
  * @since  4.0.8
  */


### PR DESCRIPTION
ns

n.b. tags need to be escaped otherwise you get http://www.jgroups.org/javadoc4/org/jgroups/protocols/MULTI_PING.html