### PR TITLE
Test to demonstrate MERGE3 speed on tcp stack

### DIFF
--- a/src/org/jgroups/protocols/VERIFY_SUSPECT.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT.java
@@ -76,6 +76,17 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
     public VERIFY_SUSPECT() {       
     }
 
+    /* ------------------------------------------ Builder-like methods  ------------------------------------------ */
+
+    public VERIFY_SUSPECT setTimeout(long timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
     public Object down(Event evt) {
         switch(evt.getType()) {
             case Event.SET_LOCAL_ADDRESS:

--- a/tests/other/org/jgroups/tests/InfinispanStackMerge3Test.java
+++ b/tests/other/org/jgroups/tests/InfinispanStackMerge3Test.java
@@ -1,0 +1,128 @@
+package org.jgroups.tests;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.jgroups.JChannel;
+import org.jgroups.View;
+import org.jgroups.protocols.FD_ALL;
+import org.jgroups.protocols.FD_SOCK;
+import org.jgroups.protocols.FRAG3;
+import org.jgroups.protocols.MERGE3;
+import org.jgroups.protocols.MFC;
+import org.jgroups.protocols.MPING;
+import org.jgroups.protocols.TCP;
+import org.jgroups.protocols.TP;
+import org.jgroups.protocols.UDP;
+import org.jgroups.protocols.UNICAST3;
+import org.jgroups.protocols.VERIFY_SUSPECT;
+import org.jgroups.protocols.pbcast.GMS;
+import org.jgroups.protocols.pbcast.NAKACK2;
+import org.jgroups.protocols.pbcast.STABLE;
+import org.jgroups.util.Util;
+
+/**
+ * This test runs number of merge events with a similar stack configuration that current Infinispan and WildFly is using to
+ * showcase speed of merges after partitioning.
+ *
+ * @author Radoslav Husar
+ */
+public class InfinispanStackMerge3Test {
+
+    private static List<Supplier<TP>> TRANSPORTS;
+    private static int RUNS;
+    private static int MEMBERS;
+
+    static {
+        TRANSPORTS = new LinkedList<>();
+        TRANSPORTS.add(TCP::new);
+        TRANSPORTS.add(UDP::new);
+
+        RUNS = Integer.valueOf(System.getProperty("runs", "10"));
+
+        MEMBERS = Integer.valueOf(System.getProperty("members", "10"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        Map<String, List<Long>> results = new HashMap<>();
+
+        for (Supplier<TP> transport : TRANSPORTS) {
+            results.put(transport.get().getClass().getSimpleName(), new LinkedList<>());
+
+            for (int run = 0; run < RUNS; run++) {
+                JChannel[] channels = new JChannel[MEMBERS];
+
+                // Setup
+                for (int member = 0; member < MEMBERS; member++) {
+                    channels[member] = createChannel(transport.get(),
+                            InfinispanStackMerge3Test.class.getSimpleName() + member);
+                }
+                Util.waitUntilAllChannelsHaveSameView(10_000, 100, channels);
+
+                // Partition
+                Stream.of(channels).forEach(channel -> {
+                    GMS gms = channel.getProtocolStack().findProtocol(GMS.class);
+                    View view = View.create(channel.getAddress(), gms.getViewId().getId() + 1, channel.getAddress());
+                    gms.installView(view);
+                });
+
+                // Merge
+                long timeBeforeMerge = System.currentTimeMillis();
+                Util.waitUntilAllChannelsHaveSameView(360_000, 100, channels);
+                long timeAfterMerge = System.currentTimeMillis();
+
+                // Cleanup
+                Stream.of(channels).forEach(JChannel::close);
+
+                results.get(transport.get().getClass().getSimpleName()).add(timeAfterMerge - timeBeforeMerge);
+            }
+        }
+
+        printStats(results);
+    }
+
+    protected static JChannel createChannel(TP transport, String name) throws Exception {
+        // Workaround FD_ALL not being builder-like
+        FD_ALL fd_all = new FD_ALL();
+        fd_all.setInterval(15_000);
+        fd_all.setTimeout(60_000);
+        fd_all.setTimeoutCheckInterval(5_000);
+
+        JChannel channel = new JChannel(
+                transport,
+                new MPING(),
+                new MERGE3()
+                        .setMinInterval(10_000)
+                        .setMaxInterval(30_000),
+                new FD_SOCK(),
+                fd_all,
+                new VERIFY_SUSPECT()
+                        .setTimeout(5_000),
+                new NAKACK2()
+                        .setUseMcastXmit(false),
+                new UNICAST3(),
+                new STABLE(),
+                new GMS(),
+                new MFC(),
+                new FRAG3()
+                        .fragSize(8_000)
+        );
+        channel.setName(name);
+        channel.connect(InfinispanStackMerge3Test.class.getSimpleName());
+        return channel;
+    }
+
+    private static void printStats(Map<String, List<Long>> results) {
+        for (Map.Entry<String, List<Long>> entry : results.entrySet()) {
+            System.out.printf("Results for %s%n", entry.getKey());
+            System.out.printf("Min merge time=%d%n", entry.getValue().stream().min(Long::compare).get());
+            System.out.printf("Max merge time=%d%n", entry.getValue().stream().max(Long::compare).get());
+            System.out.printf("Avg merge time=%s%n", entry.getValue().stream().mapToLong(x -> x).average().getAsDouble());
+            System.out.printf("===================================================================%n");
+        }
+    }
+}


### PR DESCRIPTION
Hi Bela,

here is a manual test for the issue I brought up at last meeting in Milan with MERGE3 when using TCP stack. The test configures Infinispan-like stack, creates partition by installing a view and waits for partition to merge back. This yields results like this one (runs exactly the same setup and only switches TCP/UDP):

```
-------------------------------------------------------------------
Results for TCP
Min merge time=48034
Max merge time=101050
Avg merge time=86958.1
===================================================================
Results for UDP
Min merge time=48019
Max merge time=48104
Avg merge time=48056.0
===================================================================
```

The problem being that merges with fairly low intervals 10-30 seconds can take actually up to 2 minutes for merge. Let me know what you think.
