### PR TITLE
[4.x] JGRP-2487 TLS Transport

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -20,6 +20,7 @@
         <dependency org="org.slf4j"                name="slf4j-api"               rev="1.7+"/>
         <dependency org="org.testng"               name="testng"                  rev="6.14.+"/>
         <dependency org="com.beust"                name="jcommander"              rev="1.+"/>
+        <dependency org="org.wildfly.security"     name="wildfly-elytron"         rev="1.16.+"/>
         <!--dependency org="org.sonatype.nexus.ant"   name="nexus-staging-ant-tasks" rev="1.6.3"/-->
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@
             <version>4.0.9</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>1.16.1.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src</sourceDirectory>
@@ -403,12 +409,12 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/org/jgroups/blocks/cs/TcpServer.java
+++ b/src/org/jgroups/blocks/cs/TcpServer.java
@@ -67,9 +67,6 @@ public class TcpServer extends TcpBaseServer {
                      InetAddress bind_addr, int srv_port, int end_port,
                      InetAddress external_addr, int external_port) throws Exception {
         this(thread_factory, socket_factory);
-        // this.srv_sock=this.socket_factory.createServerSocket("jgroups.tcp.server");
-        // this.srv_sock.setReuseAddress(reuse_addr);
-        // Util.bind(this.srv_sock, bind_addr, srv_port, end_port);
         this.srv_sock=Util.createServerSocket(this.socket_factory, "jgroups.tcp.server", bind_addr, srv_port, end_port);
         acceptor=factory.newThread(new Acceptor(),"TcpServer.Acceptor[" + srv_sock.getLocalPort() + "]");
         local_addr=localAddress(bind_addr, srv_sock.getLocalPort(), external_addr, external_port);

--- a/src/org/jgroups/protocols/TUNNEL.java
+++ b/src/org/jgroups/protocols/TUNNEL.java
@@ -164,7 +164,7 @@ public class TUNNEL extends TP implements RouterStub.StubReceiver {
                     stubManager.destroyStubs();
                 PhysicalAddress physical_addr=getPhysicalAddressFromCache(local);
                 String logical_name=org.jgroups.util.NameCache.get(local);
-                stubManager = new RouterStubManager(this,group,local, logical_name, physical_addr, getReconnectInterval()).useNio(this.use_nio);
+                stubManager = new RouterStubManager(this,group,local, logical_name, physical_addr, getReconnectInterval()).useNio(this.use_nio).socketFactory(getSocketFactory());
                 for(InetSocketAddress gr : gossip_routers) {
                     try {
                         stubManager.createAndRegisterStub(new IpAddress(bind_addr, bind_port), new IpAddress(gr.getAddress(), gr.getPort()))

--- a/src/org/jgroups/stack/GossipRouter.java
+++ b/src/org/jgroups/stack/GossipRouter.java
@@ -25,6 +25,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+
 /**
  * Router for TCP based group comunication (using layer TCP instead of UDP). Instead of the TCP
  * layer sending packets point-to-point to each other member, it sends the packet to the router
@@ -588,11 +596,23 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
         long soLinger=-1;
         long soTimeout=-1;
         long expiry_time=60000;
+        String tls_protocol=null;
+        String tls_provider=null;
+        String tls_keystore_path=null;
+        String tls_keystore_password=null;
+        String tls_keystore_type=null;
+        String tls_keystore_alias=null;
+        String tls_truststore_path=null;
+        String tls_truststore_password=null;
+        String tls_truststore_type=null;
+        TLSClientAuth tls_client_auth=TLSClientAuth.NONE;
+        List<SNIMatcher> tls_sni_matchers=new ArrayList<>();
 
         long start=System.currentTimeMillis();
-        GossipRouter router=null;
+        GossipRouter router;
         String bind_addr=null;
-        boolean jmx=false, nio=true, suspects=true, dump_msgs=false;
+        boolean jmx=false, suspects=true, dump_msgs=false;
+        Boolean nio=null;
 
         for(int i=0; i < args.length; i++) {
             String arg=args[i];
@@ -640,8 +660,62 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
                 max_length=Integer.parseInt(args[++i]);
                 continue;
             }
+            if("-tls_protocol".equals(arg)) {
+                tls_protocol=args[++i];
+                continue;
+            }
+            if("-tls_provider".equals(arg)) {
+                tls_provider=args[++i];
+                continue;
+            }
+            if("-tls_keystore_path".equals(arg)) {
+                tls_keystore_path=args[++i];
+                continue;
+            }
+            if("-tls_keystore_password".equals(arg)) {
+                tls_keystore_password=args[++i];
+                continue;
+            }
+            if("-tls_keystore_type".equals(arg)) {
+                tls_keystore_type=args[++i];
+                continue;
+            }
+            if("-tls_keystore_alias".equals(arg)) {
+                tls_keystore_alias=args[++i];
+                continue;
+            }
+            if("-tls_truststore_path".equals(arg)) {
+                tls_truststore_path=args[++i];
+                continue;
+            }
+            if("-tls_truststore_password".equals(arg)) {
+                tls_truststore_password=args[++i];
+                continue;
+            }
+            if("-tls_truststore_type".equals(arg)) {
+                tls_truststore_type=args[++i];
+                continue;
+            }
+            if("-tls_client_auth".equals(arg)) {
+                tls_client_auth=TLSClientAuth.valueOf(args[++i].toUpperCase());
+                continue;
+            }
+            if("-tls_sni_matcher".equals(arg)) {
+                tls_sni_matchers.add(SNIHostName.createSNIMatcher(args[++i]));
+                continue;
+            }
             help();
             return;
+        }
+        if (tls_protocol!=null) {
+            if (nio == null || !nio) {
+                nio = false;
+            } else {
+                // Doesn't work yet
+                throw new IllegalArgumentException("Cannot use NIO with TLS");
+            }
+        } else if (nio==null) {
+            nio=true;
         }
 
         router=new GossipRouter(bind_addr, port)
@@ -653,13 +727,48 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
           .emitSuspectEvents(suspects)
           .dumpMessages(dump_msgs)
           .maxLength(max_length);
+        if (tls_protocol!=null) {
+            SslContextFactory sslContextFactory = new SslContextFactory();
+            sslContextFactory
+                  .sslProtocol(tls_protocol)
+                  .sslProvider(tls_provider)
+                  .keyStoreFileName(tls_keystore_path)
+                  .keyStorePassword(tls_keystore_password)
+                  .keyStoreType(tls_keystore_type)
+                  .keyAlias(tls_keystore_alias)
+                  .trustStoreFileName(tls_truststore_path)
+                  .trustStorePassword(tls_truststore_password)
+                  .trustStoreType(tls_truststore_type);
+            SSLContext context = sslContextFactory.getContext();
+            DefaultSocketFactory socketFactory = new DefaultSocketFactory(context);
+            SSLParameters serverParameters = new SSLParameters();
+            socketFactory.setServerSocketConfigurator(s -> ((SSLServerSocket)s).setSSLParameters(serverParameters));
+            serverParameters.setSNIMatchers(tls_sni_matchers);
+            switch (tls_client_auth) {
+                case NEED:
+                    serverParameters.setNeedClientAuth(true);
+                    break;
+                case WANT:
+                    serverParameters.setWantClientAuth(true);
+                    break;
+                default:
+                    break;
+            }
+            router.socketFactory(socketFactory);
+        }
         router.start();
         long time=System.currentTimeMillis()-start;
         IpAddress local=(IpAddress)router.localAddress();
-        System.out.printf("\nGossipRouter started in %d ms listening on %s:%s\n",
-                          time, bind_addr != null? bind_addr : "0.0.0.0",  local.getPort());
+        System.out.printf("\nGossipRouter started in %d ms listening on %s:%s%s\n",
+                          time, bind_addr != null? bind_addr : "0.0.0.0",  local.getPort(),
+              tls_protocol==null?"":" ("+tls_protocol+")");
     }
 
+    public enum TLSClientAuth {
+        NONE,
+        WANT,
+        NEED
+    }
 
     static void help() {
         System.out.println();
@@ -693,6 +802,31 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener 
         System.out.println("    -suspect <true|false>   - Whether or not to use send SUSPECT events when a conn is closed");
         System.out.println();
         System.out.println("    -dump_msgs <true|false> - Dumps all messages to stdout after routing them");
+        System.out.println();
+        System.out.println("    -tls_protocol <proto>   - The name of the TLS protocol to use, e.g. TLSv1.2.");
+        System.out.println("                              Setting this requires configuring key and trust stores.");
+        System.out.println();
+        System.out.println("    -tls_provider <name>    - The name of the security provider to use for TLS.");
+        System.out.println();
+        System.out.println("    -tls_keystore_path <file> - The keystore path which contains the .");
+        System.out.println();
+        System.out.println("    -tls_keystore_password <password> - The key store password.");
+        System.out.println();
+        System.out.println("    -tls_keystore_type <type>    - The type of keystore.");
+        System.out.println();
+        System.out.println("    -tls_keystore_alias <alias>  - The alias of the key to use as identity for this Gossip router.");
+        System.out.println();
+        System.out.println("    -tls_truststore_path <file>  - The truststore path.");
+        System.out.println();
+        System.out.println("    -tls_truststore_password <password> - The trust store password.");
+        System.out.println();
+        System.out.println("    -tls_truststore_type <type>  - The truststore path.");
+        System.out.println();
+        System.out.println("    -tls_sni_matcher <name>      - A regular expression that servers use to match and accept SNI host names.");
+        System.out.println("                                   Can be repeated multiple times.");
+        System.out.println();
+        System.out.println("    -tls_client_auth <mode>      - none (default), want or need. Whether to require client");
+        System.out.println("                                   certificate authentication.");
         System.out.println();
     }
 }

--- a/src/org/jgroups/stack/RouterStub.java
+++ b/src/org/jgroups/stack/RouterStub.java
@@ -9,6 +9,7 @@ import org.jgroups.logging.LogFactory;
 import org.jgroups.protocols.PingData;
 import org.jgroups.util.ByteArrayDataInputStream;
 import org.jgroups.util.ByteArrayDataOutputStream;
+import org.jgroups.util.SocketFactory;
 import org.jgroups.util.Util;
 
 import java.io.DataInput;
@@ -52,25 +53,27 @@ public class RouterStub extends ReceiverAdapter implements Comparable<RouterStub
      * @param l The {@link org.jgroups.stack.RouterStub.CloseListener}
      */
     public RouterStub(InetAddress bind_addr, int bind_port, InetAddress router_host, int router_port,
-                      boolean use_nio, CloseListener l) {
+                      boolean use_nio, CloseListener l, SocketFactory socketFactory) {
         local=new IpAddress(bind_addr, bind_port);
         this.remote=new IpAddress(router_host, router_port);
         this.use_nio=use_nio;
         this.close_listener=l;
         client=use_nio? new NioClient(bind_addr, bind_port, router_host, router_port)
           : new TcpClient(bind_addr, bind_port, router_host, router_port);
+        if (socketFactory!=null) client.socketFactory(socketFactory);
         client.addConnectionListener(this);
         client.receiver(this);
         client.socketConnectionTimeout(sock_conn_timeout).tcpNodelay(tcp_nodelay);
     }
 
 
-    public RouterStub(IpAddress local, IpAddress remote, boolean use_nio, CloseListener l) {
+    public RouterStub(IpAddress local, IpAddress remote, boolean use_nio, CloseListener l, SocketFactory socketFactory) {
         this.local=local;
         this.remote=remote;
         this.use_nio=use_nio;
         this.close_listener=l;
         client=use_nio? new NioClient(local, remote) : new TcpClient(local, remote);
+        if (socketFactory!=null) client.socketFactory(socketFactory);
         client.receiver(this);
         client.addConnectionListener(this);
         client.socketConnectionTimeout(sock_conn_timeout).tcpNodelay(tcp_nodelay);

--- a/src/org/jgroups/stack/RouterStubManager.java
+++ b/src/org/jgroups/stack/RouterStubManager.java
@@ -6,6 +6,7 @@ import org.jgroups.PhysicalAddress;
 import org.jgroups.annotations.GuardedBy;
 import org.jgroups.logging.Log;
 import org.jgroups.logging.LogFactory;
+import org.jgroups.util.SocketFactory;
 import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
 
@@ -42,6 +43,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
     protected boolean                                   use_nio=true;  // whether to use RouterStubTcp or RouterStubNio
     protected Future<?>                                 reconnector_task;
     protected final Log                                 log;
+    private SocketFactory socket_factory;
 
 
     public RouterStubManager(Protocol owner, String cluster_name, Address local_addr,
@@ -90,7 +92,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
 
 
     public RouterStub createAndRegisterStub(IpAddress local, IpAddress router_addr) {
-        RouterStub stub=new RouterStub(local, router_addr, use_nio, this);
+        RouterStub stub=new RouterStub(local, router_addr, use_nio, this, socket_factory);
         RouterStub old_stub=unregisterStub(router_addr);
         if(old_stub != null)
             old_stub.destroy();
@@ -173,7 +175,7 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
     }
 
     protected boolean reconnect(Target target) {
-        RouterStub stub=new RouterStub(target.bind_addr, target.router_addr, this.use_nio, this).receiver(target.receiver);
+        RouterStub stub=new RouterStub(target.bind_addr, target.router_addr, this.use_nio, this, socket_factory).receiver(target.receiver);
         if(!add(stub))
             return false;
         try {
@@ -249,10 +251,10 @@ public class RouterStubManager implements Runnable, RouterStub.CloseListener {
             reconnector_task.cancel(true);
     }
 
-
-
-
-
+    public RouterStubManager socketFactory(SocketFactory socket_factory) {
+        this.socket_factory=socket_factory;
+        return this;
+    }
 
 
     protected static class Target implements Comparator<Target>, Serializable {

--- a/src/org/jgroups/util/DefaultSocketFactory.java
+++ b/src/org/jgroups/util/DefaultSocketFactory.java
@@ -1,67 +1,104 @@
 package org.jgroups.util;
 
 import java.io.IOException;
-import java.net.*;
-import java.nio.channels.ServerSocketChannel;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
 import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.net.ServerSocketFactory;
+import javax.net.ssl.SSLContext;
 
 /**
  * Default implementation, ignores service names
  * @author Bela Ban
  */
 public class DefaultSocketFactory implements SocketFactory {
+    private final javax.net.SocketFactory socketFactory;
+    private final ServerSocketFactory serverSocketFactory;
+    private Consumer<Socket> socketConfigurator = s -> {};
+    private Consumer<ServerSocket> serverSocketConfigurator = s -> {};
 
-    public Socket createSocket(String service_name) throws IOException {
-        return new Socket();
+    public DefaultSocketFactory() {
+        this(javax.net.SocketFactory.getDefault(), ServerSocketFactory.getDefault());
     }
 
-    public Socket createSocket(String service_name, String host, int port) throws IOException {
-        return new Socket(host, port);
+    public DefaultSocketFactory(SSLContext sslContext) {
+        this.socketFactory = sslContext.getSocketFactory();
+        this.serverSocketFactory = sslContext.getServerSocketFactory();
     }
 
-    public Socket createSocket(String service_name, InetAddress address, int port) throws IOException {
-        return new Socket(address, port);
+    public DefaultSocketFactory(javax.net.SocketFactory socketFactory, ServerSocketFactory serverSocketFactory) {
+        this.socketFactory = socketFactory;
+        this.serverSocketFactory = serverSocketFactory;
     }
 
-    public Socket createSocket(String service_name, String host, int port, InetAddress localAddr, int localPort) throws IOException {
-        return new Socket(host, port, localAddr, localPort);
+    public void setSocketConfigurator(Consumer<Socket> socketConfigurator) {
+        this.socketConfigurator = socketConfigurator;
     }
 
-    public Socket createSocket(String service_name, InetAddress address, int port, InetAddress localAddr, int localPort) throws IOException {
-        return new Socket(address, port, localAddr, localPort);
+    public void setServerSocketConfigurator(Consumer<ServerSocket> serverSocketConfigurator) {
+        this.serverSocketConfigurator = serverSocketConfigurator;
     }
 
-    public ServerSocket createServerSocket(String service_name) throws IOException {
-        return new ServerSocket();
+    private Socket configureSocket(Socket socket) {
+        socketConfigurator.accept(socket);
+        return socket;
     }
 
-    public ServerSocket createServerSocket(String service_name, int port) throws IOException {
-        return new ServerSocket(port);
+    private ServerSocket configureSocket(ServerSocket socket) {
+        serverSocketConfigurator.accept(socket);
+        return socket;
     }
 
-    public ServerSocket createServerSocket(String service_name, int port, int backlog) throws IOException {
-        return new ServerSocket(port, backlog);
+    @Override
+    public Socket createSocket(String s) throws IOException {
+        return configureSocket(socketFactory.createSocket());
     }
 
-    public ServerSocket createServerSocket(String service_name, int port, int backlog, InetAddress bindAddr) throws IOException {
-        return new ServerSocket(port, backlog, bindAddr);
+    @Override
+    public Socket createSocket(String s, String host, int port) throws IOException {
+        return configureSocket(socketFactory.createSocket(host, port));
     }
 
-    @SuppressWarnings("UnusedParameters")
-    public ServerSocketChannel createServerSocketChannel(String service_name) throws IOException {
-        return ServerSocketChannel.open();
+    @Override
+    public Socket createSocket(String s, InetAddress host, int port) throws IOException {
+        return configureSocket(socketFactory.createSocket(host, port));
     }
 
-    public ServerSocketChannel createServerSocketChannel(String service_name, int port) throws IOException {
-        return createServerSocketChannel(service_name).bind(new InetSocketAddress(port));
+    @Override
+    public Socket createSocket(String s, String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return configureSocket(socketFactory.createSocket(host, port, localHost, localPort));
     }
 
-    public ServerSocketChannel createServerSocketChannel(String service_name, int port, int backlog) throws IOException {
-        return createServerSocketChannel(service_name).bind(new InetSocketAddress(port), backlog);
+    @Override
+    public Socket createSocket(String s, InetAddress host, int port, InetAddress localHost, int localPort) throws IOException {
+        return configureSocket(socketFactory.createSocket(host, port, localHost, localPort));
     }
 
-    public ServerSocketChannel createServerSocketChannel(String service_name, int port, int backlog, InetAddress bindAddr) throws IOException {
-        return createServerSocketChannel(service_name).bind(new InetSocketAddress(bindAddr, port), backlog);
+    @Override
+    public ServerSocket createServerSocket(String s) throws IOException {
+        return configureSocket(serverSocketFactory.createServerSocket());
+    }
+
+    @Override
+    public ServerSocket createServerSocket(String s, int port) throws IOException {
+        return configureSocket(serverSocketFactory.createServerSocket(port));
+    }
+
+    @Override
+    public ServerSocket createServerSocket(String s, int port, int backlog) throws IOException {
+        return configureSocket(serverSocketFactory.createServerSocket(port, backlog));
+    }
+
+    @Override
+    public ServerSocket createServerSocket(String s, int port, int backlog, InetAddress bindAddress) throws IOException {
+        return configureSocket(serverSocketFactory.createServerSocket(port, backlog, bindAddress));
     }
 
     public DatagramSocket createDatagramSocket(String service_name) throws SocketException {
@@ -92,21 +129,23 @@ public class DefaultSocketFactory implements SocketFactory {
         return new MulticastSocket(bindaddr);
     }
 
-    public void close(Socket sock) throws IOException {
-        Util.close(sock);
+    @Override
+    public void close(Socket socket) throws IOException {
+        Util.close(socket);
     }
 
-    public void close(ServerSocket sock) throws IOException {
-        Util.close(sock);
+    @Override
+    public void close(ServerSocket serverSocket) throws IOException {
+        Util.close(serverSocket);
     }
 
-    public void close(DatagramSocket sock) {
-        Util.close(sock);
+    @Override
+    public void close(DatagramSocket datagramSocket) {
+        Util.close(datagramSocket);
     }
 
-    public Map<Object,String> getSockets() {
+    @Override
+    public Map<Object, String> getSockets() {
         return null;
     }
-
-
 }

--- a/src/org/jgroups/util/SocketFactory.java
+++ b/src/org/jgroups/util/SocketFactory.java
@@ -1,7 +1,14 @@
 package org.jgroups.util;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Map;

--- a/src/org/jgroups/util/SslContextFactory.java
+++ b/src/org/jgroups/util/SslContextFactory.java
@@ -1,0 +1,254 @@
+package org.jgroups.util;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+
+/**
+ * SslContextFactory.
+ *
+ * @author Tristan Tarrant
+ */
+public class SslContextFactory {
+   private static final Log log = LogFactory.getLog(SslContextFactory.class);
+   private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
+   private static final String DEFAULT_SSL_PROTOCOL;
+   private static final String CLASSPATH_RESOURCE = "classpath:";
+   private static final String DEFAULT_SSL_PROVIDER;
+
+   static {
+      String sslProtocol = null;
+      String sslProvider = null;
+      try {
+         SSLContext context = SSLContext.getDefault();
+         sslProvider = context.getProvider().getName();
+         sslProtocol = context.getProtocol();
+      } catch (Throwable t) {
+      }
+      DEFAULT_SSL_PROTOCOL = sslProtocol;
+      try {
+         Class<?> openSslProvider = Util.loadClass("org.wildfly.openssl.OpenSSLProvider", SslContextFactory.class);
+         Class<?> openSsl = Util.loadClass("org.wildfly.openssl.SSL", SslContextFactory.class);
+         if (openSslProvider != null && openSsl != null) {
+            openSslProvider.getMethod("register").invoke(null);
+            openSsl.getMethod("getInstance").invoke(null);
+            sslProvider = "openssl";
+            log.debug("Using OpenSSL");
+         }
+      } catch (Throwable e) {
+      }
+      DEFAULT_SSL_PROVIDER = sslProvider;
+   }
+
+   private KeyStore keyStore;
+   private String keyStoreFileName;
+   private char[] keyStorePassword;
+   private char[] keyStoreCertificatePassword;
+   private String keyStoreType = DEFAULT_KEYSTORE_TYPE;
+   private String keyAlias;
+   private KeyStore trustStore;
+   private String trustStoreFileName;
+   private char[] trustStorePassword;
+   private String trustStoreType = DEFAULT_KEYSTORE_TYPE;
+   private String sslProtocol = DEFAULT_SSL_PROTOCOL;
+   private String sslProvider = DEFAULT_SSL_PROVIDER;
+   private boolean useNativeIfAvailable = true;
+   private ClassLoader classLoader;
+
+   public SslContextFactory() {
+   }
+
+   public SslContextFactory keyStore(KeyStore keyStore) {
+      this.keyStore = keyStore;
+      return this;
+   }
+
+   public SslContextFactory keyStoreFileName(String keyStoreFileName) {
+      this.keyStoreFileName = keyStoreFileName;
+      return this;
+   }
+
+   public SslContextFactory keyStorePassword(String keyStorePassword) {
+      if (keyStorePassword != null) {
+         this.keyStorePassword = keyStorePassword.toCharArray();
+      }
+      return this;
+   }
+
+   public SslContextFactory keyStorePassword(char[] keyStorePassword) {
+      this.keyStorePassword = keyStorePassword;
+      return this;
+   }
+
+   public SslContextFactory keyStoreCertificatePassword(char[] keyStoreCertificatePassword) {
+      this.keyStoreCertificatePassword = keyStoreCertificatePassword;
+      return this;
+   }
+
+   public SslContextFactory keyStoreCertificatePassword(String keyStoreCertificatePassword) {
+      if (keyStoreCertificatePassword != null) {
+         this.keyStoreCertificatePassword = keyStoreCertificatePassword.toCharArray();
+      }
+      return this;
+   }
+
+   public SslContextFactory keyStoreType(String keyStoreType) {
+      if (keyStoreType != null) {
+         this.keyStoreType = keyStoreType;
+      }
+      return this;
+   }
+
+   public SslContextFactory keyAlias(String keyAlias) {
+      this.keyAlias = keyAlias;
+      return this;
+   }
+
+   public SslContextFactory trustStore(KeyStore trustStore) {
+      this.trustStore = trustStore;
+      return this;
+   }
+
+   public SslContextFactory trustStoreFileName(String trustStoreFileName) {
+      this.trustStoreFileName = trustStoreFileName;
+      return this;
+   }
+
+   public SslContextFactory trustStorePassword(char[] trustStorePassword) {
+      this.trustStorePassword = trustStorePassword;
+      return this;
+   }
+
+   public SslContextFactory trustStorePassword(String trustStorePassword) {
+      if (trustStorePassword != null) {
+         this.trustStorePassword = trustStorePassword.toCharArray();
+      }
+      return this;
+   }
+
+   public SslContextFactory trustStoreType(String trustStoreType) {
+      if (trustStoreType != null) {
+         this.trustStoreType = trustStoreType;
+      }
+      return this;
+   }
+
+   public SslContextFactory sslProtocol(String sslProtocol) {
+      if (sslProtocol != null) {
+         this.sslProtocol = sslProtocol;
+      }
+      return this;
+   }
+
+   public SslContextFactory sslProvider(String sslProvider) {
+      if (sslProvider != null) {
+         this.sslProvider = sslProvider;
+      }
+      return this;
+   }
+
+   public SslContextFactory classLoader(ClassLoader classLoader) {
+      this.classLoader = classLoader;
+      return this;
+   }
+
+   public SSLContext getContext() {
+      try {
+         KeyManager[] keyManagers = null;
+         if (keyStoreFileName != null || keyStore != null) {
+            KeyManagerFactory kmf = getKeyManagerFactory();
+            keyManagers = kmf.getKeyManagers();
+         }
+         TrustManager[] trustManagers = null;
+         if (trustStoreFileName != null || trustStore != null) {
+            TrustManagerFactory tmf = getTrustManagerFactory();
+            trustManagers = tmf.getTrustManagers();
+         }
+         SSLContext sslContext;
+         if (sslProvider != null) {
+            sslContext = SSLContext.getInstance(sslProtocol, sslProvider);
+         } else {
+            sslContext = SSLContext.getInstance(sslProtocol);
+         }
+         sslContext.init(keyManagers, trustManagers, null);
+         return sslContext;
+      } catch (Exception e) {
+         throw new RuntimeException("Could not initialize SSL", e);
+      }
+   }
+
+   public KeyManagerFactory getKeyManagerFactory() throws IOException, GeneralSecurityException {
+      if (keyStore == null) {
+         keyStore = KeyStore.getInstance(keyStoreType != null ? keyStoreType : DEFAULT_KEYSTORE_TYPE);
+         loadKeyStore(keyStore, keyStoreFileName, keyStorePassword, classLoader);
+      }
+      char[] keyPassword = keyStoreCertificatePassword == null ? keyStorePassword : keyStoreCertificatePassword;
+      if (keyAlias != null) {
+         if (keyStore.containsAlias(keyAlias) && keyStore.isKeyEntry(keyAlias)) {
+            KeyStore.PasswordProtection passParam = new KeyStore.PasswordProtection(keyPassword);
+            KeyStore.Entry entry = keyStore.getEntry(keyAlias, passParam);
+            // Recreate the keystore with just one key
+            keyStore = KeyStore.getInstance(keyStoreType != null ? keyStoreType : DEFAULT_KEYSTORE_TYPE);
+            keyStore.load(null);
+            keyStore.setEntry(keyAlias, entry, passParam);
+         } else {
+            throw new RuntimeException("No alias '" + keyAlias +"' in key store '" + keyStoreFileName+ "'");
+         }
+      }
+      KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      kmf.init(keyStore, keyPassword);
+      return kmf;
+   }
+
+   public TrustManagerFactory getTrustManagerFactory() throws IOException, GeneralSecurityException {
+      if (trustStore == null) {
+         trustStore = KeyStore.getInstance(trustStoreType != null ? trustStoreType : DEFAULT_KEYSTORE_TYPE);
+         loadKeyStore(trustStore, trustStoreFileName, trustStorePassword, classLoader);
+      }
+      TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      tmf.init(trustStore);
+      return tmf;
+   }
+
+   public static String getSslProvider() {
+      return  DEFAULT_SSL_PROVIDER;
+   }
+
+   public static SSLEngine getEngine(SSLContext sslContext, boolean useClientMode, boolean needClientAuth) {
+      SSLEngine sslEngine = sslContext.createSSLEngine();
+      sslEngine.setUseClientMode(useClientMode);
+      sslEngine.setNeedClientAuth(needClientAuth);
+      return sslEngine;
+   }
+
+   private static void loadKeyStore(KeyStore ks, String keyStoreFileName, char[] keyStorePassword, ClassLoader classLoader) throws IOException, GeneralSecurityException {
+      InputStream is = null;
+      try {
+         if (keyStoreFileName.startsWith(CLASSPATH_RESOURCE)) {
+            String fileName = keyStoreFileName.substring(keyStoreFileName.indexOf(":") + 1);
+            is = Util.getResourceAsStream(fileName, classLoader);
+            if (is == null) {
+               throw new IllegalArgumentException("Cannot find `" + keyStoreFileName +"`");
+            }
+         } else {
+            is = new BufferedInputStream(new FileInputStream(keyStoreFileName));
+         }
+         ks.load(is, keyStorePassword);
+      } finally {
+         Util.close(is);
+      }
+   }
+}

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -20,6 +20,7 @@ import org.jgroups.stack.ProtocolStack;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
+
 import java.io.*;
 import java.lang.annotation.Annotation;
 import java.lang.management.*;
@@ -3188,6 +3189,30 @@ public class Util {
         }
     }
 
+    static ClassLoader[] getClassLoaders(ClassLoader appClassLoader) {
+        return new ClassLoader[]{
+              appClassLoader,   // User defined classes
+              Util.class.getClassLoader(),           // JGroups classes (not always on TCCL [modular env])
+              ClassLoader.getSystemClassLoader(),    // Used when load time instrumentation is in effect
+              Thread.currentThread().getContextClassLoader() //Used by jboss-as stuff
+        };
+    }
+
+    public static InputStream getResourceAsStream(String resourcePath, ClassLoader userClassLoader) {
+        if (resourcePath.startsWith("/")) {
+            resourcePath = resourcePath.substring(1);
+        }
+        InputStream is = null;
+        for (ClassLoader cl : getClassLoaders(userClassLoader)) {
+            if (cl != null) {
+                is = cl.getResourceAsStream(resourcePath);
+                if (is != null) {
+                    break;
+                }
+            }
+        }
+        return is;
+    }
 
     public static InputStream getResourceAsStream(String name,Class clazz) {
         ClassLoader loader;
@@ -3647,13 +3672,9 @@ public class Util {
     }
 
     public static ServerSocket createServerSocket(SocketFactory factory, String service_name, InetAddress bind_addr, int start_port) {
-        ServerSocket ret=null;
         try {
-            ret=factory.createServerSocket(service_name);
-            Util.bind(ret, bind_addr, start_port, start_port+1000, 50);
-            return ret;
-        }
-        catch(Exception e) {
+            return createServerSocket(factory, service_name, bind_addr, start_port, start_port+1000);
+        } catch (Exception e) {
             return null;
         }
     }
@@ -3666,11 +3687,9 @@ public class Util {
 
         while(true) {
             try {
-                if(srv_sock != null);
+                if(srv_sock != null)
                     Util.close(srv_sock);
-                srv_sock=factory.createServerSocket(service_name);
-                InetSocketAddress sock_addr=new InetSocketAddress(bind_addr, start_port);
-                srv_sock.bind(sock_addr);
+                srv_sock=factory.createServerSocket(service_name, start_port, 0, bind_addr);
                 return srv_sock;
             }
             catch(SocketException bind_ex) {

--- a/tests/junit-functional/org/jgroups/protocols/TLSTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/TLSTest.java
@@ -1,0 +1,209 @@
+package org.jgroups.protocols;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
+
+import org.jgroups.Global;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.jgroups.View;
+import org.jgroups.protocols.pbcast.GMS;
+import org.jgroups.protocols.pbcast.NAKACK2;
+import org.jgroups.protocols.pbcast.STABLE;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.DefaultSocketFactory;
+import org.jgroups.util.MyReceiver;
+import org.jgroups.util.Util;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wildfly.security.x500.cert.BasicConstraintsExtension;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
+
+@Test(groups = {Global.FUNCTIONAL, Global.ENCRYPT}, singleThreaded = true)
+public class TLSTest {
+   public static final String PROTOCOL = "TLSv1.2";
+   public static final String BASE_DN = "CN=%s,OU=JGroups,O=JBoss,L=Red Hat";
+   public static final String KEY_PASSWORD = "secret";
+   public static final String KEY_ALGORITHM = "RSA";
+   public static final String KEY_SIGNATURE_ALGORITHM = "SHA256withRSA";
+   public static final String KEYSTORE_TYPE = "pkcs12";
+   private final AtomicLong certSerial = new AtomicLong(1);
+   Map<String, KeyStore> keyStores = new HashMap<>();
+   Map<String, SSLContext> sslContexts = new HashMap<>();
+
+   JChannel a, b, c;
+   MyReceiver<Message> ra, rb, rc;
+   final String cluster_name = getClass().getSimpleName();
+
+   @BeforeClass
+   public void init() throws Exception {
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM);
+      KeyPair keyPair = keyPairGenerator.generateKeyPair();
+      PrivateKey signingKey = keyPair.getPrivate();
+      PublicKey publicKey = keyPair.getPublic();
+
+      // The truststore which contains all of the certificates
+      KeyStore trustStore = KeyStore.getInstance(KEYSTORE_TYPE);
+      trustStore.load(null);
+
+      // The CA which will sign all trusted certificates
+      X500Principal CA_DN = dn("CA");
+      SelfSignedX509CertificateAndSigningKey ca = createSelfSignedCertificate(CA_DN, true, "ca");
+      trustStore.setCertificateEntry("ca", ca.getSelfSignedCertificate());
+
+      // One certificate per legitimate node, signed by the CA
+      for (String n : Arrays.asList("A", "B", "C")) {
+         keyStores.put(n, createSignedCertificate(signingKey, publicKey, ca, CA_DN, n, trustStore));
+      }
+      // A self-signed certificate which has the same DN as the CA, but which is a rogue
+      SelfSignedX509CertificateAndSigningKey other = createSelfSignedCertificate(CA_DN, true, "other");
+      keyStores.put("O", createKeyStore(ks -> {
+         try {
+            ks.setCertificateEntry("O", other.getSelfSignedCertificate());
+         } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
+         }
+      }));
+
+      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init(trustStore);
+
+      for (Map.Entry<String, KeyStore> keyStore : keyStores.entrySet()) {
+         SSLContext sslContext = SSLContext.getInstance(PROTOCOL);
+
+         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+         keyManagerFactory.init(keyStore.getValue(), KEY_PASSWORD.toCharArray());
+         String name = keyStore.getKey();
+         sslContext.init(keyManagerFactory.getKeyManagers(), name.charAt(0) < 'D' ? trustManagerFactory.getTrustManagers() : null, null);
+         sslContexts.put(name, sslContext);
+      }
+   }
+
+   @Test
+   public void testTLS() throws Exception {
+      a = create("A").connect(cluster_name).setReceiver(ra = new MyReceiver<>().rawMsgs(true));
+      b = create("B").connect(cluster_name).setReceiver(rb = new MyReceiver<>().rawMsgs(true));
+      c = create("C").connect(cluster_name).setReceiver(rc = new MyReceiver<>().rawMsgs(true));
+      Util.waitUntilAllChannelsHaveSameView(10000, 500, a, b, c);
+      verifyForbiddenJoiner("U");
+      verifyForbiddenJoiner("O");
+      Util.close(c, b, a);
+   }
+
+   private void verifyForbiddenJoiner(String name) throws Exception {
+      JChannel channel = create(name);
+      GMS gms = channel.getProtocolStack().findProtocol(GMS.class);
+      gms.setMaxJoinAttempts(1);
+      try {
+         channel.connect(cluster_name);
+      } catch (Exception ex) {
+      }
+      for (int i = 0; i < 10; i++) {
+         if (a.getView().size() > 3)
+            break;
+         Util.sleep(500);
+      }
+      Arrays.asList(a, b, c).forEach(ch -> {
+         View view = ch.getView();
+         assertEquals(3, view.size());
+         assertTrue(view.containsMembers(a.getAddress(), b.getAddress(), c.getAddress()));
+      });
+   }
+
+   private JChannel create(String name) throws Exception {
+      TCP transport = new TCP();
+      transport.setBindAddress(InetAddress.getLoopbackAddress());
+      transport.setBindPort(9600);
+      transport.setSocketFactory(sslContexts.containsKey(name) ? new DefaultSocketFactory(sslContexts.get(name)) : new DefaultSocketFactory());
+      TCPPING ping = new TCPPING();
+      ping.setInitialHosts2(Collections.singletonList(new IpAddress(transport.getBindAddress(), transport.getBindPort())));
+      return new JChannel(
+            transport,
+            ping,
+            new NAKACK2().setUseMcastXmit(false),
+            new UNICAST3(),
+            new STABLE(),
+            new GMS().joinTimeout(2000))
+            .name(name);
+   }
+
+   static X500Principal dn(String cn) {
+      return new X500Principal(String.format(BASE_DN, cn));
+   }
+
+   protected SelfSignedX509CertificateAndSigningKey createSelfSignedCertificate(X500Principal dn,
+                                                                                boolean isCA, String name) {
+      SelfSignedX509CertificateAndSigningKey.Builder certificateBuilder = SelfSignedX509CertificateAndSigningKey.builder()
+            .setDn(dn)
+            .setSignatureAlgorithmName(KEY_SIGNATURE_ALGORITHM)
+            .setKeyAlgorithmName(KEY_ALGORITHM);
+
+      if (isCA) {
+         certificateBuilder.addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647");
+      }
+      return certificateBuilder.build();
+   }
+
+   protected KeyStore createSignedCertificate(PrivateKey signingKey, PublicKey publicKey,
+                                              SelfSignedX509CertificateAndSigningKey ca,
+                                              X500Principal issuerDN,
+                                              String name, KeyStore trustStore) {
+      try {
+         X509Certificate caCertificate = ca.getSelfSignedCertificate();
+         X509Certificate certificate = new X509CertificateBuilder()
+               .setIssuerDn(issuerDN)
+               .setSubjectDn(dn(name))
+               .setSignatureAlgorithmName(KEY_SIGNATURE_ALGORITHM)
+               .setSigningKey(ca.getSigningKey())
+               .setPublicKey(publicKey)
+               .setSerialNumber(BigInteger.valueOf(certSerial.getAndIncrement()))
+               .addExtension(new BasicConstraintsExtension(false, false, -1))
+               .build();
+         trustStore.setCertificateEntry(name, certificate);
+         return createKeyStore(ks -> {
+            try {
+               ks.setCertificateEntry("ca", caCertificate);
+               ks.setKeyEntry(name, signingKey, KEY_PASSWORD.toCharArray(), new X509Certificate[]{certificate, caCertificate});
+            } catch (KeyStoreException e) {
+               throw new RuntimeException(e);
+            }
+
+         });
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private static KeyStore createKeyStore(Consumer<KeyStore> consumer) {
+      try {
+         KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+         keyStore.load(null);
+         consumer.accept(keyStore);
+         return keyStore;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/tests/other/org/jgroups/tests/RouterStubGet.java
+++ b/tests/other/org/jgroups/tests/RouterStubGet.java
@@ -16,7 +16,7 @@ public class RouterStubGet implements RouterStub.MembersNotification {
 
     protected void start(String host, int port, String cluster_name, boolean nio) {
         try {
-            stub=new RouterStub(null, 0, InetAddress.getByName(host), port, nio, null);
+            stub=new RouterStub(null, 0, InetAddress.getByName(host), port, nio, null, null);
             stub.connect();
             stub.getMembers(cluster_name, this);
             promise.getResult(5000);


### PR DESCRIPTION
https://issues.redhat.com/browse/JGRP-2487

This contains some fixes to make SocketFactories that return SSL sockets work in TCP (UDP and TCP_NIO are not supported).
Additionally the GossipRouter CLI has been enhanced to allow SSL configuration, including the ability to set SNI names.
@pruivo can you please add your review.
Once approved, I'll create a forward port for 5.x