### PR TITLE
JGRP-2470 JBDC_PING can face a split-brain issue when restarting a co…

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -112,14 +112,6 @@ public class JDBC_PING extends FILE_PING {
     }
 
 
-    @Override
-    public void stop() {
-        super.stop();
-        if(is_coord)
-            removeAll(cluster_name);
-    }
-
-
     protected void write(List<PingData> list, String clustername) {
         for(PingData data: list)
             writeToDB(data, clustername, true);


### PR DESCRIPTION
…ordinator node

Revert "https://issues.jboss.org/browse/JGRP-2199"

This reverts commit 215cdb68d043e4426bc9f4dcba826c0f7977f87a.

Purging cluster data is certainly not the responsibility of the old coordinator as this is racy and can cause singleton clusters.  While this resolves https://issues.redhat.com/browse/JGRP-2470 the question remains what's the issue/fix for https://issues.redhat.com/browse/JGRP-2199 for which this was originally put it suggested as workaround.