### PR TITLE
JGRP-2570 SITE_UNREACHABLE is discarded on originator

### DIFF
--- a/tests/junit-functional/org/jgroups/tests/Relay2Test.java
+++ b/tests/junit-functional/org/jgroups/tests/Relay2Test.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Various RELAY2-related tests
@@ -259,7 +260,7 @@ public class Relay2Test {
         assert route != null : "route is " + route + " (expected to be UP)";
     }
 
-    /** Tests https://issues.redhat.com/browse/JGRP-2554 */
+    /** Tests https://issues.redhat.com/browse/JGRP-2554 and https://issues.redhat.com/browse/JGRP-2570*/
     public void testSiteUnreachableMessageBreaksSiteUUID() throws Exception {
         a=createNode(LON, "A", LON_CLUSTER, null);
         b=createNode(LON, "B", LON_CLUSTER, null);
@@ -268,11 +269,14 @@ public class Relay2Test {
         waitForBridgeView(2, 20000, 500, a, x);
 
         BlockingQueue<Message> received = new LinkedBlockingDeque<>();
+        AtomicInteger siteUnreachableEvents = new AtomicInteger(0);
         UpHandler h = new UpHandler() {
             @Override
             public Object up(Event evt) {
-                if(evt.getType() == Event.SITE_UNREACHABLE)
+                if(evt.getType() == Event.SITE_UNREACHABLE) {
                     log.debug("Site %s is unreachable", (Object) evt.getArg());
+                    siteUnreachableEvents.incrementAndGet();
+                }
                 return null;
             }
 
@@ -303,6 +307,17 @@ public class Relay2Test {
             Message take = received.take();
             assert !(take.src() instanceof SiteUUID) : "Address was " + take.src();
         }
+        assert siteUnreachableEvents.get() == 100 : "Expecting 100 site unreachable events on node B but got " + siteUnreachableEvents.get();
+
+        siteUnreachableEvents.set(0);
+        assert ((RELAY2) a.getProtocolStack().findProtocol(RELAY2.class)).isSiteMaster();
+        a.setUpHandler(h);
+
+        // check if the site master receives the events
+        for (int i = 0; i < 100; i++)
+            a.send(new SiteMaster(SFO), "to-sfo-from-a".getBytes(StandardCharsets.UTF_8));
+
+        assert siteUnreachableEvents.get() == 100 : "Expecting 100 site unreachable events on node A but got " + siteUnreachableEvents.get();
     }
 
 


### PR DESCRIPTION
SiteMaster was sent back to the originator a message with
SITE_UNREACHABLE but it sets a SiteUUID as destination Address. The
originator discards because it cannot handle this type of Address.

https://issues.redhat.com/browse/JGRP-2570