### PR TITLE
Fix and cleanup dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: org.apache.maven.plugins:maven-compiler-plugin
-    versions:
-    - "> 3.8.1, < 3.9"
-  - dependency-name: org.testng:testng
-    versions:
-    - ">= 7.a, < 8"
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Cleanup for hard-coded dependencies - which should be rather ignored by talking to dependabot on the PRs rather than hard coded here (e.g. there is no reason why not to upgrade the compiler plugin) and a fix for https://github.com/belaban/JGroups/commit/74e293af1bd867a95bad8e3d4630df9a984668ed which I merged at a wrong indent level (gotta love yml!).

This yields an error that you can view at https://github.com/belaban/JGroups/network/updates where you can trigger dependabot manually.