### PR TITLE
JGRP-2306 only log error for unexpected disconnects

### DIFF
--- a/src/org/jgroups/client/StompConnection.java
+++ b/src/org/jgroups/client/StompConnection.java
@@ -327,7 +327,10 @@ public class StompConnection implements Runnable {
                 timeout = 0;
             }
             catch(IOException e) {
-                log.error(Util.getMessage("ConnectionClosedUnexpectedly"), e);
+                if (running) {
+                    // only unexpected if running is true, otherwise disconnect was already called
+                    log.error(Util.getMessage("ConnectionClosedUnexpectedly"), e);
+                }
                 if (reconnect) {
                     closeConnections();
                 }


### PR DESCRIPTION
When running is false this error may be expected

Note: I saw this error logging behavior in `3.6.9.Final` not sure if this is the correct branch to merge into to fix both 3.x and 4.x, nor am I sure what the differences are.