### PR TITLE
JGRP-2477 Reintroduce support for configuring a JChannel via URL

### DIFF
--- a/src/org/jgroups/JChannel.java
+++ b/src/org/jgroups/JChannel.java
@@ -16,6 +16,7 @@ import org.jgroups.util.*;
 import java.io.*;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.URL;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -111,6 +112,14 @@ public class JChannel implements Closeable {
      */
     public JChannel(InputStream input) throws Exception {
         this(ConfiguratorFactory.getStackConfigurator(input));
+    }
+
+    /**
+     * Constructs a JChannel instance with the protocol stack configuration indicated by the specified URL.
+     * @param properties A URL pointing to a JGroups XML protocol stack configuration.
+     */
+    public JChannel(URL properties) throws Exception {
+        this(properties.openStream());
     }
 
     /**


### PR DESCRIPTION
See: https://issues.redhat.com/browse/JGRP-2477

This reintroduces the constructor `org.jgroups.JChannel#JChannel(java.net.URL)` to ease library usage.

Infinispan 9.4.x (9.4.19) uses a URL to load the JGroups configuration from the infinispan configuration, when an external jgroups stack configuration file is used:
See: "Using an external JGroups file" in https://infinispan.org/docs/9.4.x/user_guide/user_guide.html#using_an_external_jgroups_file

When creating the JGroups stack, infinispan uses the constructor in org.jgroups.JChannel#JChannel(...) which takes a URL as parameter.
See: https://github.com/infinispan/infinispan/blob/9.4.x/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java#L586

However this constructor is only present in versions up-to including 4.0.22 https://github.com/belaban/JGroups/blob/4.0.22/src/org/jgroups/JChannel.java#L121
and was removed in later versions.

Because of this users of infinispan 9.4.x, who use the "Using an external JGroups file" configuration approach cannot upgrade to new JGroups versions, like 4.2.3. Some that some applications, are currently bound to Infinispan 9.4.x which prevents upgrading to a newer Infinispan version. It would be great if one could at least upgrade to newer JGroups versions in that case.