### PR TITLE
JGRP-2291 Tests do not compile with maven (org.testng:testng:jar:7.0.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>[6.9,)</version>
+            <version>[6.9,6.999]</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…0-beta1 is no longer compatible)

See https://issues.jboss.org/browse/JGRP-2291