### PR TITLE
JGRP-2505: (4.x) change dns_query to support a comma-separated list of queries

### DIFF
--- a/src/org/jgroups/protocols/dns/DNS_PING.java
+++ b/src/org/jgroups/protocols/dns/DNS_PING.java
@@ -13,6 +13,7 @@ import org.jgroups.stack.IpAddress;
 import org.jgroups.util.NameCache;
 import org.jgroups.util.Responses;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +32,7 @@ public class DNS_PING extends Discovery {
     @Property(description = "DNS Record type")
     protected String  dns_record_type = DEFAULT_DNS_RECORD_TYPE;
 
-    @Property(description = "DNS query for fetching members")
+    @Property(description = "A comma-separated list of DNS queries for fetching members")
     protected String  dns_query;
 
     @Property(description="For SRV records returned by the DNS query, the non-0 ports returned by DNS are" +
@@ -77,12 +78,33 @@ public class DNS_PING extends Discovery {
         return true;
     }
 
+    /**
+     * Gets a list of IP addresses for the provided DNS query list and record type.
+     *
+     * @param dns_query A comma-separated list of DNS queries. Must not be {@code null}.
+     * @param dns_record_type The DNS record type.
+     *
+     * @return A list of IP addresses corresponding to the provided DNS query list and record type. An empty list is
+     * returned if the provided DNS query does not resolve to any IP addresses.
+     *
+     * @throws NullPointerException if dns_query is {@code null}.
+     */
+    List<Address> getMembers(final String dns_query, final DNSResolver.DNSRecordType dns_record_type) {
+        final List<Address> dns_discovery_members = new ArrayList<>();
+        for (final String query : dns_query.split(",")) {
+            final List<Address> addresses = dns_resolver.resolveIps(query.trim(), dns_record_type);
+            if (addresses != null) {
+                dns_discovery_members.addAll(addresses);
+            }
+        }
+        return dns_discovery_members;
+    }
+
     @ManagedOperation(description="Executes the DNS query and returns the result in string format")
     public String fetchFromDns() {
         long start=System.currentTimeMillis();
-        List<Address> dns_discovery_members = dns_resolver.resolveIps(dns_query,
-                                                                      DNSResolver.DNSRecordType.valueOf(dns_record_type));
-        String ret=dns_discovery_members != null? dns_discovery_members.toString() : null;
+        List<Address> dns_discovery_members = getMembers(dns_query, DNSResolver.DNSRecordType.valueOf(dns_record_type));
+        String ret=dns_discovery_members != null && !dns_discovery_members.isEmpty() ? dns_discovery_members.toString() : null;
         long time=System.currentTimeMillis()-start;
         return String.format("%s\n(took %d ms)\n", ret, time);
     }
@@ -104,7 +126,7 @@ public class DNS_PING extends Discovery {
         }
 
         long start=System.currentTimeMillis();
-        List<Address> dns_discovery_members = dns_resolver.resolveIps(dns_query, record_type);
+        List<Address> dns_discovery_members = getMembers(dns_query, record_type);
         long time=System.currentTimeMillis()-start;
         if(log.isDebugEnabled()) {
             if(dns_discovery_members != null && !dns_discovery_members.isEmpty())

--- a/tests/junit-functional/org/jgroups/protocols/dns/DNS_PINGTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/dns/DNS_PINGTest.java
@@ -1,11 +1,14 @@
 package org.jgroups.protocols.dns;
 
+import org.jgroups.Address;
 import org.jgroups.stack.IpAddress;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,6 +41,34 @@ public class DNS_PINGTest {
       } catch (IllegalArgumentException e) {
          //then
       }
+   }
+
+   @Test
+   public void test_get_members() throws Exception {
+      //given
+      final DNS_PING ping = new DNS_PING();
+      final MockDirContext mockDirContext = MockDirContext.newDefault()
+              .addEntry("test-1", "192.168.0.1", DNSResolver.DNSRecordType.A)
+              .addEntry("test-2", "192.168.0.2", DNSResolver.DNSRecordType.A)
+              .addEntry("test-2", "192.168.1.1", DNSResolver.DNSRecordType.A)
+              .addEntry("test-2", "192.168.1.2", DNSResolver.DNSRecordType.A)
+              .addEntry("test-2", "192.168.1.3", DNSResolver.DNSRecordType.A)
+              .addEntry("test-3", "192.168.2.1", DNSResolver.DNSRecordType.A);
+
+      ping.dns_resolver = new AddressedDNSResolver(mockDirContext);
+
+      //when
+      final List<Address> addresses = ping.getMembers("test-1, test-2, test-3", DNSResolver.DNSRecordType.A);
+
+      //then
+      final List<Address> expectedResults = Arrays.asList(
+              new IpAddress("192.168.0.1"),
+              new IpAddress("192.168.0.2"),
+              new IpAddress("192.168.1.1"),
+              new IpAddress("192.168.1.2"),
+              new IpAddress("192.168.1.3"),
+              new IpAddress("192.168.2.1"));
+      Assert.assertEquals(addresses, expectedResults);
    }
 
    @Test


### PR DESCRIPTION
It turns out that our application team is still on JGroups 4.x and not updating to 5.x for the next release. Would you be willing to roll this into the next 4.x release? Would really appreciate it! Thanks :)

In multi-region deployments, it'd be useful to combine addresses from multiple DNS queries to form the cluster. This simple change makes the "dns_query" parameter to DNS_PING a comma-separated list of queries as opposed to a single query like it is currently.