### PR TITLE
fix use case DNSResolver for Consul

### DIFF
--- a/src/org/jgroups/protocols/dns/AddressedDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/AddressedDNSResolver.java
@@ -26,7 +26,7 @@ class AddressedDNSResolver extends DefaultDNSResolver {
     }
 
     @Override
-    protected List<Address> resolveAEntries(String dnsQuery) {
+    protected List<Address> resolveAEntries(String dnsQuery, String srcPort) {
         List<Address> addresses = new ArrayList<>();
         try {
             // We are parsing this kind of structure:
@@ -37,7 +37,12 @@ class AddressedDNSResolver extends DefaultDNSResolver {
                 NamingEnumeration<?> namingEnumeration = attributes.get(DNSRecordType.A.toString()).getAll();
                 while (namingEnumeration.hasMoreElements()) {
                     try {
-                        addresses.add(new IpAddress(namingEnumeration.nextElement().toString()));
+                        int p = Integer.parseInt(srcPort);
+                        if (p == 0) {
+                            addresses.add(new IpAddress(namingEnumeration.nextElement().toString()));
+                        } else {
+                            addresses.add(new IpAddress(namingEnumeration.nextElement().toString(), p));
+                        }
                     } catch (Exception e) {
                         log.trace("non critical DNS resolution error", e);
                     }

--- a/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
@@ -106,7 +106,7 @@ class DefaultDNSResolver implements DNSResolver {
         return resolveAEntries(dnsQuery, "0");
     }
 
-    protected static List<Address> resolveAEntries(String dnsQuery, String srcPort) {
+    protected List<Address> resolveAEntries(String dnsQuery, String srcPort) {
         List<Address> addresses = new ArrayList<>();
         try {
             InetAddress[] inetAddresses = InetAddress.getAllByName(dnsQuery);


### PR DESCRIPTION
I'm trying to use JGroups with HashiCorp Consul as the DNS engine during service discovery. Now this is impossible, because the Consul resolves the addresses of services in its own namespace (for example, `7f000801.addr.dc1.consul.`) which must be resolved again through `DnsContext`. This PR will fix it.