### PR TITLE
JGRP-2296: Preserve port number from SRV records

### DIFF
--- a/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
@@ -87,7 +87,7 @@ class DefaultDNSResolver implements DNSResolver {
                             String srcPort = matcher.group(1);
                             String srcDNSRecord = matcher.group(2);
                             // The implementation here is not optimal but it's easy to read. SRV discovery will be performed
-                            // extremely rare only when a fine grained discovery using ports is needed.
+                            // extremely rarely, only when a fine grained discovery using ports is needed (ie: when using containers).
                             addresses.addAll(resolveAEntries(srcDNSRecord, srcPort));
                         }
                     } catch (Exception e) {
@@ -104,16 +104,7 @@ class DefaultDNSResolver implements DNSResolver {
     }
 
     protected List<Address> resolveAEntries(String dnsQuery) {
-        List<Address> addresses = new ArrayList<>();
-        try {
-            InetAddress[] inetAddresses = InetAddress.getAllByName(dnsQuery);
-            for (InetAddress address : inetAddresses) {
-                addresses.add(new IpAddress(address, 0));
-            }
-        } catch (UnknownHostException e) {
-            log.trace("No DNS records for query: " + dnsQuery);
-        }
-        return addresses;
+        return resolveAEntries(dnsQuery, "0");
     }
 
     protected List<Address> resolveAEntries(String dnsQuery, String srcPort) {


### PR DESCRIPTION
This PR fixes JGRP-2296:

```
2018-10-05 20:08:38,083 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) Performing initial discovery
2018-10-05 20:08:38,086 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) Entries collected from DNS: [10.42.3.44:7600, 10.42.3.56:7600]
2018-10-05 20:08:38,087 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) Performing discovery of the following hosts [10.42.3.56:7600, 10.42.3.44:7600, e8c677a1d275, 98670c2eeed5]
2018-10-05 20:08:38,088 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) 98670c2eeed5: sending discovery request to 10.42.3.56:7600
2018-10-05 20:08:38,088 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) 98670c2eeed5: sending discovery request to 10.42.3.44:7600
2018-10-05 20:08:38,089 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-15,ejb,98670c2eeed5) Received discovery from: 98670c2eeed5, IP: 10.42.3.44:7600
2018-10-05 20:08:38,089 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) 98670c2eeed5: sending discovery request to e8c677a1d275
2018-10-05 20:08:38,090 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-14,ejb,98670c2eeed5) 98670c2eeed5: sending discovery request to 98670c2eeed5
2018-10-05 20:08:38,090 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-15,ejb,98670c2eeed5) Received discovery from: 98670c2eeed5, IP: 10.42.3.44:7600
2018-10-05 20:08:39,468 DEBUG [org.jboss.jca.core.connectionmanager.pool.validator.ConnectionValidator] (ConnectionValidator) Notifying pools, interval: 30000
```
Compare this with the prior version:
```
2018-10-05 16:15:06,019 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) Performing initial discovery
2018-10-05 16:15:06,024 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) Entries collected from DNS: [10.42.3.56:0, 10.42.3.44:0]
2018-10-05 16:15:06,025 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) Discovered IP Address with port 0 (10.42.3.56:0). Replacing with default Transport port: 7600
2018-10-05 16:15:06,025 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) Discovered IP Address with port 0 (10.42.3.44:0). Replacing with default Transport port: 7600
2018-10-05 16:15:06,025 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) Performing discovery of the following hosts [10.42.3.44:7600, 10.42.3.56:7600, 6aad4e9ec3ec, 132db10f3fe1]
2018-10-05 16:15:06,026 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) 6aad4e9ec3ec: sending discovery request to 10.42.3.44:7600
2018-10-05 16:15:06,026 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) 6aad4e9ec3ec: sending discovery request to 10.42.3.56:7600
2018-10-05 16:15:06,027 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-15,ejb,6aad4e9ec3ec) Received discovery from: 6aad4e9ec3ec, IP: 10.42.3.56:7600
2018-10-05 16:15:06,027 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) 6aad4e9ec3ec: sending discovery request to 6aad4e9ec3ec
2018-10-05 16:15:06,028 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-3,null,null) Received discovery from: 6aad4e9ec3ec, IP: 10.42.3.56:7600
2018-10-05 16:15:06,028 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-4,null,null) 6aad4e9ec3ec: sending discovery request to 132db10f3fe1
2018-10-05 16:15:28,984 DEBUG [org.jboss.jca.core.connectionmanager.pool.validator.ConnectionValidator] (ConnectionValidator) Notifying pools, interval: 30000
```