### PR TITLE
[master] Introduce continuous integration testing using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        java: [ 11 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build with Maven
+        run: mvn -B verify -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-os: linux
-language: java
-#install: ant deps
-#script: ant all-tests
-jdk:
-  - openjdk11


### PR DESCRIPTION
This GH action will verify compilation using JDK 11 across platforms on master branch and pull requests submitted against it. This will prevent issues like merging uncompilable code, merge conflicts, unresolvable artefacts, etc.

Commits / PRs that have been tested will be rendered on the UI with a green tick next to it. Note that this does not enforce anything (but it is possible to e.g. require passing checks in repo settings if desired).

Going forward, the appropriate tests should be executed, however, they don't seem to be in a runnable state at the moment when executed form maven; also will likely need to account for the environment (e.g. multicast, timing issues).

Here's an example run - https://github.com/rhusar/JGroups/actions/runs/1414565300 - the PR needs to be merged for the CI to actually run. 