### PR TITLE
JGRP-2531 Handle case where finishConnect() returns false even though isConnectable() returned true.

### DIFF
--- a/src/org/jgroups/blocks/cs/NioBaseServer.java
+++ b/src/org/jgroups/blocks/cs/NioBaseServer.java
@@ -141,12 +141,14 @@ public abstract class NioBaseServer extends BaseServer {
                                 conn.connected(true);
                             }
                         }
-                        if(key.isReadable())
-                            conn.receive();
-                        if(key.isWritable())
-                            conn.send();
-                        if(key.isAcceptable())
+                        else if(key.isAcceptable())
                             handleAccept(key);
+                        else {
+                            if (key.isReadable())
+                                conn.receive();
+                            if (key.isWritable())
+                                conn.send();
+                        }
                     }
                     catch(Throwable ex) {
                         closeConnection(conn);


### PR DESCRIPTION
This change addresses a case that wasn't covered by the original fix for [JGRP-2531](https://issues.redhat.com/browse/JGRP-2531). Specifically, we have found that in certain cases, the `finishConnect()` can return false, even though `isConnectable()` returned true. In these cases, if the code proceeds to call `conn.receive()`, the `NotYetConnectedException` is thrown, which results in a WARN-level log message.

The fix is, when `isConnectable()` or `isAcceptable()` returns true, the code no longer falls through and checks the `isReadable()` or `isWritable()` flags. 