### PR TITLE
Set the correct version in JGROUPS_VERSION.properties

### DIFF
--- a/conf/JGROUPS_VERSION.properties
+++ b/conf/JGROUPS_VERSION.properties
@@ -1,5 +1,5 @@
 
 ## Defines the JGroups version
 ## This file should be the *only place* to change when changing the version number
-jgroups.version=4.2.11.Final-SNAPSHOT
+jgroups.version=${version}
 jgroups.codename=Julier


### PR DESCRIPTION
The `jgroups-4.2.17.Final.jar` is reporting an incorrect version:
```
$ java -jar jgroups-4.2.17.Final.jar 

Version:      4.2.11.Final-SNAPSHOT (Julier)
```

Note: Master is not affected