### PR TITLE
The timer field is used as a flag to exit the thread's while loop

### DIFF
--- a/src/org/jgroups/protocols/VERIFY_SUSPECT.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT.java
@@ -69,7 +69,7 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
         }
     }
 
-    protected Thread timer;
+    protected volatile Thread timer;
     
     
     
@@ -109,10 +109,11 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
                 if(s == null)
                     return null;
                 s.remove(local_addr); // ignoring suspect of self
-                if(!use_icmp)
-                    verifySuspect(s);
-                else
+                if (use_icmp) {
                     s.forEach(this::verifySuspectWithICMP);
+                } else {
+                    verifySuspect(s);
+                }
                 return null;  // don't pass up; we will decide later (after verification) whether to pass it up
 
             case Event.CONFIG:


### PR DESCRIPTION
This is regarding point #2 raised here: https://issues.jboss.org/browse/JGRP-2287

The timer field is used as a flag to exit the thread's while loop but this field's visibility isn't guaranteed. The field should be volatile.

Point #1 seems to be OK to me, as all those methods use locks internally, and the loop should behave as expected.