### PR TITLE
JGRP-2328 NioConnection.Reader thread can miss stop request

### DIFF
--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -454,7 +454,7 @@ public class NioConnection extends Connection {
         }
 
         protected void _run() {
-            final Condition is_data_available=() -> data_available;
+            final Condition is_data_available=() -> data_available || !running;
             while(running) {
                 for(;;) { // try to receive as many msgs as possible, until no more msgs are ready or the conn is closed
                     try {


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2328

I only made the minimal change: I left the Reader in state `reading`, just like if the stop request arrived during `register(SelectionKey.OP_READ)`. I can try to clean it up and ensure it always gets in state `done` if you want.