### PR TITLE
In FILE_PING, ensure that coordinator creates a file for itself if none exists

### DIFF
--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -136,7 +136,14 @@ public class FILE_PING extends Discovery {
                     ; // use case #1 if we have predefined files: most members join but are not coord
             }
             else {
-                sendDiscoveryResponse(local_addr, phys_addr, UUID.get(local_addr), null, false);
+                if (data == null && is_coord) { 
+                    // a coordinator in a separate partition may have deleted this coordinator's file
+                    PingData coord_data=new PingData(local_addr, true, UUID.get(local_addr), phys_addr).coord(is_coord);
+                    write(Collections.singletonList(coord_data), cluster_name);
+                }
+                else {
+                    sendDiscoveryResponse(local_addr, phys_addr, UUID.get(local_addr), null, false);
+                }
             }
         }
         finally {

--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -136,14 +136,11 @@ public class FILE_PING extends Discovery {
                     ; // use case #1 if we have predefined files: most members join but are not coord
             }
             else {
-                if (data == null && is_coord) { 
-                    // a coordinator in a separate partition may have deleted this coordinator's file
-                    PingData coord_data=new PingData(local_addr, true, UUID.get(local_addr), phys_addr).coord(is_coord);
-                    write(Collections.singletonList(coord_data), cluster_name);
-                }
-                else {
-                    sendDiscoveryResponse(local_addr, phys_addr, UUID.get(local_addr), null, false);
-                }
+                sendDiscoveryResponse(local_addr, phys_addr, UUID.get(local_addr), null, false);
+            }
+            if (!initial_discovery && is_coord && (data == null || !data.isCoord())) {
+                // a coordinator in a separate partition may have deleted this coordinator's file
+                writeAll();
             }
         }
         finally {


### PR DESCRIPTION
This is a fix for https://issues.jboss.org/browse/JGRP-2288. The fix handles an edge case that can arise when remove_all_files_on_view_change is set to true. In a network partition, a view change in a separate partition may cause the file for this partition's coordinator to be removed. Under specific circumstances, as described in JGRP-2288, the subclusters may then never merge, even after the partition is resolved. 

I've done this fix on the 3.6 branch as that is the branch our product is currently using. I can generate a pull request for master as well, or instead, if that's preferred.