### PR TITLE
Fix memory leak

### DIFF
--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -140,14 +140,13 @@ public class NioConnection extends Connection {
         try {
             if(!server.deferClientBinding())
                 this.channel.bind(new InetSocketAddress(server.clientBindAddress(), server.clientBindPort()));
-            if(this.channel.getLocalAddress() != null && this.channel.getLocalAddress().equals(destAddr))
-                throw new IllegalStateException("socket's bind and connect address are the same: " + destAddr);
-
             this.key=server.register(channel, SelectionKey.OP_CONNECT | SelectionKey.OP_READ, this);
             if(Util.connect(channel, destAddr) && channel.finishConnect()) {
                 clearSelectionKey(SelectionKey.OP_CONNECT);
                 this.connected=channel.isConnected();
             }
+            if(this.channel.getLocalAddress() != null && this.channel.getLocalAddress().equals(destAddr))
+                throw new IllegalStateException("socket's bind and connect address are the same: " + destAddr);
             if(send_local_addr)
                 sendLocalAddress(server.localAddress());
         }

--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -91,9 +91,9 @@ public class TcpConnection extends Connection {
         try {
             if(!server.defer_client_binding)
                 this.sock.bind(new InetSocketAddress(server.client_bind_addr, server.client_bind_port));
+            Util.connect(this.sock, destAddr, server.sock_conn_timeout);
             if(this.sock.getLocalSocketAddress() != null && this.sock.getLocalSocketAddress().equals(destAddr))
                 throw new IllegalStateException("socket's bind and connect address are the same: " + destAddr);
-            Util.connect(this.sock, destAddr, server.sock_conn_timeout);
             this.out=new DataOutputStream(createBufferedOutputStream(sock.getOutputStream()));
             this.in=new DataInputStream(createBufferedInputStream(sock.getInputStream()));
             connected=sock.isConnected();


### PR DESCRIPTION
The memory leak described in https://issues.jboss.org/browse/JGRP-1530 may still occur if the bind IP address passed to the client socket is null and the resulting source and destination addresses are equal. This is because the local IP address of the client socket after binding and before connecting to the remote server is 0.0.0.0 and it differs from the destination IP address. After connecting the local IP address is being updated to the actual value.