### PR TITLE
Change method name 'size' to 'getResponsesCount'

### DIFF
--- a/src/org/jgroups/protocols/pbcast/Merger.java
+++ b/src/org/jgroups/protocols/pbcast/Merger.java
@@ -572,7 +572,7 @@ public class Merger {
             }
 
             removeRejectedMergeRequests(coords.keySet());
-            if(merge_rsps.size() == 0)
+            if(merge_rsps.getResponsesCount() == 0)
                 throw new Exception("did not get any merge responses from partition coordinators");
 
             if(!coords.keySet().contains(gms.local_addr)) // another member might have invoked a merge req on us before we got there...

--- a/src/org/jgroups/util/ResponseCollector.java
+++ b/src/org/jgroups/util/ResponseCollector.java
@@ -140,7 +140,7 @@ public class ResponseCollector<T> {
         return responses;
     }
 
-    public int size() {
+    public int getResponsesCount() {
         lock.lock();
         try {
             return responses.size();

--- a/tests/junit-functional/org/jgroups/tests/ResponseCollectorTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ResponseCollectorTest.java
@@ -24,12 +24,12 @@ public class ResponseCollectorTest {
         ResponseCollector<Integer> coll=new ResponseCollector<>(a, b, c);
         coll.add(a, 1);
         System.out.println("coll = " + coll);
-        assert coll.size() == 3;
+        assert coll.getResponsesCount() == 3;
         assert !coll.hasAllResponses();
         coll.add(c, 3);
         coll.add(b, 2);
         System.out.println("coll = " + coll);
-        assert coll.size() == 3;
+        assert coll.getResponsesCount() == 3;
         assert coll.hasAllResponses();
     }
 
@@ -37,12 +37,12 @@ public class ResponseCollectorTest {
         ResponseCollector<Integer> coll=new ResponseCollector<>(a, b);
         coll.add(a, 1);
         System.out.println("coll = " + coll);
-        assert coll.size() == 2;
+        assert coll.getResponsesCount() == 2;
         assert !coll.hasAllResponses();
         coll.add(c, 3); // will get dropped
         coll.add(b, 2);
         System.out.println("coll = " + coll);
-        assert coll.size() == 2;
+        assert coll.getResponsesCount() == 2;
         assert coll.hasAllResponses();
     }
 
@@ -119,7 +119,7 @@ public class ResponseCollectorTest {
 
         thread.join();
         System.out.println("results = " + results);
-        assert coll.size() == 0;
+        assert coll.getResponsesCount() == 0;
     }
 
 


### PR DESCRIPTION
This class is used to represent ResponseCollector.  This method named 'size' is to get the number of responses. Thus, the method name 'getResonsesCount' is more intuitive than 'size'.