### PR TITLE
JGRP-2355 Fix JDK8 compatibility with ByteBuffer methods.

### DIFF
--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -354,7 +354,9 @@ public class NioConnection extends Connection {
             ByteBuffer buf=recv_buf.get(current_position);
             if(buf == null)
                 return null;
-            buf.flip();
+            // Workaround for JDK8 compatibility
+            // flip() returns java.nio.Buffer in JDK8, but java.nio.ByteBuffer since JDK9.
+            ((java.nio.Buffer) buf).flip();
             switch(current_position) {
                 case 0:      // cookie
                     byte[] cookie_buf=getBuffer(buf);

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -471,7 +471,7 @@ public class NioConnection extends Connection {
                         if(!_receive(false))
                             break;
                     }
-                    catch(Throwable ex) {
+                    catch(Exception ex) {
                         server.closeConnection(NioConnection.this, ex);
                         state(State.done);
                         return;
@@ -497,7 +497,7 @@ public class NioConnection extends Connection {
                 registerSelectionKey(op);
                 key.selector().wakeup(); // no-op if the selector is not blocked in select()
             }
-            catch(Throwable t) {
+            catch(Exception t) {
             }
         }
 
@@ -505,7 +505,7 @@ public class NioConnection extends Connection {
             try {
                 clearSelectionKey(op);
             }
-            catch(Throwable t) {
+            catch(Exception t) {
             }
         }
 

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -395,7 +395,11 @@ public class NioConnection extends Connection {
 
 
     protected static ByteBuffer makeLengthBuffer(ByteBuffer buf) {
-        return (ByteBuffer)ByteBuffer.allocate(Global.INT_SIZE).putInt(buf.remaining()).clear();
+        ByteBuffer buffer = ByteBuffer.allocate(Global.INT_SIZE).putInt(buf.remaining());
+        // Workaround for JDK8 compatibility
+        // clear() returns java.nio.Buffer in JDK8, but java.nio.ByteBuffer since JDK9.
+        ((java.nio.Buffer) buffer).clear();
+        return buffer;
     }
 
     protected enum State {reading, waiting_to_terminate, done}

--- a/src/org/jgroups/nio/Buffers.java
+++ b/src/org/jgroups/nio/Buffers.java
@@ -139,7 +139,9 @@ public class Buffers implements Iterable<ByteBuffer> {
             return null;
 
         try {
-            return (ByteBuffer)bufs[1].duplicate().flip();
+            // Workaround for JDK8 compatibility
+            // flip() returns java.nio.Buffer in JDK8, but java.nio.ByteBuffer since JDK9.
+            return (ByteBuffer) ((java.nio.Buffer) bufs[1].duplicate()).flip();
         }
         finally {
             bufs[0].clear();

--- a/src/org/jgroups/nio/Buffers.java
+++ b/src/org/jgroups/nio/Buffers.java
@@ -130,7 +130,9 @@ public class Buffers implements Iterable<ByteBuffer> {
         int len=bufs[0].getInt(0);
         if(bufs[1] == null || len > bufs[1].capacity())
             bufs[1]=ByteBuffer.allocate(len);
-        bufs[1].limit(len);
+        // Workaround for JDK8 compatibility
+        // limit() returns java.nio.Buffer in JDK8, but java.nio.ByteBuffer since JDK9.
+        ((java.nio.Buffer) bufs[1]).limit(len);
 
         if(bufs[1].hasRemaining() && ch.read(bufs[1]) < 0)
             throw new EOFException();


### PR DESCRIPTION
https://issues.jboss.org/browse/JGRP-2355

This allows TCP_NIO2 to work under JDK8 when build using JDK9 or above.  Verified using JDK11.