### PR TITLE
Don't attempt to download SNAPSHOTS from the JBoss Release repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,7 @@
                 <updatePolicy>never</updatePolicy>
             </releases>
             <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>interval:120</updatePolicy>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
 


### PR DESCRIPTION
I noticed this mistake in the POM as every build would attempt to go and check if there were new snapshots to be fetched from the release repository.

This should speed up the build so to not waste time with that.