### PR TITLE
[4.x] JGRP-2489 TcpConnection.Receiver#run should use logger to handle exce…

### DIFF
--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -306,7 +306,7 @@ public class TcpConnection extends Connection {
                 ; // regular use case when a peer closes its connection - we don't want to log this as exception
             }
             catch(Exception e) {
-                throw new RuntimeException(String.format("failed handling message from %s: %s", peer_addr, e));
+                server.log.warn("failed handling message from %s: %s", peer_addr, e);
             }
             finally {
                 server.notifyConnectionClosed(TcpConnection.this);


### PR DESCRIPTION
…ption rather than rely on the UncaughtExceptionHandler