### PR TITLE
Adding IV support to SYM_ENCRYPT and ASYM_ENCRYPT protocols (JGRP-2386).

### DIFF
--- a/src/org/jgroups/protocols/DH_KEY_EXCHANGE.java
+++ b/src/org/jgroups/protocols/DH_KEY_EXCHANGE.java
@@ -40,7 +40,7 @@ public class DH_KEY_EXCHANGE extends KeyExchange {
     }
 
     @Property(description="The type of secret key to be sent up the stack (converted from DH). " +
-      "Should be the same as ASYM_ENCRYPT.sym_algorithm if ASYM_ENCRYPT is used")
+      "Should be the same as the algorithm part of ASYM_ENCRYPT.sym_algorithm if ASYM_ENCRYPT is used")
     protected String                        secret_key_algorithm="AES";
 
     @Property(description="The length of the secret key (in bits) to be sent up the stack. AES requires 128 bits. " +
@@ -83,9 +83,9 @@ public class DH_KEY_EXCHANGE extends KeyExchange {
 
         ASYM_ENCRYPT asym_encrypt=findProtocolAbove(ASYM_ENCRYPT.class);
         if(asym_encrypt != null) {
-            String sym_alg=asym_encrypt.symAlgorithm();
+            String sym_alg=asym_encrypt.symKeyAlgorithm();
             int sym_keylen=asym_encrypt.symKeylength();
-            if(Util.match(sym_alg, secret_key_algorithm)) {
+            if(!Util.match(sym_alg, secret_key_algorithm)) {
                 log.warn("overriding %s=%s to %s from %s", "secret_key_algorithm", secret_key_algorithm,
                          sym_alg, ASYM_ENCRYPT.class.getSimpleName());
                 secret_key_algorithm=sym_alg;

--- a/src/org/jgroups/protocols/EncryptHeader.java
+++ b/src/org/jgroups/protocols/EncryptHeader.java
@@ -21,10 +21,16 @@ public class EncryptHeader extends Header {
     protected byte    type;
     protected byte[]  version;
     protected Address server; // used with FETCH_SHARED_KEY
-
+    protected byte[]  iv;
 
     public EncryptHeader() {}
 
+
+    public EncryptHeader(byte type, byte[] version, byte[] iv) {
+        this.type=type;
+        this.version=version;
+        this.iv = iv;
+    }
 
     public EncryptHeader(byte type, byte[] version) {
         this.type=type;
@@ -38,6 +44,7 @@ public class EncryptHeader extends Header {
     public byte                       type()            {return type;}
     public byte[]                     version()         {return version;}
     public Address                    server()          {return server;}
+    public byte[]                     iv()              {return iv;}
     public EncryptHeader              server(Address s) {this.server=s; return this;}
     public short                      getMagicId()      {return 88;}
     public Supplier<? extends Header> create()          {return EncryptHeader::new;}
@@ -47,6 +54,7 @@ public class EncryptHeader extends Header {
         out.writeByte(type);
         Util.writeByteBuffer(version, 0, version != null? version.length : 0, out);
         Util.writeAddress(server, out);
+        Util.writeByteBuffer(iv, 0, iv != null? iv.length : 0, out);
     }
 
     @Override
@@ -54,16 +62,18 @@ public class EncryptHeader extends Header {
         type=in.readByte();
         version=Util.readByteBuffer(in);
         server=Util.readAddress(in);
+        iv = Util.readByteBuffer(in);
     }
 
     @Override
     public String toString() {
         return String.format("%s [version=%s]",
                              typeToString(type), (version != null? Util.byteArrayToHexString(version) : "null"))
-          + (server == null? "" : " [server=" + server + "]");
+          + (server == null? "" : " [server=" + server + "]")
+          + (iv == null? "" : " [iv=" + Util.byteArrayToHexString(iv) + "]");
     }
 
-    public int serializedSize() {return Global.BYTE_SIZE + Util.size(version) + Util.size(server);}
+    public int serializedSize() {return Global.BYTE_SIZE + Util.size(version) + Util.size(server) + Util.size(iv);}
 
     protected static String typeToString(byte type) {
         switch(type) {

--- a/src/org/jgroups/protocols/SSL_KEY_EXCHANGE.java
+++ b/src/org/jgroups/protocols/SSL_KEY_EXCHANGE.java
@@ -81,7 +81,7 @@ public class SSL_KEY_EXCHANGE extends KeyExchange {
     protected String          keystore_password="changeit";
 
     @Property(description="The type of secret key to be sent up the stack (converted from DH). " +
-      "Should be the same as ASYM_ENCRYPT.sym_algorithm if ASYM_ENCRYPT is used")
+      "Should be the same as the algorithm part of ASYM_ENCRYPT.sym_algorithm if ASYM_ENCRYPT is used")
     protected String          secret_key_algorithm="AES";
 
     @Property(description="If enabled, clients are authenticated as well (not just the server). Set to true to prevent " +
@@ -152,7 +152,7 @@ public class SSL_KEY_EXCHANGE extends KeyExchange {
             throw new IllegalStateException("port must not be 0 or else clients will not be able to connect");
         ASYM_ENCRYPT asym_encrypt=findProtocolAbove(ASYM_ENCRYPT.class);
         if(asym_encrypt != null) {
-            String sym_alg=asym_encrypt.symAlgorithm();
+            String sym_alg=asym_encrypt.symKeyAlgorithm();
             if(!Util.match(sym_alg, secret_key_algorithm)) {
                 log.warn("%s: overriding %s=%s to %s from %s", "secret_key_algorithm", local_addr, secret_key_algorithm,
                          sym_alg, ASYM_ENCRYPT.class.getSimpleName());

--- a/src/org/jgroups/protocols/SYM_ENCRYPT.java
+++ b/src/org/jgroups/protocols/SYM_ENCRYPT.java
@@ -68,7 +68,16 @@ public class SYM_ENCRYPT extends Encrypt<KeyStore.SecretKeyEntry> {
     }
 
     public void setSecretKey(SecretKey key) {
-        this.sym_algorithm = key.getAlgorithm();
+        String key_algorithm = key.getAlgorithm();
+        if (sym_algorithm == null)
+            sym_algorithm = key_algorithm;
+        else if (!getAlgorithm(sym_algorithm).equals(key_algorithm)) {
+            // avoid overwriting the sym_algorithm transformation in case it includes a mode and padding
+            if (getModeAndPadding(sym_algorithm) != null) {
+                log.warn("%s: replacing sym_algorithm %s with key algorithm %s", local_addr, sym_algorithm, key_algorithm);
+            }
+            this.sym_algorithm = key_algorithm;
+        }
         this.secret_key = key;
     }
 

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTest.java
@@ -22,6 +22,8 @@ public class ASYM_ENCRYPT_LeaveTest extends BaseLeaveTest {
     protected static final String      KEYSTORE_PWD="password";
 
     protected boolean useExternalKeyExchange() {return false;}
+    protected String symAlgorithm() { return "AES"; }
+    protected int symIvLength() { return 0; }
 
     @AfterMethod protected void destroy() {
         super.destroy();
@@ -41,7 +43,7 @@ public class ASYM_ENCRYPT_LeaveTest extends BaseLeaveTest {
           new SSL_KEY_EXCHANGE().setKeystoreName(KEYSTORE).setKeystorePassword(KEYSTORE_PWD)
             .setPortRange(30).setPort(2257),
           new ASYM_ENCRYPT().setUseExternalKeyExchange(useExternalKeyExchange())
-            .symKeylength(128).symAlgorithm("AES").asymKeylength(512).asymAlgorithm("RSA"),
+            .symKeylength(128).symAlgorithm(symAlgorithm()).symIvLength(symIvLength()).asymKeylength(512).asymAlgorithm("RSA"),
           new NAKACK2().setUseMcastXmit(false),
           new UNICAST3(),
           new STABLE(),

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestCbc.java
@@ -1,0 +1,13 @@
+package org.jgroups.protocols;
+
+/**
+ * Exercise ASYM_ENCRYPT_LeaveTest with CBC mode cipher.
+ */
+public class ASYM_ENCRYPT_LeaveTestCbc extends ASYM_ENCRYPT_LeaveTest {
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /** For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!! */
+    public void dummy2() {}
+}

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestKeyExchangeCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestKeyExchangeCbc.java
@@ -1,0 +1,13 @@
+package org.jgroups.protocols;
+
+/**
+ * Exercise ASYM_ENCRYPT_LeaveTestKeyExchange with CBC mode cipher.
+ */
+public class ASYM_ENCRYPT_LeaveTestKeyExchangeCbc extends ASYM_ENCRYPT_LeaveTestKeyExchange {
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /** For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!! */
+    public void dummy3() {}
+}

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_Test.java
@@ -277,7 +277,7 @@ public class ASYM_ENCRYPT_Test extends EncryptTest {
           // omit MERGE3 from the stack -- nodes are leaving gracefully
           new SSL_KEY_EXCHANGE().setKeystoreName(KEYSTORE).setKeystorePassword(KEYSTORE_PWD).setPortRange(10),
           new ASYM_ENCRYPT().setUseExternalKeyExchange(useExternalKeyExchange())
-            .symKeylength(128).symAlgorithm("AES").asymKeylength(512).asymAlgorithm("RSA"),
+            .symKeylength(128).symAlgorithm(symAlgorithm()).symIvLength(symIvLength()).asymKeylength(512).asymAlgorithm("RSA"),
           new NAKACK2().setUseMcastXmit(false),
           new UNICAST3(),
           new STABLE(),

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestCbc.java
@@ -1,0 +1,17 @@
+package org.jgroups.protocols;
+
+import org.testng.annotations.AfterMethod;
+
+/**
+ * Exercise ASYM_ENCRYPT_Test with CBC mode cipher.
+ */
+public class ASYM_ENCRYPT_TestCbc extends ASYM_ENCRYPT_Test {
+
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /** For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!! */
+    public void dummy2() {}
+
+}

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestKeyExchangeCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestKeyExchangeCbc.java
@@ -1,0 +1,15 @@
+package org.jgroups.protocols;
+
+/**
+ * Exercise ASYM_ENCRYPT_TestKeyExchange with CBC mode cipher.
+ */
+public class ASYM_ENCRYPT_TestKeyExchangeCbc extends ASYM_ENCRYPT_TestKeyExchange {
+
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /** For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!! */
+    public void dummy2() {}
+
+}

--- a/tests/junit-functional/org/jgroups/protocols/ENCRYPTKeystoreTestCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/ENCRYPTKeystoreTestCbc.java
@@ -1,0 +1,13 @@
+package org.jgroups.protocols;
+
+/**
+ * Exercise ENCRYPTKeystoreTest with CBC mode cipher.
+ */
+public class ENCRYPTKeystoreTestCbc extends ENCRYPTKeystoreTest {
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /** For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!! */
+    public void dummy2() {}
+}

--- a/tests/junit-functional/org/jgroups/protocols/EncryptTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/EncryptTest.java
@@ -39,6 +39,8 @@ public abstract class EncryptTest {
         GMS_ID=ClassConfigurator.getProtocolId(GMS.class);
     }
 
+    protected String symAlgorithm() { return "AES"; }
+    protected int symIvLength() { return 0; }
 
     protected void init() throws Exception {
         a=create("A").connect(cluster_name).setReceiver(ra=new MyReceiver<>().rawMsgs(true));
@@ -163,11 +165,12 @@ public abstract class EncryptTest {
         encrypt.init();
 
         short encrypt_id=ClassConfigurator.getProtocolId(SYM_ENCRYPT.class);
-        EncryptHeader hdr=new EncryptHeader(encrypt.symVersion());
+        byte[] iv = encrypt.makeIv();
+        EncryptHeader hdr=new EncryptHeader((byte)0, encrypt.symVersion(), iv);
         Message msg=new Message(null).putHeader(encrypt_id, hdr);
 
         byte[] buf="hello from rogue".getBytes();
-        byte[] encrypted_buf=encrypt.code(buf, 0, buf.length, false);
+        byte[] encrypted_buf=encrypt.code(buf, 0, buf.length, iv, false);
         msg.setBuffer(encrypted_buf);
 
         rogue.send(msg);

--- a/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_Test.java
@@ -9,6 +9,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.security.SecureRandom;
+
 /**
  * Tests use cases for {@link SYM_ENCRYPT} described in https://issues.jboss.org/browse/JGRP-2021.
  * Make sure you create the keystore before running this test (ant make-keystore).
@@ -33,12 +35,16 @@ public class SYM_ENCRYPT_Test extends EncryptTest {
 
 
     protected JChannel create(String name) throws Exception {
+        // Verify that the SecureRandom instance can be customized
+        SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
         SYM_ENCRYPT encr;
         try {
-            encr=new SYM_ENCRYPT().keystoreName("keystore/defaultStore.keystore").alias("myKey").storePassword(DEF_PWD);
+            encr=new SYM_ENCRYPT().keystoreName("keystore/defaultStore.keystore").alias("myKey").storePassword(DEF_PWD)
+              .symAlgorithm(symAlgorithm()).symIvLength(symIvLength()).secureRandom(secureRandom);
         }
         catch(Throwable t) {
-            encr=new SYM_ENCRYPT().keystoreName("defaultStore.keystore").alias("myKey").storePassword(DEF_PWD);
+            encr=new SYM_ENCRYPT().keystoreName("defaultStore.keystore").alias("myKey").storePassword(DEF_PWD)
+              .symAlgorithm(symAlgorithm()).symIvLength(symIvLength()).secureRandom(secureRandom);
         }
 
         return new JChannel(

--- a/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_TestCbc.java
+++ b/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_TestCbc.java
@@ -1,0 +1,20 @@
+package org.jgroups.protocols;
+
+/**
+ * Exercise SYM_ENCRYPT_Test with CBC mode cipher.
+ */
+public class SYM_ENCRYPT_TestCbc extends SYM_ENCRYPT_Test {
+
+    @Override protected String symAlgorithm() { return "AES/CBC/PKCS5Padding"; }
+    @Override protected int symIvLength() { return 16; }
+
+    /**
+     * For some obscure TestNG reasons, this method is needed. Remove it and all tests are executed in separate threads,
+     * which makes the testsuite fail!!!
+     */
+    public void dummy2() {}
+
+}
+
+
+

--- a/tests/junit-functional/org/jgroups/tests/SizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SizeTest.java
@@ -630,9 +630,9 @@ public class SizeTest {
 
 
     public void testEncryptHeader() throws Exception {
-        EncryptHeader hdr=new EncryptHeader(new byte[]{'b','e', 'l', 'a'});
+        EncryptHeader hdr=new EncryptHeader((byte)0, new byte[]{'b','e', 'l', 'a'}, new byte[]{'b', 'a', 'n'});
         _testSize(hdr);
-        hdr=new EncryptHeader("Hello".getBytes());
+        hdr=new EncryptHeader((byte)0, "Hello".getBytes(), "World".getBytes());
         _testSize(hdr);
     }
 


### PR DESCRIPTION
This change allows JGroups to support symmetric encryption algorithms that require an initialization vector (IV). An important example is "AES/CBC/PKCS5Padding" which uses the CBC cipher mode. 

The main changes that were required are as follows:

- Added a sym_iv_length field to Encrypt. This must be set to a non-zero value when using a cipher mode that requires an IV.
- Added an iv field to the EncryptHeader (which may be null if the cipher mode does not require an IV).
- Since the IV is passed when the Cipher is initialized and the IV is created per-message, cipher initialization is now deferred until the message is being encrypted/decrypted.
- Since the key is passed to the Cipher.init() method and init() is deferred, we now store the Key rather than the Cipher in the key_map field of Encrypt.
- DH_KEY_EXCHANGE is mostly unchanged. So it does not support using an IV-based cipher to encrypt the shared symmetric key. This seems okay as a fresh DH session key is generated for each key exchange, so the ciphertext will always be different. This saves us having to add an iv field to the DhHeader. 
- All the SYM_ENCRYPT and ASYM_ENCRYPT tests have been extended with subclasses that run the same tests using "AES/CBC/PKCS5Padding".
