### PR TITLE
JGRP-2316: if the port for a discovered member is non-zero, use it

### DIFF
--- a/src/org/jgroups/protocols/dns/DNS_PING.java
+++ b/src/org/jgroups/protocols/dns/DNS_PING.java
@@ -113,18 +113,22 @@ public class DNS_PING extends Discovery {
                     continue;
                 if (address instanceof IpAddress) {
                     IpAddress ip = ((IpAddress) address);
-                    for(int i=0; i <= portRange; i++) {
-                        IpAddress addr=new IpAddress(ip.getIpAddress(), transportPort + i);
-                        if(!cluster_members.contains(addr))
-                            cluster_members.add(addr);
+                    if (ip.getPort() != 0) {
+                        cluster_members.add(ip);
+                    }
+                    else {
+                        for (int i = 0; i <= portRange; i++) {
+                            IpAddress addr = new IpAddress(ip.getIpAddress(), transportPort + i);
+                            if (!cluster_members.contains(addr))
+                                cluster_members.add(addr);
+                        }
                     }
                 }
             }
         }
 
-        if(dns_discovery_members != null && !dns_discovery_members.isEmpty() && log.isDebugEnabled())
-            log.debug("%s: sending discovery requests to hosts %s on ports [%d .. %d]",
-                      local_addr, dns_discovery_members, transportPort, transportPort+portRange);
+        if(!cluster_members.isEmpty() && log.isDebugEnabled())
+            log.debug("%s: sending discovery requests to hosts %s", local_addr, cluster_members);
 
         PingHeader hdr = new PingHeader(PingHeader.GET_MBRS_REQ).clusterName(cluster_name).initialDiscovery(initial_discovery);
         for (Address addr : cluster_members) {


### PR DESCRIPTION
This PR fixes https://issues.jboss.org/browse/JGRP-2316

The log entries below show the fix in action... 1 service with 2 TCP ports were discovered, the discovery request was sent (with the discovered port):

```
2018-11-29 22:21:04,473 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-3,null,null) Entries collected from DNS (in 4 ms): [172.29.11.50:3249, 172.29.11.50:3250]
2018-11-29 22:21:04,473 DEBUG [org.jgroups.protocols.dns.DNS_PING] (thread-3,null,null) 9c0fc2b7a794: sending discovery requests to hosts [172.29.11.50:3249]
```