### PR TITLE
[4.2.x] Added missing destination check before processing message batch

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -1496,7 +1496,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
 
     protected void processBatch(MessageBatch batch, boolean oob, boolean internal) {
         try {
-            if(batch != null && !batch.isEmpty())
+            if(batch != null && !batch.isEmpty() && !unicastDestMismatch(batch.getDest()))
                 msg_processing_policy.process(batch, oob, internal);
         }
         catch(Throwable t) {


### PR DESCRIPTION
Upport of #515 for 4.2.x
#515 contains a detailed description of the bugfix for 4.0.x