### PR TITLE
Remove reference to sendMulticast from comments

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
  * </ul>
  * A subclass has to override
  * <ul>
- * <li>{@link #sendMulticast(byte[], int, int)}
  * <li>{@link #sendUnicast(org.jgroups.PhysicalAddress, byte[], int, int)}
  * <li>{@link #init()}
  * <li>{@link #start()}: subclasses <em>must</em> call super.start() <em>after</em> they initialize themselves


### PR DESCRIPTION
sendMulticast is no longer part of the TP class as of https://github.com/belaban/JGroups/commit/e290a38b5eac738b7cdbb2076e2f637d7b5a660f