### PR TITLE
[5.x] Added missing destination check before processing message batch

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -1579,7 +1579,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
 
     protected void processBatch(MessageBatch batch, boolean oob, boolean internal) {
         try {
-            if(batch != null && !batch.isEmpty())
+            if(batch != null && !batch.isEmpty() && !unicastDestMismatch(batch.getDest()))
                 msg_processing_policy.process(batch, oob, internal);
         }
         catch(Throwable t) {


### PR DESCRIPTION
Upport of #515 for 5.x
#515 contains a detailed description of the bugfix for 4.0.x