### PR TITLE
JGRP-2484 SSL_KEY_EXCHANGE Add keystore as truststore

### DIFF
--- a/src/org/jgroups/protocols/SSL_KEY_EXCHANGE.java
+++ b/src/org/jgroups/protocols/SSL_KEY_EXCHANGE.java
@@ -172,6 +172,8 @@ public class SSL_KEY_EXCHANGE extends KeyExchange {
                     .keyStoreType(keystore_type)
                     .keyStoreFileName(keystore_name)
                     .keyStorePassword(keystore_password.toCharArray())
+                    .trustStoreFileName(keystore_name)
+                    .trustStorePassword(keystore_password.toCharArray())
                     .sslProtocol(ssl_protocol).getContext();
             if (client_ssl_ctx == null) {
                 client_ssl_ctx = sslContext;

--- a/src/org/jgroups/util/SSLContextFactory.java
+++ b/src/org/jgroups/util/SSLContextFactory.java
@@ -18,8 +18,6 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
-import org.wildfly.openssl.OpenSSLProvider;
-import org.wildfly.openssl.SSL;
 
 /**
  * SslContextFactory.
@@ -37,8 +35,8 @@ public class SSLContextFactory {
         String sslProtocolPrefix = "";
         if (Boolean.parseBoolean(SecurityActions.getProperty("org.jgroups.openssl", "true"))) {
             try {
-                OpenSSLProvider.register();
-                SSL.getInstance();
+                org.wildfly.openssl.OpenSSLProvider.register();
+                org.wildfly.openssl.SSL.getInstance();
                 sslProtocolPrefix = "openssl.";
                 log.info("Using OpenSSL");
             } catch (Throwable e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/JGRP-2484

This fixes the ASYM_ENCRYPT_TestKeyExchange failures.