### PR TITLE
Fix compilation or 4.x branch (JGRP-2578 Use ThreadLocalRandom to gen…

### DIFF
--- a/src/org/jgroups/stack/IpAddressUUID.java
+++ b/src/org/jgroups/stack/IpAddressUUID.java
@@ -143,7 +143,7 @@ public class IpAddressUUID extends IpAddress {
     }
 
     protected static long[] createUUID() {
-        byte[] data=UUID.generateRandomBytes(12);
+        byte[] data=UUID.generateRandomBytes();
         long msb = 0;
         int lsb = 0;
         for (int i=0; i<8; i++)


### PR DESCRIPTION
…erate UUID)

Resolves compilation error in 4.x branch:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/rhusar/git/jgroups/src/org/jgroups/stack/IpAddressUUID.java:[146,25] method generateRandomBytes in class org.jgroups.util.UUID cannot be applied to given types;
  required: no arguments
  found: int
  reason: actual and formal argument lists differ in length
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.373 s
[INFO] Finished at: 2021-11-01T23:41:31+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project jgroups: Compilation failure
[ERROR] /Users/rhusar/git/jgroups/src/org/jgroups/stack/IpAddressUUID.java:[146,25] method generateRandomBytes in class org.jgroups.util.UUID cannot be applied to given types;
[ERROR]   required: no arguments
[ERROR]   found: int
[ERROR]   reason: actual and formal argument lists differ in length
```