### PR TITLE
Update maven version to SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>jgroups</artifactId>
     <packaging>bundle</packaging>
     <name>JGroups</name>
-    <version>4.1.3.Final</version>
+    <version>4.1.4.Final-SNAPSHOT</version>
     <url>http://www.jgroups.org</url>
 
     <properties>


### PR DESCRIPTION
Development branches like `master` need to use `-SNAPSHOT` version suffix not to spoil local maven repositories.