### PR TITLE
JGRP-2503 Extend DataInput & DataOutput to avoid copy of byte[]

### DIFF
--- a/src/org/jgroups/util/ByteArrayDataInputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataInputStream.java
@@ -15,6 +15,7 @@ public class ByteArrayDataInputStream extends InputStream implements DataInput {
 
     // index of last byte to be read, reading beyond will return -1 or throw EOFException. Limit has to be <= buf.length
     protected final int    limit;
+    protected static final ByteBuffer EMPTY=ByteBuffer.allocate(0);
 
     public ByteArrayDataInputStream(byte[] buf) {
         this(buf, 0, buf != null? buf.length : 0);
@@ -50,8 +51,17 @@ public class ByteArrayDataInputStream extends InputStream implements DataInput {
     public int position() {return pos;}
     public int limit()    {return limit;}
     public int capacity() {return buf.length;}
-
-
+    
+    public ByteBuffer readBuffer(int len) {
+        int avail=limit - pos;
+        if(len > avail || len < 0)
+            throw new IndexOutOfBoundsException();
+        if(len == 0)
+            return EMPTY;
+        ByteBuffer val=ByteBuffer.wrap(buf, pos, len);
+        pos += len;
+        return val;
+    }
 
     /**
      * Reads the next byte of data from buf. The value byte is returned as an {@code int} in the range {@code 0} to

--- a/tests/junit-functional/org/jgroups/tests/ByteArrayDataInputOutputStreamTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ByteArrayDataInputOutputStreamTest.java
@@ -440,7 +440,7 @@ public class ByteArrayDataInputOutputStreamTest {
         assert tmp == null;
     }
 
-    public static void testReadLine() throws IOException {
+    public void testReadLine() throws IOException {
         String str="Gallia est omnis divisa in partes tres,\n\rquarum unam incolunt Belgae,\naliam Aquitani," +
           "\ntertiam qui ipsorum lingua Celtae, nostra Galli appellantur";
         byte[] buf=str.getBytes();
@@ -452,5 +452,19 @@ public class ByteArrayDataInputOutputStreamTest {
             lines.add(line);
         }
         assert lines.size() == 4;
+    }
+    
+    public void testReadBuffer() throws IOException {
+        String str="JGroups";
+        ByteArrayDataInputStream in=new ByteArrayDataInputStream(str.getBytes());
+        ByteBuffer buf=in.readBuffer(3);
+        byte[] a=new byte[3];
+        buf.get(a);
+        byte[] b=new byte[4];
+        in.readFully(b);
+        assert "JGr".equals(new String(a));
+        assert "oups".equals(new String(b));
+        buf=in.readBuffer(0);
+        assert !buf.hasRemaining();
     }
 }


### PR DESCRIPTION
`ByteArrayDataInputStream` add an extra method `readBuffer(int)` that avoid byte array copy in `readFully(byte[])` method. this method also can used in user define Streamable interface.
Ticket [https://issues.redhat.com/browse/JGRP-2503](https://issues.redhat.com/browse/JGRP-2503)
Signed-off-by: Baoyi Chen <chen.bao.yi@qq.com>