### PR TITLE
Fix all broken Jira links

### DIFF
--- a/conf/scripts/ASYM_ENCRYPT_BlockTest/testASYM_ENCRYPT_NotBlockingJoin.btm
+++ b/conf/scripts/ASYM_ENCRYPT_BlockTest/testASYM_ENCRYPT_NotBlockingJoin.btm
@@ -1,6 +1,6 @@
 
 
-## Send unicast message to joiner *before* JOIN-RSP (https://issues.jboss.org/browse/JGRP-2131)
+## Send unicast message to joiner *before* JOIN-RSP (https://issues.redhat.com/browse/JGRP-2131)
 RULE InjectAdditionalUnicast
 CLASS GMS
 METHOD sendJoinResponse

--- a/conf/scripts/BecomeServerTest/testSendingOfMsgsOnUnconnectedChannel.btm
+++ b/conf/scripts/BecomeServerTest/testSendingOfMsgsOnUnconnectedChannel.btm
@@ -1,6 +1,6 @@
 
 
-## Test case for https://issues.jboss.org/browse/JGRP-1522
+## Test case for https://issues.redhat.com/browse/JGRP-1522
 ## - Join A
 ## - Try to join B
 ##   - After the stack is started (so that NAKACK2 can receive messages), but before connect() returns,

--- a/conf/scripts/MessageBeforeConnectedTest/testSendingOfMsgsOnUnconnectedChannel.btm
+++ b/conf/scripts/MessageBeforeConnectedTest/testSendingOfMsgsOnUnconnectedChannel.btm
@@ -1,6 +1,6 @@
 
 
-## Test case for https://issues.jboss.org/browse/JGRP-1545
+## Test case for https://issues.redhat.com/browse/JGRP-1545
 ## - Join A
 ## - Before the channel is set to 'connected', deliver a unicast message to A
 ## - A sends a response and the response triggers an exception as the channel is not yet connected

--- a/conf/scripts/SequencerFailoverTest/testResendingVersusNewMessages.btm
+++ b/conf/scripts/SequencerFailoverTest/testResendingVersusNewMessages.btm
@@ -1,5 +1,5 @@
 
-## Test case for https://issues.jboss.org/browse/JGRP-1449 (SEQUENCER):
+## Test case for https://issues.redhat.com/browse/JGRP-1449 (SEQUENCER):
 ## - When a coord A fails, we resend messages in the forward-queue that we haven't yet received
 ## - If, at the same time, new messages are sent, the old messages in the forward-queue might be received
 ##   *after* the new ones. JGRP-1449 is supposed to fix that. The fix is that sending of new messages on a view

--- a/doc/design/CENTRAL_LOCK2.txt
+++ b/doc/design/CENTRAL_LOCK2.txt
@@ -5,7 +5,7 @@ CENTRAL_LOCK2
 
 Author: Bela Ban
 Date: July 2018
-JIRA: https://issues.jboss.org/browse/JGRP-2249
+JIRA: https://issues.redhat.com/browse/JGRP-2249
 
 
 Overview

--- a/doc/design/CloudBasedDiscovery.txt
+++ b/doc/design/CloudBasedDiscovery.txt
@@ -2,7 +2,7 @@
 Optimizations for cloud based discovery stores
 ==============================================
 Author: Bela Ban, 2014
-JIRA: https://issues.jboss.org/browse/JGRP-1841
+JIRA: https://issues.redhat.com/browse/JGRP-1841
 
 Goals
 -----

--- a/doc/design/ConcurrentConnectionEstablishment.txt
+++ b/doc/design/ConcurrentConnectionEstablishment.txt
@@ -7,7 +7,7 @@
 Concurrent initial connection establishment in ConnectionTable
 ==============================================================
 
-[JIRA: http://jira.jboss.com/jira/browse/JGRP-549]
+[JIRA: https://issues.redhat.com/browse/JGRP-549]
 
 If we have members A and B, and they don't yet have connections to each other, and start sending messages to each other
 at the exact same time, then we run into the following scenario:

--- a/doc/design/ConcurrentStack.txt
+++ b/doc/design/ConcurrentStack.txt
@@ -5,9 +5,9 @@ Concurrent stack
 
 Author: Bela Ban
 JIRAs:
-http://jira.jboss.com/jira/browse/JGRP-180 (harden stack)
-http://jira.jboss.com/jira/browse/JGRP-181 (concurrent stack)
-http://jira.jboss.com/jira/browse/JGRP-205 (out-of-band messages)
+https://issues.redhat.com/browse/JGRP-180 (harden stack)
+https://issues.redhat.com/browse/JGRP-181 (concurrent stack)
+https://issues.redhat.com/browse/JGRP-205 (out-of-band messages)
 
 
 Concurrent stack

--- a/doc/design/FLUSH.txt
+++ b/doc/design/FLUSH.txt
@@ -3,7 +3,7 @@ FLUSH protocol for default stack
 ================================
 
 Author: Bela Ban
-See http://jira.jboss.com/jira/browse/JGRP-82
+See https://issues.redhat.com/browse/JGRP-82
 
 Overview
 --------
@@ -117,7 +117,7 @@ This algorithm also works for a number of JOIN and LEAVE requests (view bundling
 
 FLUSH with join & state transfer
 --------------------------------
-http://jira.jboss.com/jira/browse/JGRP-236 (DONE)
+https://issues.redhat.com/browse/JGRP-236 (DONE)
 
 Needs description (TODO)
 

--- a/doc/design/FORK.txt
+++ b/doc/design/FORK.txt
@@ -3,7 +3,7 @@ Design of FORK
 ==============
 
 Author: Bela Ban, Sanne Grinovero
-JIRA: https://issues.jboss.org/browse/JGRP-1613
+JIRA: https://issues.redhat.com/browse/JGRP-1613
 
 The purpose of FORK is (1) to enable multiple light-weight channels (fork-channels) to piggyback messages on an existing
 channel and (2) to add protocols to an existing channel that are to be used exclusively by the light-weight channel.

--- a/doc/design/GossipRouterChanges-1.8.txt
+++ b/doc/design/GossipRouterChanges-1.8.txt
@@ -16,8 +16,8 @@ addresses, but only returns logical addresses (UUIDs) [1].
 In TUNNEL, RouterStubs are conceptually associated with a single channel, and cannot process traffic from multiple
 channels on top of a shared transport.
 
-[1] https://jira.jboss.org/jira/browse/JGRP-1005
-[2] https://jira.jboss.org/jira/browse/JGRP-924
+[1] https://issues.redhat.com/browse/JGRP-1005
+[2] https://issues.redhat.com/browse/JGRP-924
 
 
 Design overview

--- a/doc/design/JoinAndStateTransfer.txt
+++ b/doc/design/JoinAndStateTransfer.txt
@@ -1,4 +1,4 @@
-Implementation of JChannel.connect() with state transfer - http://jira.jboss.com/jira/browse/JGRP-236
+Implementation of JChannel.connect() with state transfer - https://issues.redhat.com/browse/JGRP-236
 -----------------------------------------------
 
 There are essentially three major different implementations possibilites for new JChannel.connect with state 

--- a/doc/design/LargeClusters.txt
+++ b/doc/design/LargeClusters.txt
@@ -4,7 +4,7 @@ Considerations for large clusters
 =================================
 
 Author: Bela Ban
-JIRA: https://jira.jboss.org/browse/JGRP-100
+JIRA: https://issues.redhat.com/browse/JGRP-100
 
 
 Discovery
@@ -27,7 +27,7 @@ With ergonomics [1], we could for example set bucket sizes for CCHMs dynamically
 
 
 
-[1] https://jira.jboss.org/jira/browse/JGRP-1037
+[1] https://issues.redhat.com/browse/JGRP-1037
 
 
 Misc

--- a/doc/design/LogicalAddresses.txt
+++ b/doc/design/LogicalAddresses.txt
@@ -4,7 +4,7 @@ Logical addresses
 =================
 
 Author:  Bela Ban
-JIRA:    https://jira.jboss.org/jira/browse/JGRP-129
+JIRA:    https://issues.redhat.com/browse/JGRP-129
 
 The address chosen by each node is essentially the IP address and port of the receiver socket. However, for the
 following reasons, this is not good enough:

--- a/doc/design/MERGE.new.txt
+++ b/doc/design/MERGE.new.txt
@@ -3,7 +3,7 @@ New merging algorithm
 =====================
 
 Author: Bela Ban
-JIRAs: https://jira.jboss.org/jira/browse/JGRP-948, https://jira.jboss.org/jira/browse/JGRP-940
+JIRAs: https://issues.redhat.com/browse/JGRP-948, https://issues.redhat.com/browse/JGRP-940
 
 Goal
 ----

--- a/doc/design/MERGE4.txt
+++ b/doc/design/MERGE4.txt
@@ -3,7 +3,7 @@ MERGE4
 ------
 
 Author: Bela Ban
-JIRA: https://jira.jboss.org/jira/browse/JGRP-937
+JIRA: https://issues.redhat.com/browse/JGRP-937
 
 Goal
 ----

--- a/doc/design/MERGE_View_Separation.txt
+++ b/doc/design/MERGE_View_Separation.txt
@@ -4,7 +4,7 @@ Separation of merges from view handling
 =======================================
 
 Author: Bela Ban
-JIRA: https://jira.jboss.org/jira/browse/JGRP-1009
+JIRA: https://issues.redhat.com/browse/JGRP-1009
 
 Goal:
 -----

--- a/doc/design/MaliciousAttacks.txt
+++ b/doc/design/MaliciousAttacks.txt
@@ -2,7 +2,7 @@
 Use of encryption and authentication protocols to fend off malicious attacks
 ============================================================================
 Author: Bela Ban, April 2016
-JIRA:   https://issues.jboss.org/browse/JGRP-2021
+JIRA:   https://issues.redhat.com/browse/JGRP-2021
 
 The following discussion refers to the changes made in JGroups 4.0. These have been backported to the 3.6 branch, but
 the syntax looks different. However, the concepts are the same.

--- a/doc/design/NAKACK.txt
+++ b/doc/design/NAKACK.txt
@@ -5,7 +5,7 @@ Design of new NAKACK with only 1 retransmission table
 
 Author:   Bela Ban
 Date:     April 3, 2007
-JIRA:     http://jira.jboss.com/jira/browse/JGRP-281
+JIRA:     https://issues.redhat.com/browse/JGRP-281
 
 
 

--- a/doc/design/NullingSrcAddresses.txt
+++ b/doc/design/NullingSrcAddresses.txt
@@ -2,7 +2,7 @@
 Loopback adaptor issues on Windows
 ----------------------------------
 
-JIRA: http://jira.jboss.com/jira/browse/JGRP-79
+JIRA: https://issues.redhat.com/browse/JGRP-79
 
 On Windows, when a loopback adaptor is created, we can associate multiple (virtual) IP
 addresses with it, e.g. 10.0.0.1 and 10.0.0.2.

--- a/doc/design/PortingToGraalVM.txt
+++ b/doc/design/PortingToGraalVM.txt
@@ -4,7 +4,7 @@ Changes in JGroups to make it run natively in GraalVM
 
 Author: Bela Ban
 Date:   March 2019
-JIRA:   https://issues.jboss.org/browse/JGRP-2332
+JIRA:   https://issues.redhat.com/browse/JGRP-2332
 
 The command to create a native image is JGroups/bin/compile.sh org.jgroups.tests.perf.ProgrammaticUPerf2.
 

--- a/doc/design/RELAY2.txt
+++ b/doc/design/RELAY2.txt
@@ -3,7 +3,7 @@ RELAY2 - multi-site clustering
 ==============================
 
 Author: Bela Ban
-JIRA:   https://issues.jboss.org/browse/JGRP-1433
+JIRA:   https://issues.redhat.com/browse/JGRP-1433
 
 
 The architecture of RELAY2 is similar to RELAY: relaying between sites is done via a protocol (RELAY2). The biggest

--- a/doc/design/Reincarnation.txt
+++ b/doc/design/Reincarnation.txt
@@ -4,7 +4,7 @@ Problems with reincarnation
 ===========================
 
 Author:  Bela Ban
-JIRA:    http://jira.jboss.com/jira/browse/JGRP-130
+JIRA:    https://issues.redhat.com/browse/JGRP-130
 
 The identity of a JGroups member is always the IP address and a port. The port is usually chosen by the OS, unless
 bind_port is set (not set by default).
@@ -42,5 +42,5 @@ don't reuse previous addresses
 
 C: Use logical addresses, such as java.rmi.VMID or java.rmi.server.UID, which are unique over time for a given host.
 Then, it doesn't matter what ports we use because the ports are not used to determine a member's identity.
-The JIRA task for logical addresses is http://jira.jboss.com/jira/browse/JGRP-129.
+The JIRA task for logical addresses is https://issues.redhat.com/browse/JGRP-129.
 

--- a/doc/design/StreamingStateTransfer.txt
+++ b/doc/design/StreamingStateTransfer.txt
@@ -13,7 +13,7 @@ In order to transfer application state to a joining member of a group we current
 into memory and send it to a joining member. Major limitation of this approach is that the state transfer that 
 is very large (>1Gb) would likely result in OutOfMemoryException. In order to alleviate this problem a new state 
 transfer methodology, based on a streaming state transfer, will be introduced in JGroups 2.4 
-(see http://jira.jboss.com/jira/browse/JGRP-89)
+(see https://issues.redhat.com/browse/JGRP-89)
 
 New streaming state transfer supports both partial and full state transfer.
 

--- a/doc/design/TCPConnectionMap.txt
+++ b/doc/design/TCPConnectionMap.txt
@@ -4,7 +4,7 @@ Design for concurrent connects
 =================================================
 
 Author: Bela Ban
-JIRA:   https://issues.jboss.org/browse/JGRP-1549
+JIRA:   https://issues.redhat.com/browse/JGRP-1549
 
 
 The goal is to avoid initial message loss (and subsequent retransmission) in TCP when 2 members connect to each other at

--- a/doc/design/TransportNextGen
+++ b/doc/design/TransportNextGen
@@ -16,7 +16,7 @@ the connection table functionality of TCP would be largely removed, because this
 This requires JDK 7, because NetworkChannel.open() does not yet exist in prior JDKs. To be more precise, it does exist,
 but only for datagram sockets (DatagramChannel.open()), not for multicast sockets (no MulticastChannel.open()).
 
-Transport NetGen should be combined with the copyless stack (https://jira.jboss.org/jira/browse/JGRP-809). On the
+Transport NetGen should be combined with the copyless stack (https://issues.redhat.com/browse/JGRP-809). On the
 receive side, this is done by passing the selection key to a thread from the thread pool. If the key has an attachment,
 it is the ByteBuffer previously created by a (possibly different) thread to receive the message. The receiver thread
 will then simply call read() (or receive()) on the input NIO channel and - when all bytes have been received (defined

--- a/doc/design/UNICAST3-SYNC.txt
+++ b/doc/design/UNICAST3-SYNC.txt
@@ -3,7 +3,7 @@ UNICAST3: syncing a receiver with a sender
 ==========================================
 Author: Bela Ban
 Date:   Sept 2014
-JIRA:   https://issues.jboss.org/browse/JGRP-1875
+JIRA:   https://issues.redhat.com/browse/JGRP-1875
 
 
 Issue
@@ -17,9 +17,9 @@ When the network heals, and B receives messages from A again, the SEND-FIRST-SEQ
 asking A for the lowest seqno and for retransmission of missing messages.
 
 There are 2 deficiencies with SEND-FIRST-SEQNO:
-- It generates a lot of traffic (see https://issues.jboss.org/browse/JGRP-1874 for details)
+- It generates a lot of traffic (see https://issues.redhat.com/browse/JGRP-1874 for details)
 - A delayed ACK message sent by B to A can cause A to purge messages that haven't yet been seen by B
-  (see https://issues.jboss.org/browse/JGRP-1873 and https://issues.jboss.org/browse/JGRP-1875)
+  (see https://issues.redhat.com/browse/JGRP-1873 and https://issues.redhat.com/browse/JGRP-1875)
 
 The goals are therefore:
 #1 Reduce traffic needed by a receiver to sync its receive window (JGRP-1874)

--- a/doc/design/UNICAST3.txt
+++ b/doc/design/UNICAST3.txt
@@ -141,8 +141,8 @@ Retransmission task (reaping)
 References
 ----------
 
-[1] https://issues.jboss.org/browse/JGRP-1563
-[2] https://issues.jboss.org/browse/JGRP-1548
-[3] https://issues.jboss.org/browse/JGRP-1577
-[4] https://issues.jboss.org/browse/JGRP-1586
+[1] https://issues.redhat.com/browse/JGRP-1563
+[2] https://issues.redhat.com/browse/JGRP-1548
+[3] https://issues.redhat.com/browse/JGRP-1577
+[4] https://issues.redhat.com/browse/JGRP-1586
 

--- a/doc/design/VERIFY_SUSPECT2.txt
+++ b/doc/design/VERIFY_SUSPECT2.txt
@@ -3,7 +3,7 @@ VERIFY_SUSPECT2
 ===============
 Author: Bela Ban
 Date:   June 2021
-JIRA:   https://issues.jboss.org/browse/JGRP-2558
+JIRA:   https://issues.redhat.com/browse/JGRP-2558
 
 
 Issue

--- a/doc/design/varia2.txt
+++ b/doc/design/varia2.txt
@@ -19,7 +19,7 @@ This issue is moot; we simply return the digest to the client. Here's the exampl
 - D gets #36 (the view), but discards it as the join response already installed this view
  - D delivers #37
 
-[https://issues.jboss.org/browse/JGRP-1455]
+[https://issues.redhat.com/browse/JGRP-1455]
 *******************************************************************************************************************
 
 The digest returned to clients determines the seqnos they have to

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -30,7 +30,7 @@ ossiejnr    = Chris Mills (chris.mills@jboss.com)
 
 ***********
 THIS FILE IS NOT UPDATED ANYMORE AS OF MAY 2 2006, I SWITCHED TO JIRA FOR THE ROADMAP AND HISTORY.
-http://jira.jboss.com/jira/browse/JGRP
+https://issues.redhat.com/browse/JGRP
 ***********
 
 
@@ -44,11 +44,11 @@ Version 2.3
   Previously it returned the exception as an object, now the exception will be thrown.
   Callers of these methods have to change their code, so this is an incompatible change. However,
   these calls are not used in JBossCache and JBoss Clustering.
-  (http://jira.jboss.com/jira/browse/JGRP-154)
+  (https://issues.redhat.com/browse/JGRP-154)
   (bela Feb 16 2006)
 
 - Added encryption of entire message to ENCRYPT
-  (http://jira.jboss.com/jira/browse/JGRP-190)
+  (https://issues.redhat.com/browse/JGRP-190)
   (bela Feb 9 2006)
 
 - Converted Word prog guide to docbook (./doc/progguide). Done by gdvieira@ic.unicamp.br
@@ -57,11 +57,11 @@ Version 2.3
 - Created global JGroups thread group (all threads belong to it)
   (bela Jan 19 2006)
 
-- Added AUTH protocol, samle configs and documentation. http://jira.jboss.com/jira/browse/JGRP-164
+- Added AUTH protocol, samle configs and documentation. https://issues.redhat.com/browse/JGRP-164
   (ossiejnr Jan 12 2006)
 
 - Fix in ReplicatedHashtable where state transfer notification is not emitted
-  (http://jira.jboss.com/jira/browse/JGRP-175)
+  (https://issues.redhat.com/browse/JGRP-175)
   (David Forget Jan 5 2006)
 
 - init() is now called after all protocols have been created
@@ -69,7 +69,7 @@ Version 2.3
 
 - Fixed bug where srv_sock_bind_addr could be different from transport's bind_addr.
   This could cause incorrect suspect messages.
-  (http://jira.jboss.com/jira/browse/JGRP-173)
+  (https://issues.redhat.com/browse/JGRP-173)
   (bela Jan 3 2006)
 
 - Added total order SEQUENCER protocol. See doc/SEQUENCER.txt for details
@@ -86,19 +86,19 @@ Version 2.2.9.1
   (bela Dec 29 2005)
 
 - Fixed bug "binding to same interface twice fails"
-  (http://jira.jboss.com/jira/browse/JGRP-167)
+  (https://issues.redhat.com/browse/JGRP-167)
   (bela Dec 23 2005)
 
 - Fixed merge bug occurring when members are joining during a merge
-  (http://jira.jboss.com/jira/browse/JGRP-139)
+  (https://issues.redhat.com/browse/JGRP-139)
   (bela Dec 23 2005)
 
 - Fixed ENCRYPT bug where down messages were queued unnecessarily
-  (JIRA: http://jira.jboss.com/jira/browse/JGRP-166)
+  (JIRA: https://issues.redhat.com/browse/JGRP-166)
   (bela Dec 21 2005)
 
 - Replaced Vector for members and pingable_members in FD with CopyOnWriteArrayList.
-  Fixes  (http://jira.jboss.com/jira/browse/JGRP-161)
+  Fixes  (https://issues.redhat.com/browse/JGRP-161)
   (bela Dec 16 2005)
 
 
@@ -158,14 +158,14 @@ Version 2.2.9
   original sender of the message. This eases the burden on senders in large groups
   (bela May 25 2005)
 
-- Fixed http://jira.jboss.com/jira/browse/JGRP-79 (problems with nulling src addresses on
+- Fixed https://issues.redhat.com/browse/JGRP-79 (problems with nulling src addresses on
   loopback adapter in Windows). See JGroups/docs/NullingSrcAddresses.txt for details.
   (bela May 19 2005)
 
-- Fixed problem with PingWaiter/PingSender in applets (http://jira.jboss.com/jira/browse/JGRP-86)
+- Fixed problem with PingWaiter/PingSender in applets (https://issues.redhat.com/browse/JGRP-86)
   (bela Ma 19 2005)
 
-- Fixed STATE_TRANSFER stuck in Channel.queue bug (http://jira.jboss.com/jira/browse/JGRP-80)
+- Fixed STATE_TRANSFER stuck in Channel.queue bug (https://issues.redhat.com/browse/JGRP-80)
   (bela May 10 2005)
 
 - Added support for multiple locked locks to the DistributedLockManager.
@@ -187,11 +187,11 @@ Version 2.2.8
   (bela April 25 2005)
 
 - UDP: fixed incorrect marshalling of IpAddresses with additional_data
-  (http://jira.jboss.com/jira/browse/JGRP-63)
+  (https://issues.redhat.com/browse/JGRP-63)
   (bela April 23 2005)
 
 - Replaced getClass().getClassLoader() with Thread.currentThread().getContextClassLoader().
-  JIRA issue http://jira.jboss.com/jira/browse/JGRP-34
+  JIRA issue https://issues.redhat.com/browse/JGRP-34
   (bela April 23 2005)
 
 - UDP: synchronization around message marshalling and sending, non-sync could lead to intermingled
@@ -219,7 +219,7 @@ Version 2.2.8
   JDK 1.4 and higher
   (bela April 1 2005)
 
-- Fixed stopping outgoing packet handler (http://jira.jboss.com/jira/browse/JGRP-49)
+- Fixed stopping outgoing packet handler (https://issues.redhat.com/browse/JGRP-49)
   [fix by Steve Nicolai]
   (bela April 1 2005)
 

--- a/doc/manual/installation.adoc
+++ b/doc/manual/installation.adoc
@@ -263,7 +263,7 @@ You should be able to type in the mcast window and see the output in all other i
 in the sender. If this still fails, consult a system administrator to help you setup IP multicast correctly. If you
 _are_ the system administrator, look for another job :-)
 
-Other means of getting help: there is a public forum on http://jira.jboss.com/jira/browse/JGRP[JIRA]
+Other means of getting help: there is a public forum on https://issues.redhat.com/browse/JGRP[JIRA]
 for questions. Also consider subscribing to the javagroups-users mailing list to discuss such and other problems.
 
 
@@ -286,7 +286,7 @@ To force use of IPv6, start your JVM with `-Djava.net.preferIPv6Addresses=true`.
 === I have discovered a bug!
 
 If you think that you discovered a bug, submit a bug report on
-http://jira.jboss.com/jira/browse/JGRP[JIRA] or send email to the jgroups-users mailing list if you're unsure about it.
+https://issues.redhat.com/browse/JGRP[JIRA] or send email to the jgroups-users mailing list if you're unsure about it.
 Please include the following information:
         
 - [x] Version of JGroups (java org.jgroups.Version)

--- a/doc/manual/protocols.adoc
+++ b/doc/manual/protocols.adoc
@@ -1544,7 +1544,7 @@ Contrary to FRAG, FRAG2 does not need to serialize a message in order to break i
 ${FRAG3}
 
 FRAG3 needs only half the memory than FRAG2 to handle fragments and the final full message. See
-https://issues.jboss.org/browse/JGRP-2154 for details.
+https://issues.redhat.com/browse/JGRP-2154 for details.
 
 === Ordering
 
@@ -2003,7 +2003,7 @@ The AuthToken implementations are listed below. Check the javadoc for details.
 ===== Problems with AUTH
 `MD5Token` and `SimpleToken` implementations were removed in 5.0. The problem was that an attacker can find out the
 value of the hashed password (MD5Token) or the plain password (SimpleToken). Once they have it, they can bypass AUTH
-and join (or merge into) a cluster. See https://issues.jboss.org/browse/JGRP-2367 for details.
+and join (or merge into) a cluster. See https://issues.redhat.com/browse/JGRP-2367 for details.
 
 The usefulness of AUTH therefore only lies in filtering out JOIN/MERGE requests from members that are not included in
 a list of IP addresses (`FixedMembershipToken`) or IP addresses / hosts / symbolic names (`RegexMembership`).

--- a/doc/tutorial/sampleapp.adoc
+++ b/doc/tutorial/sampleapp.adoc
@@ -351,6 +351,6 @@ Here are some links for further information about JGroups:
 * SimpleChat code: link:./code/SimpleChat.java[SimpleChat.java]
 * JGroups web site: http://www.jgroups.org[http://www.jgroups.org]
 * Downloads: http://sourceforge.net/projects/javagroups/files/JGroups/[here]
-* JIRA bug tracking: http://jira.jboss.com/jira/browse/JGRP[http://jira.jboss.com/jira/browse/JGRP]
+* JIRA bug tracking: https://issues.redhat.com/browse/JGRP[https://issues.redhat.com/browse/JGRP]
 * Mailing lists: http://sourceforge.net/mail/?group_id=6081[http://sourceforge.net/mail/?group_id=6081]
         

--- a/project.properties
+++ b/project.properties
@@ -62,5 +62,5 @@ hudsonLink=
     
 # Issue tracker links
 #######################################################
-issueTrackerLink=https://issues.jboss.org/browse/JGRP
+issueTrackerLink=https://issues.redhat.com/browse/JGRP
 jiraLink=

--- a/src/org/jgroups/JChannel.java
+++ b/src/org/jgroups/JChannel.java
@@ -840,7 +840,7 @@ public class JChannel implements Closeable {
                 successfulFlush=flushInvoker.call();
             }
             catch(Throwable e) {
-                successfulFlush=false; // http://jira.jboss.com/jira/browse/JGRP-759
+                successfulFlush=false; // https://issues.redhat.com/browse/JGRP-759
             }
             if(!successfulFlush)
                 throw new IllegalStateException("Node " + local_addr + " could not flush the cluster for state retrieval");

--- a/src/org/jgroups/MergeView.java
+++ b/src/org/jgroups/MergeView.java
@@ -114,7 +114,7 @@ public class MergeView extends View {
         for(View v: subgroups) {
             int index=get(v.getCreator());
             out.writeShort(index);
-            // if we don't find the member, write the addres (https://issues.jboss.org/browse/JGRP-1707)
+            // if we don't find the member, write the addres (https://issues.redhat.com/browse/JGRP-1707)
             if(index < 0)
                 Util.writeAddress(v.getCreator(), out);
 

--- a/src/org/jgroups/Message.java
+++ b/src/org/jgroups/Message.java
@@ -205,7 +205,7 @@ public interface Message extends SizeStreamable, Constructable<Message> {
         NO_RELIABILITY((short)(1 <<  4)),    // bypass UNICAST(2) and NAKACK
         NO_TOTAL_ORDER((short)(1 <<  5)),    // bypass total order (e.g. SEQUENCER)
         NO_RELAY(      (short)(1 <<  6)),    // bypass relaying (RELAY)
-        RSVP(          (short)(1 <<  7)),    // ack of a multicast (https://issues.jboss.org/browse/JGRP-1389)
+        RSVP(          (short)(1 <<  7)),    // ack of a multicast (https://issues.redhat.com/browse/JGRP-1389)
         RSVP_NB(       (short)(1 <<  8)),    // non blocking RSVP
         SKIP_BARRIER(  (short)(1 << 10)),    // passing messages through a closed BARRIER
         SERIALIZED(    (short)(1 << 11));    // used by BytesMessage/NioMessage (internal flag)

--- a/src/org/jgroups/Receiver.java
+++ b/src/org/jgroups/Receiver.java
@@ -64,7 +64,7 @@ public interface Receiver {
      * Note that during new view installation we provide guarantee that unblock invocation strictly
      * follows view installation at some node A belonging to that view. However, some other message
      * M may squeeze in between view and unblock callbacks.<br/>
-     * For more details see https://jira.jboss.org/jira/browse/JGRP-986
+     * For more details see https://issues.redhat.com/browse/JGRP-986
      */
     default void unblock() {}
 

--- a/src/org/jgroups/blocks/RequestCorrelator.java
+++ b/src/org/jgroups/blocks/RequestCorrelator.java
@@ -119,7 +119,7 @@ public class RequestCorrelator {
             if(log.isTraceEnabled())
                 log.trace("%s: invoking multicast RPC [req-id=%d]", local_addr, req_id);
             requests.putIfAbsent(req_id, req);
-            // make sure no view is received before we add ourself as a view handler (https://issues.jboss.org/browse/JGRP-1428)
+            // make sure no view is received before we add ourself as a view handler (https://issues.redhat.com/browse/JGRP-1428)
             req.viewChange(view, false);
             if(rpc_stats.extendedStats())
                 req.start_time=System.nanoTime();
@@ -160,7 +160,7 @@ public class RequestCorrelator {
             if(log.isTraceEnabled())
                 log.trace("%s: invoking unicast RPC [req-id=%d] on %s", local_addr, req_id, dest);
             requests.putIfAbsent(req_id, req);
-            // make sure no view is received before we add ourself as a view handler (https://issues.jboss.org/browse/JGRP-1428)
+            // make sure no view is received before we add ourself as a view handler (https://issues.redhat.com/browse/JGRP-1428)
             req.viewChange(view, false);
             if(rpc_stats.extendedStats())
                 req.start_time=System.nanoTime();

--- a/src/org/jgroups/blocks/cs/BaseServer.java
+++ b/src/org/jgroups/blocks/cs/BaseServer.java
@@ -424,7 +424,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
                 tmp=conns.remove(address);
             }
         }
-        if(tmp != null) { // Moved conn close outside of sync block (https://issues.jboss.org/browse/JGRP-2053)
+        if(tmp != null) { // Moved conn close outside of sync block (https://issues.redhat.com/browse/JGRP-2053)
             log.trace("%s: removed connection to %s", local_addr, address);
             Util.close(tmp);
         }

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -196,7 +196,7 @@ public class NioConnection extends Connection {
                 updateLastAccessed();
             if(!success) {
                 if(copy_on_partial_write)
-                    send_buf.copy(); // copy data on partial write as subsequent writes might corrupt data (https://issues.jboss.org/browse/JGRP-1991)
+                    send_buf.copy(); // copy data on partial write as subsequent writes might corrupt data (https://issues.redhat.com/browse/JGRP-1991)
                 partial_writes++;
             }
         }
@@ -226,7 +226,7 @@ public class NioConnection extends Connection {
                 updateLastAccessed();
             if(!success) {
                 if(copy_on_partial_write)
-                    send_buf.copy(); // copy data on partial write as subsequent writes might corrupt data (https://issues.jboss.org/browse/JGRP-1991)
+                    send_buf.copy(); // copy data on partial write as subsequent writes might corrupt data (https://issues.redhat.com/browse/JGRP-1991)
                 partial_writes++;
             }
         }

--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -367,7 +367,7 @@ public class TcpConnection extends Connection {
     }
 
     public void close() throws IOException {
-        Util.close(sock); // fix for https://issues.jboss.org/browse/JGRP-2350
+        Util.close(sock); // fix for https://issues.redhat.com/browse/JGRP-2350
         send_lock.lock();
         try {
             if(receiver != null) {

--- a/src/org/jgroups/fork/ForkChannel.java
+++ b/src/org/jgroups/fork/ForkChannel.java
@@ -70,7 +70,7 @@ public class ForkChannel extends JChannel implements ChannelListener {
         this.fork_channel_id=fork_channel_id;
 
         FORK fork;
-        // To prevent multiple concurrent FORK creations https://issues.jboss.org/browse/JGRP-1842
+        // To prevent multiple concurrent FORK creations https://issues.redhat.com/browse/JGRP-1842
         synchronized(this.main_channel) {
             fork=getFORK(main_channel, position, neighbor, create_fork_if_absent);
         }

--- a/src/org/jgroups/logging/JDKLogImpl.java
+++ b/src/org/jgroups/logging/JDKLogImpl.java
@@ -20,7 +20,7 @@ public class JDKLogImpl implements Log {
     }
 
     public JDKLogImpl(Class<?> clazz) {
-        logger=Logger.getLogger(clazz.getName()); // fix for https://jira.jboss.org/browse/JGRP-1224
+        logger=Logger.getLogger(clazz.getName()); // fix for https://issues.redhat.com/browse/JGRP-1224
     }
 
 

--- a/src/org/jgroups/protocols/AlternatingBundler.java
+++ b/src/org/jgroups/protocols/AlternatingBundler.java
@@ -16,7 +16,7 @@ import java.util.List;
  * Messages are removed from the main queue one by one and processed as follows:<br/>
  * A B B C C A causes the following sends: A -> {CC} -> {BB} -> A<br/>
  * Note that <em>null</em> is also a valid destination (send-to-all).<br/>
- * JIRA: https://issues.jboss.org/browse/JGRP-2171
+ * JIRA: https://issues.redhat.com/browse/JGRP-2171
  * @author Bela Ban
  * @since  4.0.4
  */

--- a/src/org/jgroups/protocols/BARRIER.java
+++ b/src/org/jgroups/protocols/BARRIER.java
@@ -157,7 +157,7 @@ public class BARRIER extends Protocol {
     }
 
     public Object up(Message msg) {
-        // https://issues.jboss.org/browse/JGRP-1341: let unicast messages pass
+        // https://issues.redhat.com/browse/JGRP-1341: let unicast messages pass
         if(msg.isFlagSet(Message.Flag.SKIP_BARRIER) || msg.getDest() != null
           && ((msg.isFlagSet(Message.Flag.OOB)) || holes.contains(msg.getSrc())))
             return up_prot.up(msg);

--- a/src/org/jgroups/protocols/BaseBundler.java
+++ b/src/org/jgroups/protocols/BaseBundler.java
@@ -59,7 +59,7 @@ public abstract class BaseBundler implements Bundler {
     public void send(Message msg) throws Exception {}
 
     public void viewChange(View view) {
-        // code removed (https://issues.jboss.org/browse/JGRP-2324)
+        // code removed (https://issues.redhat.com/browse/JGRP-2324)
     }
 
     /** Returns the total number of messages in the hashmap */

--- a/src/org/jgroups/protocols/BasicTCP.java
+++ b/src/org/jgroups/protocols/BasicTCP.java
@@ -51,7 +51,7 @@ public abstract class BasicTCP extends TP implements Receiver {
     @Property(description="SO_LINGER in msec. Default of -1 disables it")
     protected int         linger=-1; // SO_LINGER (number of ms, -1 disables it)
 
-    // @Property(description="Sets socket option SO_REUSEADDR (https://issues.jboss.org/browse/JGRP-2009)")
+    // @Property(description="Sets socket option SO_REUSEADDR (https://issues.redhat.com/browse/JGRP-2009)")
     // protected boolean     reuse_addr;
 
     @LocalAddress

--- a/src/org/jgroups/protocols/CENTRAL_LOCK2.java
+++ b/src/org/jgroups/protocols/CENTRAL_LOCK2.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * This protocol requires less traffic than {@link CENTRAL_LOCK} (each request also has to be sent to the backup(s)),
  * but introduces communication between the new coord and all members (and thus a small pause) on coord change.
  * <br/>
- * The JIRA issue is https://issues.jboss.org/browse/JGRP-2249.
+ * The JIRA issue is https://issues.redhat.com/browse/JGRP-2249.
  * @author Bela Ban
  * @since  4.0.13
  * @see Locking

--- a/src/org/jgroups/protocols/COMPRESS.java
+++ b/src/org/jgroups/protocols/COMPRESS.java
@@ -190,7 +190,7 @@ public class COMPRESS extends Protocol {
                 inflater.setInput(compressed_payload, msg.getOffset(), msg.getLength());
                 try {
                     inflater.inflate(uncompressed_payload);
-                    // we need to copy: https://jira.jboss.org/jira/browse/JGRP-867
+                    // we need to copy: https://issues.redhat.com/browse/JGRP-867
                     if(needs_deserialization) {
                         return messageFromByteArray(uncompressed_payload, msg_factory);
                     }

--- a/src/org/jgroups/protocols/DAISYCHAIN.java
+++ b/src/org/jgroups/protocols/DAISYCHAIN.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  * members, it needs to send it 9 times. With daisy chaining, it sends it 1 time, and in the next round, can already
  * send another message. This leads to much better throughput, see the ref in the JIRA.<p/>
  * Should be inserted just above MERGE3, in TCP based configurations.
- * JIRA: https://jira.jboss.org/browse/JGRP-1021
+ * JIRA: https://issues.redhat.com/browse/JGRP-1021
  * @author Bela Ban
  * @since 2.11
  */

--- a/src/org/jgroups/protocols/Discovery.java
+++ b/src/org/jgroups/protocols/Discovery.java
@@ -81,7 +81,7 @@ public abstract class Discovery extends Protocol {
     protected int                        max_rank_to_reply;
 
     @Property(description="The number of times a discovery process is executed when finding initial members " +
-      "(https://issues.jboss.org/browse/JGRP-2317)")
+      "(https://issues.redhat.com/browse/JGRP-2317)")
     protected int                        num_discovery_runs=1;
 
     /* ---------------------------------------------   JMX      ------------------------------------------------------ */
@@ -293,7 +293,7 @@ public abstract class Discovery extends Protocol {
         if(hdr == null)
             return up_prot.up(msg);
         if(is_leaving)
-            return null; // prevents merging back a leaving member (https://issues.jboss.org/browse/JGRP-1336)
+            return null; // prevents merging back a leaving member (https://issues.redhat.com/browse/JGRP-1336)
         return handle(hdr, msg);
     }
 

--- a/src/org/jgroups/protocols/Encrypt.java
+++ b/src/org/jgroups/protocols/Encrypt.java
@@ -267,7 +267,7 @@ public abstract class Encrypt<E extends KeyStore.Entry> extends Protocol {
     }
 
     protected Object handleEncryptedMessage(Message msg) throws Exception {
-        // decrypt the message; we need to copy msg as we modify its buffer (http://jira.jboss.com/jira/browse/JGRP-538)
+        // decrypt the message; we need to copy msg as we modify its buffer (https://issues.redhat.com/browse/JGRP-538)
         Message tmpMsg=decrypt(null, msg.copy(true, true)); // need to copy for possible xmits
         return tmpMsg != null? up_prot.up(tmpMsg) : null;
     }

--- a/src/org/jgroups/protocols/FD_ALL.java
+++ b/src/org/jgroups/protocols/FD_ALL.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
  * Failure detection based on simple heartbeat protocol. Every member periodically multicasts a heartbeat.
  * Every member also maintains a table of all members (minus itself). When data or a heartbeat from P is received,
  * we reset the timestamp for P to the current time. Periodically, we check for expired members, and suspect those.</p>
- * Reduced number of messages exchanged on suspect event: https://jira.jboss.org/browse/JGRP-1241
+ * Reduced number of messages exchanged on suspect event: https://issues.redhat.com/browse/JGRP-1241
  * 
  * @author Bela Ban
  */

--- a/src/org/jgroups/protocols/FD_HOST.java
+++ b/src/org/jgroups/protocols/FD_HOST.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * <p/>
  * This protocol would typically be used when multiple cluster members are running on the same physical box.
  * <p/>
- * JIRA:  https://issues.jboss.org/browse/JGRP-1855
+ * JIRA:  https://issues.redhat.com/browse/JGRP-1855
  * @author  Bela Ban
  * @version 3.5, 3.4.5
  */

--- a/src/org/jgroups/protocols/FD_SOCK.java
+++ b/src/org/jgroups/protocols/FD_SOCK.java
@@ -586,7 +586,7 @@ public class FD_SOCK extends Protocol implements Runnable {
         if(isPingerThreadRunning()) {
             regular_sock_close=true;
             if (sendTerminationSignal) {
-                sendPingTermination();  // PATCH by Bruce Schuchardt (http://jira.jboss.com/jira/browse/JGRP-246)
+                sendPingTermination();  // PATCH by Bruce Schuchardt (https://issues.redhat.com/browse/JGRP-246)
             }
             teardownPingSocket(); // will wake up the pinger thread. less elegant than Thread.interrupt(), but does the job
         }

--- a/src/org/jgroups/protocols/FILE_PING.java
+++ b/src/org/jgroups/protocols/FILE_PING.java
@@ -53,7 +53,7 @@ public class FILE_PING extends Discovery {
     protected long    info_writer_sleep_time=10000;
 
     @Property(description="When a non-initial discovery is run, and InfoWriter is not running, write the data to " +
-      "disk (if true). JIRA: https://issues.jboss.org/browse/JGRP-2288")
+      "disk (if true). JIRA: https://issues.redhat.com/browse/JGRP-2288")
     protected boolean write_data_on_find;
 
     @Property(description = "If set, a shutdown hook is registered with the JVM to remove the local address "

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 /**
- * The FORK protocol; multiplexes messages to different forks in a stack (https://issues.jboss.org/browse/JGRP-1613).
+ * The FORK protocol; multiplexes messages to different forks in a stack (https://issues.redhat.com/browse/JGRP-1613).
  * See doc/design/FORK.txt for details
  * @author Bela Ban
  * @since  3.4

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -326,7 +326,7 @@ public class FORK extends Protocol {
         try {
             configStream=new FileInputStream(config);
         }
-        catch(FileNotFoundException fnfe) { // catching ACE fixes http://jira.jboss.com/jira/browse/JGRP-94
+        catch(FileNotFoundException fnfe) { // catching ACE fixes https://issues.redhat.com/browse/JGRP-94
         }
 
         // Check to see if the properties string is a URL.

--- a/src/org/jgroups/protocols/FRAG.java
+++ b/src/org/jgroups/protocols/FRAG.java
@@ -131,7 +131,7 @@ public class FRAG extends Fragmentation {
             FragHeader hdr=msg.getHeader(this.id);
             Message assembled_msg=unfragment(msg, hdr);
             if(assembled_msg != null)
-                // the reassembled msg has to be add in the right place (https://issues.jboss.org/browse/JGRP-1648),
+                // the reassembled msg has to be add in the right place (https://issues.redhat.com/browse/JGRP-1648),
                 // and cannot be added at the tail of the batch!
                 it.replace(assembled_msg);
             else

--- a/src/org/jgroups/protocols/FRAG2.java
+++ b/src/org/jgroups/protocols/FRAG2.java
@@ -147,7 +147,7 @@ public class FRAG2 extends Fragmentation {
                 continue;
             Message assembled_msg=unfragment(msg, hdr);
             if(assembled_msg != null) {
-                // the reassembled msg has to be add in the right place (https://issues.jboss.org/browse/JGRP-1648),
+                // the reassembled msg has to be add in the right place (https://issues.redhat.com/browse/JGRP-1648),
                 // and cannot be added to the tail of the batch!
                 assembled_msg.setSrc(batch.sender());
                 it.replace(assembled_msg);

--- a/src/org/jgroups/protocols/FRAG3.java
+++ b/src/org/jgroups/protocols/FRAG3.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
  * message at its offset and length. When all fragments have been received, the full message is passed up.<br/>
  * Only the first fragment carries the headers and dest and src addresses. When received, its src/dest addresses and
  * the headers will be set in the full message.<br/>
- * For details see https://issues.jboss.org/browse/JGRP-2154
+ * For details see https://issues.redhat.com/browse/JGRP-2154
  * <br/>
  * Requirement: lossless delivery (e.g. NAKACK2 or UNICAST3). No requirement on ordering. Works for both unicast and
  * multicast messages.<br/>
@@ -141,7 +141,7 @@ public class FRAG3 extends Fragmentation {
             Frag3Header hdr=msg.getHeader(this.id);
             Message assembled_msg=unfragment(msg, hdr);
             if(assembled_msg != null) {
-                // the reassembled msg has to be add in the right place (https://issues.jboss.org/browse/JGRP-1648),
+                // the reassembled msg has to be add in the right place (https://issues.redhat.com/browse/JGRP-1648),
                 // and canot be added to the tail of the batch !
                 assembled_msg.setSrc(batch.sender());
                 it.replace(assembled_msg);

--- a/src/org/jgroups/protocols/FailureDetection.java
+++ b/src/org/jgroups/protocols/FailureDetection.java
@@ -355,7 +355,7 @@ public abstract class FailureDetection extends Protocol {
 
         public void run() {
             synchronized(this) {
-                retainKeys(members); // remove all non-members (// https://issues.jboss.org/browse/JGRP-2387)
+                retainKeys(members); // remove all non-members (// https://issues.redhat.com/browse/JGRP-2387)
             }
             List<Address> suspects=new LinkedList<>();
             for(Iterator<? extends Map.Entry<Address,?>> it=getTimestamps().entrySet().iterator(); it.hasNext();) {

--- a/src/org/jgroups/protocols/FlowControl.java
+++ b/src/org/jgroups/protocols/FlowControl.java
@@ -177,7 +177,7 @@ public abstract class FlowControl extends Protocol {
                        "a fragmentation protocol, due to https://issues.redhat.com/browse/JGRP-590");
         if(frag_size > 0 && frag_size >= min_credits) {
             log.warn("The fragmentation size of the fragmentation protocol is %d, which is greater than min_credits (%d). " +
-                       "This can lead to blockings (https://issues.jboss.org/browse/JGRP-1659)", frag_size, min_credits);
+                       "This can lead to blockings (https://issues.redhat.com/browse/JGRP-1659)", frag_size, min_credits);
         }
         running=true;
     }

--- a/src/org/jgroups/protocols/FlowControl.java
+++ b/src/org/jgroups/protocols/FlowControl.java
@@ -174,7 +174,7 @@ public abstract class FlowControl extends Protocol {
         boolean is_udp_transport=getTransport().isMulticastCapable();
         if(is_udp_transport && frag_size <= 0)
             log.warn("No fragmentation protocol was found. When flow control is used, we recommend " +
-                       "a fragmentation protocol, due to http://jira.jboss.com/jira/browse/JGRP-590");
+                       "a fragmentation protocol, due to https://issues.redhat.com/browse/JGRP-590");
         if(frag_size > 0 && frag_size >= min_credits) {
             log.warn("The fragmentation size of the fragmentation protocol is %d, which is greater than min_credits (%d). " +
                        "This can lead to blockings (https://issues.jboss.org/browse/JGRP-1659)", frag_size, min_credits);

--- a/src/org/jgroups/protocols/LOCAL_PING.java
+++ b/src/org/jgroups/protocols/LOCAL_PING.java
@@ -85,7 +85,7 @@ public class LOCAL_PING extends Discovery {
                         if(down_prot.down(new Event(Event.GET_PHYSICAL_ADDRESS, mbr)) == null)
                             down_prot.down(new Event(Event.ADD_PHYSICAL_ADDRESS, new Tuple<>(mbr, d.getPhysicalAddr())));
 
-                        // set the coordinator based on the new view (https://issues.jboss.org/browse/JGRP-2381)
+                        // set the coordinator based on the new view (https://issues.redhat.com/browse/JGRP-2381)
                         if(Objects.equals(local_addr, mbr)) {
                             if(!was_coord && is_coord) { // this member became coordinator
                                 d.coord(true);
@@ -115,7 +115,7 @@ public class LOCAL_PING extends Discovery {
                 final List<PingData> list=discovery.computeIfAbsent(cluster_name, FUNC);
                 if(list.isEmpty()) {
                     // the first member will become coord (may be changed by view changes/merges later)
-                    // https://issues.jboss.org/browse/JGRP-2395
+                    // https://issues.redhat.com/browse/JGRP-2395
                     data.coord(true);
                 }
                 list.add(data);

--- a/src/org/jgroups/protocols/Locking.java
+++ b/src/org/jgroups/protocols/Locking.java
@@ -49,7 +49,7 @@ abstract public class Locking extends Protocol {
     protected int                                    lock_striping_size=10;
 
     @Property(description="By default, a lock owner is address:thread-id. If false, we only use the node's address. " +
-      "See https://issues.jboss.org/browse/JGRP-1886 for details")
+      "See https://issues.redhat.com/browse/JGRP-1886 for details")
     protected boolean                                use_thread_id_for_lock_owner=true;
 
     protected View                                   view;

--- a/src/org/jgroups/protocols/MERGE3.java
+++ b/src/org/jgroups/protocols/MERGE3.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * Protocol to discover subgroups; e.g., existing due to a network partition (that healed). Example: group
  * {p,q,r,s,t,u,v,w} is split into 3 subgroups {p,q}, {r,s,t,u} and {v,w}. This protocol will eventually send
  * a MERGE event with the views of each subgroup up the stack: {p,r,v}. <p/>
- * Works as follows (https://issues.jboss.org/browse/JGRP-1387): every member periodically broadcasts its address (UUID),
+ * Works as follows (https://issues.redhat.com/browse/JGRP-1387): every member periodically broadcasts its address (UUID),
  * logical name, physical address and ViewID information. Other members collect this information and see if the ViewIds
  * are different (indication of different subpartitions). If they are, the member with the lowest address (first in the
  * sorted list of collected addresses) sends a MERGE event up the stack, which will be handled by GMS.

--- a/src/org/jgroups/protocols/MFC_NB.java
+++ b/src/org/jgroups/protocols/MFC_NB.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 
 /**
  * Non-blocking alternative to {@link MFC}.<br/>
- * JIRA: JIRA: https://issues.jboss.org/browse/JGRP-2172
+ * JIRA: JIRA: https://issues.redhat.com/browse/JGRP-2172
  * @author Bela Ban
  * @since 4.0.4
  */

--- a/src/org/jgroups/protocols/MPING.java
+++ b/src/org/jgroups/protocols/MPING.java
@@ -134,7 +134,7 @@ public class MPING extends PING implements Runnable {
     public void start() throws Exception {
         if(bind_addr == null)
             bind_addr=getTransport().getBindAddr();
-        if(Util.can_bind_to_mcast_addr) // https://jira.jboss.org/jira/browse/JGRP-836 - prevent cross talking on Linux
+        if(Util.can_bind_to_mcast_addr) // https://issues.redhat.com/browse/JGRP-836 - prevent cross talking on Linux
             mcast_receive_sock=Util.createMulticastSocket(getSocketFactory(), "jgroups.mping.mcast_sock", mcast_addr, mcast_port, log);
         else
             mcast_receive_sock=getSocketFactory().createMulticastSocket("jgroups.mping.mcast_sock", mcast_port);

--- a/src/org/jgroups/protocols/PING.java
+++ b/src/org/jgroups/protocols/PING.java
@@ -42,7 +42,7 @@ public class PING extends Discovery {
     protected void sendDiscoveryRequest(String cluster_name, List<Address> members_to_find, boolean initial_discovery) throws Exception {
         PhysicalAddress physical_addr=(PhysicalAddress)down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
 
-        // https://issues.jboss.org/browse/JGRP-1670
+        // https://issues.redhat.com/browse/JGRP-1670
         PingData data=new PingData(local_addr, false, NameCache.get(local_addr), physical_addr);
         if(members_to_find != null && members_to_find.size() <= max_members_in_discovery_request)
             data.mbrs(members_to_find);

--- a/src/org/jgroups/protocols/RSVP.java
+++ b/src/org/jgroups/protocols/RSVP.java
@@ -19,7 +19,7 @@ import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 /**
- * Protocol which implements synchronous messages (https://issues.jboss.org/browse/JGRP-1389). A send of a message M
+ * Protocol which implements synchronous messages (https://issues.redhat.com/browse/JGRP-1389). A send of a message M
  * with flag RSVP set will block until all non-faulty recipients (one for unicasts, N for multicasts) have acked M, or
  * until a timeout kicks in.
  * @author Bela Ban
@@ -125,7 +125,7 @@ public class RSVP extends Protocol {
             ids.put(next_id, entry);
 
             // sync members again - if a view was received after reading members intro Entry, but
-            // before adding Entry to ids (https://issues.jboss.org/browse/JGRP-1503)
+            // before adding Entry to ids (https://issues.redhat.com/browse/JGRP-1503)
             entry.retainAll(members);
 
             // Send the message

--- a/src/org/jgroups/protocols/RemoveQueueBundler.java
+++ b/src/org/jgroups/protocols/RemoveQueueBundler.java
@@ -22,7 +22,7 @@ import java.util.List;
  * and the size of the remove queue is fixed. TransferQueueBundler increases the size of the remove queue
  * dynamically, which leads to higher latency if the remove queue grows too much.
  * <br/>
- * JIRA: https://issues.jboss.org/browse/JGRP-2171
+ * JIRA: https://issues.redhat.com/browse/JGRP-2171
  * @author Bela Ban
  * @since  4.0.4
  */

--- a/src/org/jgroups/protocols/SEQUENCER.java
+++ b/src/org/jgroups/protocols/SEQUENCER.java
@@ -78,7 +78,7 @@ public class SEQUENCER extends Protocol {
     protected int                               threshold=10;
 
     @Property(description="If true, all messages in the forward-table are sent to the new coord, else thye're " +
-      "dropped (https://issues.jboss.org/browse/JGRP-2268)")
+      "dropped (https://issues.redhat.com/browse/JGRP-2268)")
     protected boolean                           flush_forward_table=true;
 
     @ManagedAttribute protected int  num_acks;
@@ -147,7 +147,7 @@ public class SEQUENCER extends Protocol {
             block();
 
         // A seqno is not used to establish ordering, but only to weed out duplicates; next_seqno doesn't need
-        // to increase monotonically, but only to be unique (https://issues.jboss.org/browse/JGRP-1461) !
+        // to increase monotonically, but only to be unique (https://issues.redhat.com/browse/JGRP-1461) !
         long next_seqno=seqno.incrementAndGet();
         in_flight_sends.incrementAndGet();
         try {
@@ -346,7 +346,7 @@ public class SEQUENCER extends Protocol {
         // - B receives message 4 and broadcasts it
         // ==> C's message 4 is delivered *before* message 3 !
         // ==> By resending 3 until it is received, then resending 4 until it is received, we make sure this won't happen
-        // (see https://issues.jboss.org/browse/JGRP-1449)
+        // (see https://issues.redhat.com/browse/JGRP-1449)
         while(flushing && running && !forward_table.isEmpty()) {
             Map.Entry<Long,Message> entry=forward_table.firstEntry();
             final Long key=entry.getKey();
@@ -545,7 +545,7 @@ public class SEQUENCER extends Protocol {
         if(flusher == null || !flusher.isAlive()) {
             if(log.isTraceEnabled())
                 log.trace(local_addr + ": flushing started");
-            // causes subsequent message sends (broadcasts and forwards) to block (https://issues.jboss.org/browse/JGRP-1495)
+            // causes subsequent message sends (broadcasts and forwards) to block (https://issues.redhat.com/browse/JGRP-1495)
             flushing=true;
             
             flusher=new Flusher(new_coord);

--- a/src/org/jgroups/protocols/SERIALIZE.java
+++ b/src/org/jgroups/protocols/SERIALIZE.java
@@ -19,7 +19,7 @@ import org.jgroups.util.Util;
  * To be used with {@link ASYM_ENCRYPT} or {@link SYM_ENCRYPT} when the entire message (including the headers) needs to
  * be encrypted. Can be used as a replacement for the deprecated attribute encrypt_entire_message in the above encryption
  * protocols.<br/>
- * See https://issues.jboss.org/browse/JGRP-2273 for details.
+ * See https://issues.redhat.com/browse/JGRP-2273 for details.
  * @author Bela Ban
  * @since  4.0.12
  */

--- a/src/org/jgroups/protocols/SHARED_LOOPBACK.java
+++ b/src/org/jgroups/protocols/SHARED_LOOPBACK.java
@@ -196,7 +196,7 @@ public class SHARED_LOOPBACK extends TP {
             Map<Address,SHARED_LOOPBACK> map=routing_table.computeIfAbsent(cluster, FUNC);
             if(map.isEmpty()) {
                 // the first member will become coord (may be changed by view changes/merges later)
-                // https://issues.jboss.org/browse/JGRP-2395
+                // https://issues.redhat.com/browse/JGRP-2395
                 shared_loopback.coord(true);
             }
             map.putIfAbsent(local_addr, shared_loopback);

--- a/src/org/jgroups/protocols/SYM_ENCRYPT.java
+++ b/src/org/jgroups/protocols/SYM_ENCRYPT.java
@@ -48,7 +48,7 @@ public class SYM_ENCRYPT extends Encrypt<KeyStore.SecretKeyEntry> {
     protected String   store_password="changeit"; // JDK default
 
     @Property(description="Password for recovering the key. Change the default", exposeAsManagedAttribute=false)
-    protected String   key_password; // allows to assign keypwd=storepwd if not set (https://issues.jboss.org/browse/JGRP-1375)
+    protected String   key_password; // allows to assign keypwd=storepwd if not set (https://issues.redhat.com/browse/JGRP-1375)
 
 
     @Property(name="alias", description="Alias used for recovering the key. Change the default",exposeAsManagedAttribute=false)

--- a/src/org/jgroups/protocols/TCP.java
+++ b/src/org/jgroups/protocols/TCP.java
@@ -131,7 +131,7 @@ public class TCP extends BasicTCP {
         if(max_length > 0)
             srv.setMaxLength(max_length);
 
-        // we first start threads in TP (http://jira.jboss.com/jira/browse/JGRP-626)
+        // we first start threads in TP (https://issues.redhat.com/browse/JGRP-626)
         super.start();
     }
     

--- a/src/org/jgroups/protocols/TCPGOSSIP.java
+++ b/src/org/jgroups/protocols/TCPGOSSIP.java
@@ -84,7 +84,7 @@ public class TCPGOSSIP extends Discovery implements RouterStub.MembersNotificati
     public void init() throws Exception {
         super.init();
         stubManager = RouterStubManager.emptyGossipClientStubManager(this).useNio(this.use_nio);
-        // we cannot use TCPGOSSIP together with TUNNEL (https://jira.jboss.org/jira/browse/JGRP-1101)
+        // we cannot use TCPGOSSIP together with TUNNEL (https://issues.redhat.com/browse/JGRP-1101)
         TP tp=getTransport();
         if(tp instanceof TUNNEL)
             throw new IllegalStateException("TCPGOSSIP cannot be used with TUNNEL; use either TUNNEL:PING or " +

--- a/src/org/jgroups/protocols/TCPPING.java
+++ b/src/org/jgroups/protocols/TCPPING.java
@@ -58,7 +58,7 @@ public class TCPPING extends Discovery {
 
     protected Collection<PhysicalAddress>  initial_hosts=new HashSet<>();
 
-    /** https://jira.jboss.org/jira/browse/JGRP-989 */
+    /** https://issues.redhat.com/browse/JGRP-989 */
     protected BoundedList<PhysicalAddress> dynamic_hosts;
 
     protected StackType stack_type=StackType.Dual;

--- a/src/org/jgroups/protocols/TCPPING.java
+++ b/src/org/jgroups/protocols/TCPPING.java
@@ -174,7 +174,7 @@ public class TCPPING extends Discovery {
     public void findMembers(List<Address> members, boolean initial_discovery, Responses responses) {
         PhysicalAddress physical_addr=(PhysicalAddress)down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
 
-        // https://issues.jboss.org/browse/JGRP-1670
+        // https://issues.redhat.com/browse/JGRP-1670
         PingData data=new PingData(local_addr, false, NameCache.get(local_addr), physical_addr);
         if(members != null && members.size() <= max_members_in_discovery_request)
             data.mbrs(members);

--- a/src/org/jgroups/protocols/TIME.java
+++ b/src/org/jgroups/protocols/TIME.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Protocol measuring delivery times. Can be used in the up or down direction
- * JIRA: https://issues.jboss.org/browse/JGRP-2101
+ * JIRA: https://issues.redhat.com/browse/JGRP-2101
  * @author Bela Ban
  * @since  4.0
  */

--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -1203,7 +1203,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
     public void receive(Address sender, byte[] data, int offset, int length) {
         if(data == null) return;
 
-        // drop message from self; it has already been looped back up (https://issues.jboss.org/browse/JGRP-1765)
+        // drop message from self; it has already been looped back up (https://issues.redhat.com/browse/JGRP-1765)
         if(Objects.equals(local_physical_addr, sender))
             return;
 
@@ -1229,7 +1229,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
     public void receive(Address sender, DataInput in) throws Exception {
         if(in == null) return;
 
-        // drop message from self; it has already been looped back up (https://issues.jboss.org/browse/JGRP-1765)
+        // drop message from self; it has already been looped back up (https://issues.redhat.com/browse/JGRP-1765)
         if(Objects.equals(local_physical_addr, sender))
             return;
 

--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -367,7 +367,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
     protected final Set<Address> members=new CopyOnWriteArraySet<>();
 
 
-    //http://jira.jboss.org/jira/browse/JGRP-849
+    //https://issues.redhat.com/browse/JGRP-849
     protected final ReentrantLock connectLock = new ReentrantLock();
     
 
@@ -913,7 +913,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
                     members.clear();
                     members.addAll(v.getMembers());
 
-                    // fix for https://jira.jboss.org/jira/browse/JGRP-918
+                    // fix for https://issues.redhat.com/browse/JGRP-918
                     logical_addr_cache.retainAll(members);
                     fetchLocalAddresses();
 
@@ -1100,7 +1100,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
             passMessageUp(copy, null, false, multicast, false);
             return;
         }
-        // changed to fix http://jira.jboss.com/jira/browse/JGRP-506
+        // changed to fix https://issues.redhat.com/browse/JGRP-506
         msg_processing_policy.loopback(msg, msg.isFlagSet(Message.Flag.OOB));
     }
 

--- a/src/org/jgroups/protocols/TransferQueueBundler.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler.java
@@ -13,7 +13,7 @@ import java.util.concurrent.BlockingQueue;
 
 /**
  * This bundler adds all (unicast or multicast) messages to a queue until max size has been exceeded, but does send
- * messages immediately when no other messages are available. https://issues.jboss.org/browse/JGRP-1540
+ * messages immediately when no other messages are available. https://issues.redhat.com/browse/JGRP-1540
  */
 public class TransferQueueBundler extends BaseBundler implements Runnable {
     protected BlockingQueue<Message> queue;

--- a/src/org/jgroups/protocols/TransferQueueBundler2.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler2.java
@@ -25,7 +25,7 @@ import static org.jgroups.protocols.TP.MSG_OVERHEAD;
 
 /**
  * This bundler adds all (unicast or multicast) messages to a queue until max size has been exceeded, but does send
- * messages immediately when no other messages are available. https://issues.jboss.org/browse/JGRP-1540<br/>
+ * messages immediately when no other messages are available. https://issues.redhat.com/browse/JGRP-1540<br/>
  * The difference to {@link TransferQueueBundler} is that a size is maintained <pre>per destination</pre> and we
  * maintain byte arrays of max_bundle_size per destination into which we marshall a message directly when it is sent.
  */

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -279,7 +279,7 @@ public class UDP extends TP {
 
     protected void _send(InetAddress dest, int port, byte[] data, int offset, int length) throws Exception {
         DatagramPacket packet=new DatagramPacket(data, offset, length, dest, port);
-        // using the datagram socket to send multicasts or unicasts (https://issues.jboss.org/browse/JGRP-1765)
+        // using the datagram socket to send multicasts or unicasts (https://issues.redhat.com/browse/JGRP-1765)
         if(sock != null) {
             try {
                 sock.send(packet);

--- a/src/org/jgroups/protocols/UDP.java
+++ b/src/org/jgroups/protocols/UDP.java
@@ -419,7 +419,7 @@ public class UDP extends TP {
 
         // 3. Create socket for receiving IP multicast packets
         if(ip_mcast) {
-            // https://jira.jboss.org/jira/browse/JGRP-777 - this doesn't work on MacOS, and we don't have
+            // https://issues.redhat.com/browse/JGRP-777 - this doesn't work on MacOS, and we don't have
             // cross talking on Windows anyway, so we just do it for Linux. (How about Solaris ?)
 
             // If possible, the MulticastSocket(SocketAddress) ctor is used which binds to mcast_addr:mcast_port.

--- a/src/org/jgroups/protocols/UFC_NB.java
+++ b/src/org/jgroups/protocols/UFC_NB.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 
 /**
  * Non-blocking alternative to {@link UFC}.<br/>
- * JIRA: https://issues.jboss.org/browse/JGRP-2172
+ * JIRA: https://issues.redhat.com/browse/JGRP-2172
  * @author Bela Ban
  * @since  4.0.4
  */

--- a/src/org/jgroups/protocols/UNICAST3.java
+++ b/src/org/jgroups/protocols/UNICAST3.java
@@ -124,7 +124,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
 
     protected final ReentrantLock          recv_table_lock=new ReentrantLock();
 
-    /** Used by the retransmit task to keep the last retransmitted seqno per sender (https://issues.jboss.org/browse/JGRP-1539) */
+    /** Used by the retransmit task to keep the last retransmitted seqno per sender (https://issues.redhat.com/browse/JGRP-1539) */
     protected final Map<Address,Long>      xmit_task_map=new HashMap<>();
 
     /** RetransmitTask running every xmit_interval ms */

--- a/src/org/jgroups/protocols/UNICAST3.java
+++ b/src/org/jgroups/protocols/UNICAST3.java
@@ -559,7 +559,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
             Table<Message> win=entry.msgs;
             update(entry, len);
 
-            // OOB msg is passed up. When removed, we discard it. Affects ordering: http://jira.jboss.com/jira/browse/JGRP-379
+            // OOB msg is passed up. When removed, we discard it. Affects ordering: https://issues.redhat.com/browse/JGRP-379
             if(batch.mode() == MessageBatch.Mode.OOB) {
                 MessageBatch oob_batch=new MessageBatch(local_addr, batch.sender(), batch.clusterName(), batch.multicast(), MessageBatch.Mode.OOB, len);
                 for(LongTuple<Message> tuple: list) {
@@ -791,7 +791,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
             entry.sendAck(); // will be sent delayed (on the next xmit_interval)
 
         // An OOB message is passed up immediately. Later, when remove() is called, we discard it. This affects ordering !
-        // http://jira.jboss.com/jira/browse/JGRP-377
+        // https://issues.redhat.com/browse/JGRP-377
         if(oob && added)
             deliverMessage(msg, sender, seqno);
     }
@@ -821,7 +821,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
         final Table<Message> win=entry.msgs;
 
         // An OOB message is passed up immediately. Later, when remove() is called, we discard it.
-        // This affects ordering ! JIRA: http://jira.jboss.com/jira/browse/JGRP-377
+        // This affects ordering ! JIRA: https://issues.redhat.com/browse/JGRP-377
         if(msg.isFlagSet(Message.Flag.OOB)) {
             msg=win.get(seqno); // we *have* to get a message, because loopback means we didn't add it to win !
             if(msg != null && msg.isFlagSet(Message.Flag.OOB) && msg.setFlagIfAbsent(Message.TransientFlag.OOB_DELIVERED))
@@ -847,7 +847,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
         else
             entry.sendAck();
 
-        // OOB msg is passed up. When removed, we discard it. Affects ordering: http://jira.jboss.com/jira/browse/JGRP-379
+        // OOB msg is passed up. When removed, we discard it. Affects ordering: https://issues.redhat.com/browse/JGRP-379
         if(added && oob) {
             MessageBatch oob_batch=new MessageBatch(local_addr, sender, null, false, MessageBatch.Mode.OOB, msgs.size());
             for(LongTuple<Message> tuple: msgs)
@@ -862,7 +862,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
 
     /**
      * Try to remove as many messages as possible from the table as pass them up.
-     * Prevents concurrent passing up of messages by different threads (http://jira.jboss.com/jira/browse/JGRP-198);
+     * Prevents concurrent passing up of messages by different threads (https://issues.redhat.com/browse/JGRP-198);
      * lots of threads can come up to this point concurrently, but only 1 is allowed to pass at a time.
      * We *can* deliver messages from *different* senders concurrently, e.g. reception of P1, Q1, P2, Q2 can result in
      * delivery of P1, Q1, Q2, P2: FIFO (implemented by UNICAST) says messages need to be delivered in the
@@ -1016,7 +1016,7 @@ public class UNICAST3 extends Protocol implements AgeOutCache.Handler<Address> {
         if(rsp != null) {
             // We need to copy the UnicastHeader and put it back into the message because Message.copy() doesn't copy
             // the headers and therefore we'd modify the original message in the sender retransmission window
-            // (https://jira.jboss.org/jira/browse/JGRP-965)
+            // (https://issues.redhat.com/browse/JGRP-965)
             Message copy=rsp.copy(true, true);
             UnicastHeader3 hdr=copy.getHeader(this.id);
             UnicastHeader3 newhdr=hdr.copy();

--- a/src/org/jgroups/protocols/dns/DNS_PING.java
+++ b/src/org/jgroups/protocols/dns/DNS_PING.java
@@ -120,7 +120,7 @@ public class DNS_PING extends Discovery {
         DNSResolver.DNSRecordType record_type=DNSResolver.DNSRecordType.valueOf(dns_record_type);
 
         physical_addr = (PhysicalAddress) down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
-        // https://issues.jboss.org/browse/JGRP-1670
+        // https://issues.redhat.com/browse/JGRP-1670
         data = new PingData(local_addr, false, NameCache.get(local_addr), physical_addr);
         if (members != null && members.size() <= max_members_in_discovery_request)
             data.mbrs(members);

--- a/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
@@ -73,7 +73,7 @@ public class ClientGmsImpl extends GmsImpl {
                     }
                 }
 
-                // Sept 2008 (bela): return if we got a belated JoinRsp (https://jira.jboss.org/jira/browse/JGRP-687)
+                // Sept 2008 (bela): return if we got a belated JoinRsp (https://issues.redhat.com/browse/JGRP-687)
                 if(installViewIfValidJoinRsp(join_promise, false))
                     return;
 

--- a/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
@@ -43,7 +43,7 @@ public class CoordGmsImpl extends ServerGmsImpl {
     /** The coordinator itself wants to leave the group */
     public void leave() {
         ViewHandler<Request> vh=gms.getViewHandler();
-        vh.add(new Request(Request.COORD_LEAVE)); // https://issues.jboss.org/browse/JGRP-2293
+        vh.add(new Request(Request.COORD_LEAVE)); // https://issues.redhat.com/browse/JGRP-2293
         vh.waitUntilComplete();
     }
 
@@ -191,7 +191,7 @@ public class CoordGmsImpl extends ServerGmsImpl {
 
             sendLeaveResponses(leaving_mbrs); // no-op if no leaving members
 
-            // we don't need to send the digest to existing members: https://issues.jboss.org/browse/JGRP-1317
+            // we don't need to send the digest to existing members: https://issues.redhat.com/browse/JGRP-1317
             gms.castViewChangeAndSendJoinRsps(new_view, null, new_view.getMembers(), new_mbrs, join_rsp);
         }
         finally {

--- a/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/CoordGmsImpl.java
@@ -162,7 +162,7 @@ public class CoordGmsImpl extends ServerGmsImpl {
         try {            
             boolean successfulFlush =!useFlushIfPresent || !gms.flushProtocolInStack || gms.startFlush(new_view);
             if(!successfulFlush && hasJoiningMembers) {
-                // Don't send a join response if the flush fails (http://jira.jboss.org/jira/browse/JGRP-759)
+                // Don't send a join response if the flush fails (https://issues.redhat.com/browse/JGRP-759)
                 // The joiner should block until the previous FLUSH completed
                 sendLeaveResponses(leaving_mbrs); // we still have to send potential leave responses
                 // but let the joining client timeout and send another join request

--- a/src/org/jgroups/protocols/pbcast/DeltaView.java
+++ b/src/org/jgroups/protocols/pbcast/DeltaView.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
  * a GmsHeader, the header is then marshalled. On the receiving side, the DeltaView is created from the stream, a View
  * is created and the DeltaView discarded again.<p/>
  * Instances of this class are created by {@link CoordGmsImpl#handleMembershipChange(java.util.Collection)}.<p/>
- * JIRA issue: https://issues.jboss.org/browse/JGRP-1354
+ * JIRA issue: https://issues.redhat.com/browse/JGRP-1354
  * @author Bela Ban
  * @since  3.4
  */

--- a/src/org/jgroups/protocols/pbcast/FLUSH.java
+++ b/src/org/jgroups/protocols/pbcast/FLUSH.java
@@ -477,7 +477,7 @@ public class FLUSH extends Protocol {
                 }
                 return null; // do not pass FLUSH msg up
             } else {
-                // http://jira.jboss.com/jira/browse/JGRP-575: for processing of application messages after we join,
+                // https://issues.redhat.com/browse/JGRP-575: for processing of application messages after we join,
                 // lets wait for STOP_FLUSH to complete before we start allowing message up
                 if (msg.getDest() != null)
                     return up_prot.up(msg); // allow unicasts to pass, virtual synchrony only applies to multicasts

--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -670,8 +670,8 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
             }
         }
 
-        // - Changed order of passing view up and down (http://jira.jboss.com/jira/browse/JGRP-347)
-        // - Changed it back (bela Sept 4 2007): http://jira.jboss.com/jira/browse/JGRP-564
+        // - Changed order of passing view up and down (https://issues.redhat.com/browse/JGRP-347)
+        // - Changed it back (bela Sept 4 2007): https://issues.redhat.com/browse/JGRP-564
         // - Moved sending up view_event out of the synchronized block (bela Nov 2011)
         down_prot.down(view_event); // needed e.g. by failure detector or UDP
         up_prot.up(view_event);

--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -79,7 +79,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
     protected boolean                   print_physical_addrs=true;
 
     @Property(description="If true, then GMS is allowed to send VIEW messages with delta views, otherwise " +
-      "it always sends full views. See https://issues.jboss.org/browse/JGRP-1354 for details.")
+      "it always sends full views. See https://issues.redhat.com/browse/JGRP-1354 for details.")
     protected boolean                   use_delta_views=true;
 
     @Property(description="Max number of old members to keep in history. Default is 50")
@@ -545,7 +545,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
 
         Message view_change_msg=new BytesMessage().putHeader(this.id, new GmsHeader(GmsHeader.VIEW))
           .setArray(marshal(new_view, digest)).setFlag(Message.TransientFlag.DONT_LOOPBACK);
-        if(new_view instanceof MergeView) // https://issues.jboss.org/browse/JGRP-1484
+        if(new_view instanceof MergeView) // https://issues.redhat.com/browse/JGRP-1484
             view_change_msg.setFlag(Message.Flag.NO_TOTAL_ORDER);
 
         ack_collector.reset(expected_acks, local_addr) // exclude self, as we'll install the view locally

--- a/src/org/jgroups/protocols/pbcast/Merger.java
+++ b/src/org/jgroups/protocols/pbcast/Merger.java
@@ -178,7 +178,7 @@ public class Merger {
 
     /**
      * Removes all members from a given view which don't have us in their view
-     * (https://jira.jboss.org/browse/JGRP-1061). Example:
+     * (https://issues.redhat.com/browse/JGRP-1061). Example:
      * <pre>
      * A: AB
      * B: AB
@@ -501,7 +501,7 @@ public class Merger {
             subviews.addAll(views.values());
 
             // now remove all members which don't have us in their view, so RPCs won't block (e.g. FLUSH)
-            // https://jira.jboss.org/browse/JGRP-1061
+            // https://issues.redhat.com/browse/JGRP-1061
             sanitizeViews(views);
 
             Map<Address,Collection<Address>> tmp_coords=determineMergeCoords(views);

--- a/src/org/jgroups/protocols/pbcast/Merger.java
+++ b/src/org/jgroups/protocols/pbcast/Merger.java
@@ -226,7 +226,7 @@ public class Merger {
         // we need the merge *coordinators* not merge participants because not everyone can lead a merge !
         Collection<Address> coords=Util.determineActualMergeCoords(views);
         if(coords.isEmpty())
-            coords=Util.determineMergeCoords(views); // https://issues.jboss.org/browse/JGRP-2092
+            coords=Util.determineMergeCoords(views); // https://issues.redhat.com/browse/JGRP-2092
         if(coords.isEmpty()) {
             log.error("%s: unable to determine merge leader from %s; not starting a merge", gms.getAddress(), views);
             return null;
@@ -236,7 +236,7 @@ public class Merger {
 
     /**
      * Needs to return a map of all subview coordinators and their views (as a collection of members). The merge policy
-     * is defined in https://issues.jboss.org/browse/JGRP-1910
+     * is defined in https://issues.redhat.com/browse/JGRP-1910
      */
     protected static Map<Address,Collection<Address>> determineMergeCoords(Map<Address,View> views) {
            Map<Address,Collection<Address>> retval=new HashMap<>();
@@ -290,7 +290,7 @@ public class Merger {
         if(gms.flushProtocolInStack && !gms.startFlush(view)) // if flush is in stack, let this coord flush its subcluster
             throw new Exception("flush failed");
 
-        // we still need to fetch digests from all members, and not just return our own digest (https://issues.jboss.org/browse/JGRP-948)
+        // we still need to fetch digests from all members, and not just return our own digest (https://issues.redhat.com/browse/JGRP-948)
         Digest digest=fetchDigestsFromAllMembersInSubPartition(view, merge_id);
         if(digest == null || digest.capacity() == 0)
             throw new Exception("failed fetching digests from subpartition members; dropping merge response");

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -803,7 +803,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
      * store a copy of the message, but a reference ! This saves us a lot of memory. However, this also means that a
      * message should not be changed after storing it in the sent-table ! See protocols/DESIGN for details.
      * Made seqno increment and adding to sent_msgs atomic, e.g. seqno won't get incremented if adding to
-     * sent_msgs fails e.g. due to an OOM (see http://jira.jboss.com/jira/browse/JGRP-179). bela Jan 13 2006
+     * sent_msgs fails e.g. due to an OOM (see https://issues.redhat.com/browse/JGRP-179). bela Jan 13 2006
      */
     protected void send(Message msg) {
         if(!running) {
@@ -836,7 +836,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
         }
         while(running);
 
-        // moved down_prot.down() out of synchronized clause (bela Sept 7 2006) http://jira.jboss.com/jira/browse/JGRP-300
+        // moved down_prot.down() out of synchronized clause (bela Sept 7 2006) https://issues.redhat.com/browse/JGRP-300
         if(is_trace)
             log.trace("%s --> [all]: #%d", local_addr, msg_id);
         down_prot.down(msg); // if this fails, since msg is in sent_msgs, it can be retransmitted
@@ -868,7 +868,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
         // removal. Else insert the real message
         boolean added=loopback || buf.add(hdr.seqno, msg.isFlagSet(Message.Flag.OOB)? DUMMY_OOB_MSG : msg);
 
-        // OOB msg is passed up. When removed, we discard it. Affects ordering: http://jira.jboss.com/jira/browse/JGRP-379
+        // OOB msg is passed up. When removed, we discard it. Affects ordering: https://issues.redhat.com/browse/JGRP-379
         if(added && msg.isFlagSet(Message.Flag.OOB)) {
             if(loopback) { // sent by self
                 msg=buf.get(hdr.seqno); // we *have* to get a message, because loopback means we didn't add it to win !
@@ -895,7 +895,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
         boolean loopback=local_addr.equals(sender), oob=mb.mode() == OOB;
         boolean added=loopback || buf.add(mb, SEQNO_GETTER, !oob, oob? DUMMY_OOB_MSG : null);
 
-        // OOB msg is passed up. When removed, we discard it. Affects ordering: http://jira.jboss.com/jira/browse/JGRP-379
+        // OOB msg is passed up. When removed, we discard it. Affects ordering: https://issues.redhat.com/browse/JGRP-379
         if(added && oob) {
             Address dest=mb.dest();
             MessageBatch oob_batch=loopback? new MessageBatch(dest, sender, null, dest == null, OOB, size) : mb;
@@ -916,7 +916,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
 
 
     /** Efficient way of checking whether another thread is already processing messages from sender. If that's the case,
-     *  we return immediately and let the existing thread process our message (https://jira.jboss.org/jira/browse/JGRP-829).
+     *  we return immediately and let the existing thread process our message (https://issues.redhat.com/browse/JGRP-829).
      *  Benefit: fewer threads blocked on the same lock, these threads can be returned to the thread pool
      */
     protected void removeAndDeliver(Table<Message> buf, Address sender, boolean loopback, AsciiString cluster_name) {
@@ -1301,7 +1301,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
     /**
      * For all members of the digest, adjust the retransmit buffers in xmit_table. If no entry
      * exists, create one with the initial seqno set to the seqno of the member in the digest. If the member already
-     * exists, and is not the local address, replace it with the new entry (http://jira.jboss.com/jira/browse/JGRP-699)
+     * exists, and is not the local address, replace it with the new entry (https://issues.redhat.com/browse/JGRP-699)
      * if the digest's seqno is greater than the seqno in the window.
      */
     protected void mergeDigest(Digest digest) {
@@ -1329,7 +1329,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
             Table<Message> buf=xmit_table.get(member);
             if(buf != null) {
                 if(local_addr.equals(member)) {
-                    // Adjust the highest_delivered seqno (to send msgs again): https://jira.jboss.org/browse/JGRP-1251
+                    // Adjust the highest_delivered seqno (to send msgs again): https://issues.redhat.com/browse/JGRP-1251
                     buf.setHighestDelivered(highest_delivered_seqno);
                     continue; // don't destroy my own window
                 }
@@ -1370,7 +1370,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
             Table<Message> buf=xmit_table.get(member);
             if(buf != null) {
                 // We only reset the window if its seqno is lower than the seqno shipped with the digest. Also, we
-                // don't reset our own window (https://jira.jboss.org/jira/browse/JGRP-948, comment 20/Apr/09 03:39 AM)
+                // don't reset our own window (https://issues.redhat.com/browse/JGRP-948, comment 20/Apr/09 03:39 AM)
                 if(!merge
                         || (Objects.equals(local_addr, member))                  // never overwrite our own entry
                         || buf.getHighestDelivered() >= highest_delivered_seqno) // my seqno is >= digest's seqno for sender
@@ -1378,7 +1378,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
 
                 xmit_table.remove(member);
                 // to get here, merge must be false !
-                if(member.equals(local_addr)) { // Adjust the seqno: https://jira.jboss.org/browse/JGRP-1251
+                if(member.equals(local_addr)) { // Adjust the seqno: https://issues.redhat.com/browse/JGRP-1251
                     seqno.set(highest_delivered_seqno);
                     set_own_seqno=true;
                 }

--- a/src/org/jgroups/protocols/pbcast/NAKACK2.java
+++ b/src/org/jgroups/protocols/pbcast/NAKACK2.java
@@ -109,7 +109,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
 
     @Property(description="Size of the queue to hold messages received after creating the channel, but before being " +
       "connected (is_server=false). After becoming the server, the messages in the queue are fed into up() and the " +
-      "queue is cleared. The motivation is to avoid retransmissions (see https://issues.jboss.org/browse/JGRP-1509 " +
+      "queue is cleared. The motivation is to avoid retransmissions (see https://issues.redhat.com/browse/JGRP-1509 " +
       "for details). 0 disables the queue.")
     protected int     become_server_queue_size=50;
 
@@ -230,7 +230,7 @@ public class NAKACK2 extends Protocol implements DiagnosticsHandler.ProbeHandler
 
     /** RetransmitTask running every xmit_interval ms */
     protected Future<?>                 xmit_task;
-    /** Used by the retransmit task to keep the last retransmitted seqno per sender (https://issues.jboss.org/browse/JGRP-1539) */
+    /** Used by the retransmit task to keep the last retransmitted seqno per sender (https://issues.redhat.com/browse/JGRP-1539) */
     protected final Map<Address,Long>   xmit_task_map=new ConcurrentHashMap<>();
 
     protected volatile boolean          leaving=false;

--- a/src/org/jgroups/protocols/pbcast/STABLE.java
+++ b/src/org/jgroups/protocols/pbcast/STABLE.java
@@ -238,7 +238,7 @@ public class STABLE extends Protocol {
             }
         }
 
-        // only if message counting is on, and only for multicast messages (http://jira.jboss.com/jira/browse/JGRP-233)
+        // only if message counting is on, and only for multicast messages (https://issues.redhat.com/browse/JGRP-233)
         if(max_bytes > 0 && batch.dest() == null && !batch.isEmpty() && maxBytesExceeded(batch.length()))
             sendStableMessage(true);
 
@@ -292,7 +292,7 @@ public class STABLE extends Protocol {
     }
 
     protected void handleRegularMessage(Message msg) {
-        // only if bytes counting is enabled, and only for multicast messages (http://jira.jboss.com/jira/browse/JGRP-233)
+        // only if bytes counting is enabled, and only for multicast messages (https://issues.redhat.com/browse/JGRP-233)
         if(max_bytes > 0 && msg.getDest() == null &&  maxBytesExceeded(msg.getLength()))
             sendStableMessage(true);
     }
@@ -600,7 +600,7 @@ public class STABLE extends Protocol {
                 }
             };
 
-            // Run in a separate thread so we don't potentially block (http://jira.jboss.com/jira/browse/JGRP-532)
+            // Run in a separate thread so we don't potentially block (https://issues.redhat.com/browse/JGRP-532)
             timer.execute(r, getTransport() instanceof TCP);
         }
         catch(Throwable t) {

--- a/src/org/jgroups/protocols/pbcast/STABLE.java
+++ b/src/org/jgroups/protocols/pbcast/STABLE.java
@@ -620,7 +620,7 @@ public class STABLE extends Protocol {
             return;
         }
 
-        // https://issues.jboss.org/browse/JGRP-1638: we reverted to sending the STABILITY message *unreliably*,
+        // https://issues.redhat.com/browse/JGRP-1638: we reverted to sending the STABILITY message *unreliably*,
         // but clear votes *before* sending it
         try {
             Message msg=new ObjectMessage(null, d).setFlag(OOB, NO_RELIABILITY).setFlag(DONT_LOOPBACK)

--- a/src/org/jgroups/protocols/pbcast/STATE.java
+++ b/src/org/jgroups/protocols/pbcast/STATE.java
@@ -142,7 +142,7 @@ public class STATE extends StreamingStateTransfer {
             // we're copying the buffer passed from the state provider here: if a BufferedOutputStream is used, the
             // buffer (b) will always be the same and can be modified after it has been set in the message !
 
-            // Fix for https://issues.jboss.org/browse/JGRP-1598
+            // Fix for https://issues.redhat.com/browse/JGRP-1598
             byte[] data=new byte[len];
             System.arraycopy(b, off, data, 0, len);
             // m.setBuffer(b, off, len);

--- a/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
@@ -255,7 +255,7 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
             // this handles the case where a coord dies during a state transfer; prevents clients from hanging forever
             // Note this only takes a coordinator crash into account, a getState(target, timeout), where target is not
             // null is not handled ! (Usually we get the state from the coordinator)
-            // http://jira.jboss.com/jira/browse/JGRP-148
+            // https://issues.redhat.com/browse/JGRP-148
             if(waiting_for_state_response && old_coord != null && !members.contains(old_coord))
                 send_up_exception=true;
         }
@@ -357,7 +357,7 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
         try {
             if(isDigestNeeded()) {
                 punchHoleFor(sender);
-                closeBarrierAndSuspendStable(); // fix for https://jira.jboss.org/jira/browse/JGRP-1013
+                closeBarrierAndSuspendStable(); // fix for https://issues.redhat.com/browse/JGRP-1013
                 if(digest != null)
                     down_prot.down(new Event(Event.OVERWRITE_DIGEST, digest)); // set the digest (e.g. in NAKACK)
             }

--- a/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
+++ b/src/org/jgroups/protocols/pbcast/STATE_TRANSFER.java
@@ -367,7 +367,7 @@ public class STATE_TRANSFER extends Protocol implements ProcessingQueue.Handler<
                       (state == null? "0" : Util.printBytes(state.length)), stop - start);
             StateTransferResult result=new StateTransferResult(state);
             up_prot.up(new Event(Event.GET_STATE_OK, result));
-            down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.jboss.org/browse/JGRP-1751
+            down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.redhat.com/browse/JGRP-1751
         }
         catch(Throwable t) {
             handleException(t);

--- a/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
@@ -270,7 +270,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
 
     protected void handleEOF(Address sender) {
         state_provider=null;
-        down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.jboss.org/browse/JGRP-1751
+        down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.redhat.com/browse/JGRP-1751
     }
 
     protected void handleException(Throwable exception) {
@@ -297,7 +297,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
         try {
             up_prot.up(new Event(Event.STATE_TRANSFER_INPUTSTREAM, in));
             up_prot.up(new Event(Event.STATE_TRANSFER_INPUTSTREAM_CLOSED, new StateTransferResult()));
-            down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.jboss.org/browse/JGRP-1751
+            down_prot.down(new Event(Event.GET_VIEW_FROM_COORD)); // https://issues.redhat.com/browse/JGRP-1751
         }
         catch(Throwable t) {
             handleException(t);

--- a/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
+++ b/src/org/jgroups/protocols/pbcast/StreamingStateTransfer.java
@@ -464,7 +464,7 @@ public abstract class StreamingStateTransfer extends Protocol implements Process
         if(isDigestNeeded()) {
             try {
                 punchHoleFor(provider);
-                closeBarrierAndSuspendStable(); // fix for https://jira.jboss.org/jira/browse/JGRP-1013
+                closeBarrierAndSuspendStable(); // fix for https://issues.redhat.com/browse/JGRP-1013
                 down_prot.down(new Event(Event.OVERWRITE_DIGEST, hdr.getDigest())); // set the digest (e.g. in NAKACK)
             }
             catch(Throwable t) {

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 /**
  *
  * Design: ./doc/design/RELAY2.txt and at https://github.com/belaban/JGroups/blob/master/doc/design/RELAY2.txt.<p/>
- * JIRA: https://issues.jboss.org/browse/JGRP-1433
+ * JIRA: https://issues.redhat.com/browse/JGRP-1433
  * @author Bela Ban
  * @since 3.2
  */
@@ -338,7 +338,7 @@ public class RELAY2 extends Protocol {
 
         if(!site_config.getForwards().isEmpty())
             log.warn(local_addr + ": forwarding routes are currently not supported and will be ignored. This will change " +
-                       "with hierarchical routing (https://issues.jboss.org/browse/JGRP-1506)");
+                       "with hierarchical routing (https://issues.redhat.com/browse/JGRP-1506)");
 
         if(enable_address_tagging) {
             JChannel ch=getProtocolStack().getChannel();
@@ -659,7 +659,7 @@ public class RELAY2 extends Protocol {
             Message copy=copy(msg).setDest(null).setSrc(null).putHeader(id, hdr);
             down_prot.down(copy); // multicast locally
 
-            // Don't forward: https://issues.jboss.org/browse/JGRP-1519
+            // Don't forward: https://issues.redhat.com/browse/JGRP-1519
             // sendToBridges(msg.getSrc(), buf, from_site, site_id);  // forward to all bridges except self and from
         }
     }

--- a/src/org/jgroups/protocols/relay/SiteMasterPicker.java
+++ b/src/org/jgroups/protocols/relay/SiteMasterPicker.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Allows an implementation to pick a {@link SiteMaster} or a {@link Route} from a list (if multiple site masters are
  * enabled). An implementation could for example always pick the same site master (or route) for messages from a given
- * sender (sticky site master policy, see https://issues.jboss.org/browse/JGRP-2112).<p/>
+ * sender (sticky site master policy, see https://issues.redhat.com/browse/JGRP-2112).<p/>
  * The default implementation picks a random site master for every message to be relayed, even if they have the same
  * original sender.<p/>
  * If only one site master is configured, then {@link #pickSiteMaster(List,Address)} (List,Address)} or

--- a/src/org/jgroups/stack/Configurator.java
+++ b/src/org/jgroups/stack/Configurator.java
@@ -63,7 +63,7 @@ public class Configurator {
      */
     public static Protocol setupProtocolStack(List<ProtocolConfiguration> protocol_configs, ProtocolStack st) throws Exception {
         List<Protocol> protocols=createProtocolsAndInitializeAttrs(protocol_configs, st);
-        // Fixes NPE with concurrent channel creation when using a shared stack (https://issues.jboss.org/browse/JGRP-1488)
+        // Fixes NPE with concurrent channel creation when using a shared stack (https://issues.redhat.com/browse/JGRP-1488)
         Protocol top_protocol=protocols.get(protocols.size() - 1);
         top_protocol.setUpProtocol(st);
         return connectProtocols(protocols);
@@ -106,7 +106,7 @@ public class Configurator {
             return null;
 
         // Determine how to resolve addresses that are set (e.g.) via symbolic names, by the type of bind_addr in the
-        // transport. The logic below is described in https://issues.jboss.org/browse/JGRP-2343
+        // transport. The logic below is described in https://issues.redhat.com/browse/JGRP-2343
         StackType ip_version=Util.getIpStackType();
         Protocol transport=protocols.get(0);
         if(transport instanceof TP) {

--- a/src/org/jgroups/stack/DiagnosticsHandler.java
+++ b/src/org/jgroups/stack/DiagnosticsHandler.java
@@ -357,7 +357,7 @@ public class DiagnosticsHandler extends ReceiverAdapter implements Closeable {
                     }
                 }
             }
-            catch(Exception e) { // also catches NPE in getInterfaceAddresses() (https://issues.jboss.org/browse/JGRP-1845)
+            catch(Exception e) { // also catches NPE in getInterfaceAddresses() (https://issues.redhat.com/browse/JGRP-1845)
                 log.warn("failed to join " + group_addr + " on " + i.getName() + ": " + e);
             }
         }

--- a/src/org/jgroups/stack/DiagnosticsHandler.java
+++ b/src/org/jgroups/stack/DiagnosticsHandler.java
@@ -224,7 +224,7 @@ public class DiagnosticsHandler extends ReceiverAdapter implements Closeable {
             udp_ucast_sock=socket_factory.createDatagramSocket("jgroups.tp.diag.udp_ucast_sock");
 
         if(udp_mcast_sock == null || udp_mcast_sock.isClosed()) {
-            // https://jira.jboss.org/jira/browse/JGRP-777 - this doesn't work on MacOS, and we don't have
+            // https://issues.redhat.com/browse/JGRP-777 - this doesn't work on MacOS, and we don't have
             // cross talking on Windows anyway, so we just do it for Linux. (How about Solaris ?)
 
             // If possible, the MulticastSocket(SocketAddress) ctor is used which binds to diagnostics_addr:diagnostics_port.

--- a/src/org/jgroups/stack/LargestWinningPolicy.java
+++ b/src/org/jgroups/stack/LargestWinningPolicy.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * Policy which picks the new coordinator in a merge from the largest subview.
- * JIRA: https://issues.jboss.org/browse/JGRP-1976
+ * JIRA: https://issues.redhat.com/browse/JGRP-1976
  * @author Osamu Nagano
  * @since  3.6.7
  */

--- a/src/org/jgroups/util/MaxOneThreadPerSender.java
+++ b/src/org/jgroups/util/MaxOneThreadPerSender.java
@@ -16,7 +16,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * {@link org.jgroups.stack.MessageProcessingPolicy} which processes <em>regular</em> messages and message batches by
  * assigning a max of 1 thread per message from the same sender. So if we have senders A, B, C and D, we'll have no more
  * than 4 threads handling regular unicasts and 4 threads handling regular multicasts.<p>
- * See <a href="https://issues.jboss.org/browse/JGRP-2143">JGRP-2143</a> for details.
+ * See <a href="https://issues.redhat.com/browse/JGRP-2143">JGRP-2143</a> for details.
  * @author Bela Ban
  * @since  4.0
  */

--- a/src/org/jgroups/util/NonBlockingCredit.java
+++ b/src/org/jgroups/util/NonBlockingCredit.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
  * Non-blocking credit for a unicast destination.<br/>
  * Instead of blocking when insufficient credits are available for sending a message, this class <em>queues</em> the
  * message and sends it at a later time when enough credits have been received to send it.<br/>
- * JIRA: https://issues.jboss.org/browse/JGRP-2172
+ * JIRA: https://issues.redhat.com/browse/JGRP-2172
  * @author Bela Ban
  * @since  4.0.4
  */

--- a/src/org/jgroups/util/RequestTable.java
+++ b/src/org/jgroups/util/RequestTable.java
@@ -13,7 +13,7 @@ import java.util.stream.LongStream;
  * Could be used for example in {@link org.jgroups.blocks.RequestCorrelator}. Grows and shrinks when needed.
  * Addition is always at the end, yielding monotonically increasing seqnos. Removal is done by nulling the element(s)
  * between low and high and advancing the low pointer whenever possible.<p/>
- * See <a href="https://issues.jboss.org/browse/JGRP-1982">JGRP-1982</a> for details.
+ * See <a href="https://issues.redhat.com/browse/JGRP-1982">JGRP-1982</a> for details.
  * @author Bela Ban
  * @since  3.6.7
  */

--- a/src/org/jgroups/util/Responses.java
+++ b/src/org/jgroups/util/Responses.java
@@ -68,7 +68,7 @@ public class Responses implements Iterable<PingData> {
         boolean is_coord_rsp=rsp.isCoord(), changed=false;
         lock.lock();
         try {
-            // https://jira.jboss.org/jira/browse/JGRP-1179
+            // https://issues.redhat.com/browse/JGRP-1179
             int ind=find(rsp);
             if(ind == -1) { // new addition
                 add(rsp);

--- a/src/org/jgroups/util/TimeScheduler3.java
+++ b/src/org/jgroups/util/TimeScheduler3.java
@@ -183,7 +183,7 @@ public class TimeScheduler3 implements TimeScheduler, Runnable {
             }
         }
 
-        // clears the threads list (https://issues.jboss.org/browse/JGRP-1971)
+        // clears the threads list (https://issues.redhat.com/browse/JGRP-1971)
         if(timer_thread_factory instanceof LazyThreadFactory)
             ((LazyThreadFactory)timer_thread_factory).destroy();
     }

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -4225,7 +4225,7 @@ public class Util {
         else
             bind_addr=getAddress(bind_intf, AddressScope.NON_LOOPBACK, ip_version);
 
-        //http://jira.jboss.org/jira/browse/JGRP-739
+        //https://issues.redhat.com/browse/JGRP-739
         //check all bind_address against NetworkInterface.getByInetAddress() to see if it exists on the machine
         //in some Linux setups NetworkInterface.getByInetAddress(InetAddress.getLocalHost()) returns null, so skip
         //the check in that case

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -3383,7 +3383,7 @@ public class Util {
                 Method[] m = superclass.getDeclaredMethods();
                 Collections.addAll(methods, m);
 
-                // find the default methods of all interfaces (https://issues.jboss.org/browse/JGRP-2247)
+                // find the default methods of all interfaces (https://issues.redhat.com/browse/JGRP-2247)
                 Class<?>[] interfaces=superclass.getInterfaces();
                 if(interfaces != null) {
                     for(Class<?> cl: interfaces) {

--- a/src/org/jgroups/util/XMLSchemaGenerator.java
+++ b/src/org/jgroups/util/XMLSchemaGenerator.java
@@ -29,7 +29,7 @@ import java.util.*;
 /**
  * Iterates over all concrete Protocol classes and creates XML schema used for validation of configuration files.
  * 
- * https://jira.jboss.org/jira/browse/JGRP-448
+ * https://issues.redhat.com/browse/JGRP-448
  * 
  * @author Vladimir Blagojevic
  * @author Bela Ban

--- a/tests/byteman/org/jgroups/tests/byteman/ASYM_ENCRYPT_BlockTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/ASYM_ENCRYPT_BlockTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * Tests https://issues.jboss.org/browse/JGRP-2131
+ * Tests https://issues.redhat.com/browse/JGRP-2131
  * @author Bela Ban
  * @since  3.6.12, 4.0.0
  */

--- a/tests/byteman/org/jgroups/tests/byteman/BecomeServerTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/BecomeServerTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 /**
  * Tests the behavior of queueing messages (in NAKACK{2}) before becoming a server
- * (https://issues.jboss.org/browse/JGRP-1522)
+ * (https://issues.redhat.com/browse/JGRP-1522)
  * @author Bela Ban
  * @since 3.2
  */
@@ -27,7 +27,7 @@ public class BecomeServerTest extends BMNGRunner {
     /**
      * When we flush the server queue and one or more of the delivered messages triggers a response (in the same thread),
      * we need to make sure the channel is connected, or else the JOIN will fail as the exception happens on the same
-     * thread. Note that the suggested fix on JGRP-1522 will solve this. Issue: https://issues.jboss.org/browse/JGRP-1522
+     * thread. Note that the suggested fix on JGRP-1522 will solve this. Issue: https://issues.redhat.com/browse/JGRP-1522
      */
     @BMScript(dir="scripts/BecomeServerTest", value="testSendingOfMsgsOnUnconnectedChannel")
     public void testSendingOfMsgsOnUnconnectedChannel() throws Exception {

--- a/tests/byteman/org/jgroups/tests/byteman/MessageBeforeConnectedTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/MessageBeforeConnectedTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Tests the behavior of receiving a unicast message before being connected and sending a response which will
- * throw an exception as the channel is not connected yet (https://issues.jboss.org/browse/JGRP-1545).
+ * throw an exception as the channel is not connected yet (https://issues.redhat.com/browse/JGRP-1545).
  * @author Bela Ban
  * @since 3.3
  */
@@ -51,7 +51,7 @@ public class MessageBeforeConnectedTest extends BMNGRunner {
     /**
      * When we connect to a channel, but before the state is changed to 'connected', we send a message which will
      * trigger an exception.
-     * Issue: https://issues.jboss.org/browse/JGRP-1545
+     * Issue: https://issues.redhat.com/browse/JGRP-1545
      */
     @BMScript(dir="scripts/MessageBeforeConnectedTest", value="testSendingOfMsgsOnUnconnectedChannel")
     public void testSendingOfMsgsOnUnconnectedChannel() throws Throwable {

--- a/tests/byteman/org/jgroups/tests/byteman/SequencerFailoverTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/SequencerFailoverTest.java
@@ -63,7 +63,7 @@ public class SequencerFailoverTest extends BMNGRunner {
     /**
      * Tests that resending of messages in the forward-queue on a view change and sending of new messages at the
      * same time doesn't lead to incorrect ordering (forward-queue messages need to be delivered before new msgs).
-     * https://issues.jboss.org/browse/JGRP-1449
+     * https://issues.redhat.com/browse/JGRP-1449
      */
     @BMScript(dir="scripts/SequencerFailoverTest", value="testResendingVersusNewMessages")
     public void testResendingVersusNewMessages() throws Exception {

--- a/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
@@ -131,7 +131,7 @@ public class ServerTest extends BMNGRunner {
     /**
      * Tests multiple threads sending a message to the same (unconnected) server; the first thread should establish
      * the connection to the server and the other threads should be blocked until the connection has been created.<br/>
-     * JIRA: https://issues.jboss.org/browse/JGRP-2271
+     * JIRA: https://issues.redhat.com/browse/JGRP-2271
      */
     // @Test(invocationCount=50,dataProvider="configProvider")
     public void testConcurrentConnect2(BaseServer first, BaseServer second) throws Exception {

--- a/tests/junit-functional/org/jgroups/blocks/GroupRequestTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/GroupRequestTest.java
@@ -142,7 +142,7 @@ public class GroupRequestTest {
     /**
      * Tests reception of 3 null values, which are all rejected by the NonNullFilter. However, isDone() returns true
      * because we received responses for all 3 requests, even though all of them were rejected. If we continued here,
-     * we'd block until we run into the timeout. See https://issues.jboss.org/browse/JGRP-1330 for details.
+     * we'd block until we run into the timeout. See https://issues.redhat.com/browse/JGRP-1330 for details.
      */
     public void testAllNullResponsesWithFilter() {
         dests.add(c);
@@ -173,7 +173,7 @@ public class GroupRequestTest {
 
     /**
      * Verifies that a received *and* suspected flag on a Rsp counts only once, to prevent premature termination of
-     * a blocking RPC. https://issues.jboss.org/browse/JGRP-1505
+     * a blocking RPC. https://issues.redhat.com/browse/JGRP-1505
      */
     public void testResponsesComplete() {
         GroupRequest<Integer> req=new GroupRequest<>(null, Arrays.asList(a,b,c), RequestOptions.SYNC());

--- a/tests/junit-functional/org/jgroups/blocks/LockServiceDuplicateLockTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/LockServiceDuplicateLockTest.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 /**
  * Tests the lock service under partitions: when members in different partitions hold the same lock, after a merge, all
  * but one lock holder will get notified that their locks have been revoked.
- * See https://issues.jboss.org/browse/JGRP-2249 for details.
+ * See https://issues.redhat.com/browse/JGRP-2249 for details.
  * @author Bela Ban
  * @since  4.0.13
  */

--- a/tests/junit-functional/org/jgroups/blocks/LockServiceTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/LockServiceTest.java
@@ -287,7 +287,7 @@ public class LockServiceTest {
         assert num_acquired == 1 : "expected 1 but got " + num_acquired;
     }
 
-    /** Tests locking by T1 and unlocking by T2 (https://issues.jboss.org/browse/JGRP-1886) */
+    /** Tests locking by T1 and unlocking by T2 (https://issues.redhat.com/browse/JGRP-1886) */
     public void testLockUnlockByDiffentThreads(Class<? extends Locking> locking_class) throws Exception {
         init(locking_class);
         CyclicBarrier barrier=null;

--- a/tests/junit-functional/org/jgroups/blocks/LockService_JGRP_2234_Test.java
+++ b/tests/junit-functional/org/jgroups/blocks/LockService_JGRP_2234_Test.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Stream;
 
-/** Tests https://issues.jboss.org/browse/JGRP-2234 with {@link LockService}
+/** Tests https://issues.redhat.com/browse/JGRP-2234 with {@link LockService}
  * @author Bela Ban
  */
 @Test(groups={Global.FUNCTIONAL,Global.EAP_EXCLUDED},singleThreaded=true,dataProvider="createLockingProtocol")

--- a/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
@@ -588,7 +588,7 @@ public class RpcDispatcherTest {
     
 
     /**
-     * Tests a method call to {A,B,C} where C left *before* the call. http://jira.jboss.com/jira/browse/JGRP-620
+     * Tests a method call to {A,B,C} where C left *before* the call. https://issues.redhat.com/browse/JGRP-620
      */
     public void testMethodInvocationToNonExistingMembers() throws Exception {
         final int timeout = 5 * 1000 ;

--- a/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
+++ b/tests/junit-functional/org/jgroups/blocks/RpcDispatcherTest.java
@@ -466,7 +466,7 @@ public class RpcDispatcherTest {
 
     /**
      * Invoke a call which sleeps for 5s 5 times. Since the sleep should be done in parallel (OOB msgs), all 5 futures
-     * should be done in roughly 5s. JIRA: https://issues.jboss.org/browse/JGRP-2039
+     * should be done in roughly 5s. JIRA: https://issues.redhat.com/browse/JGRP-2039
      */
     public void testMultipleFutures() throws Exception {
         _testMultipleUnicastFuturesToDest(null); // send to all
@@ -483,7 +483,7 @@ public class RpcDispatcherTest {
 
     /**
      * Invoke a call which sleeps for 5s 5 times. Since the sleep should be done in parallel (OOB msgs), all 5 futures
-     * should be done in roughly 5s. JIRA: https://issues.jboss.org/browse/JGRP-2039
+     * should be done in roughly 5s. JIRA: https://issues.redhat.com/browse/JGRP-2039
      */
     protected void _testMultipleUnicastFuturesToDest(Address dest) throws Exception {
         final int                   NUM_CALLS=5, MAX_SLEEP=8000; // should be done in ~5s, make it 8s to be safe

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 /**
  * Tests graceful leaving of the coordinator and second-in-line in a 10 node cluster with ASYM_ENCRYPT configured.
  * <br/>
- * Reproducer for https://issues.jboss.org/browse/JGRP-2297
+ * Reproducer for https://issues.redhat.com/browse/JGRP-2297
  * @author Bela Ban
  * @since  4.0.12
  */

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestKeyExchange.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_LeaveTestKeyExchange.java
@@ -3,7 +3,7 @@ package org.jgroups.protocols;
 /**
  * Tests graceful leaving of the coordinator and second-in-line in a 10 node cluster with ASYM_ENCRYPT configured.
  * <br/>
- * Reproducer for https://issues.jboss.org/browse/JGRP-2297
+ * Reproducer for https://issues.redhat.com/browse/JGRP-2297
  * @author Bela Ban
  * @since  4.0.12
  */

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_Test.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 import static org.jgroups.util.Util.shutdown;
 
 /**
- * Tests use cases for {@link ASYM_ENCRYPT} described in https://issues.jboss.org/browse/JGRP-2021.
+ * Tests use cases for {@link ASYM_ENCRYPT} described in https://issues.redhat.com/browse/JGRP-2021.
  * @author Bela Ban
  * @since  4.0
  */
@@ -171,7 +171,7 @@ public class ASYM_ENCRYPT_Test extends EncryptTest {
     /**
      * Tests {A,B,C} with A crashing. B installs a new view with a freshly created secret key SK. However, C won't be
      * able to decrypt the new view as it doesn't have SK.<br/>
-     * https://issues.jboss.org/browse/JGRP-2203
+     * https://issues.redhat.com/browse/JGRP-2203
      */
     public void testCrashOfCoord() throws Exception {
         Address crashed_coord=a.getAddress();

--- a/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestKeyExchange.java
+++ b/tests/junit-functional/org/jgroups/protocols/ASYM_ENCRYPT_TestKeyExchange.java
@@ -5,7 +5,7 @@ import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 
 /**
- * Tests use cases for {@link ASYM_ENCRYPT} described in https://issues.jboss.org/browse/JGRP-2021.
+ * Tests use cases for {@link ASYM_ENCRYPT} described in https://issues.redhat.com/browse/JGRP-2021.
  * @author Bela Ban
  * @since  4.0
  */

--- a/tests/junit-functional/org/jgroups/protocols/EncryptTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/EncryptTest.java
@@ -194,7 +194,7 @@ public abstract class EncryptTest {
     /**
      * Tests the scenario where the non-member R captures a message from some cluster member in {A,B,C}, then
      * increments the NAKACK2 seqno and resends that message. The message must not be received by {A,B,C};
-     * it should be discarded. see https://issues.jboss.org/browse/JGRP-2273
+     * it should be discarded. see https://issues.redhat.com/browse/JGRP-2273
      */
     public void testCapturingOfMessageByNonMemberAndResending() throws Exception {
 

--- a/tests/junit-functional/org/jgroups/protocols/FILE_PING_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/FILE_PING_Test.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Tests partition and merge of {@link FILE_PING} (https://issues.jboss.org/browse/JGRP-2288)
+ * Tests partition and merge of {@link FILE_PING} (https://issues.redhat.com/browse/JGRP-2288)
  * @author Bela Ban
  * @since  4.0.17
  */

--- a/tests/junit-functional/org/jgroups/protocols/FlowControlUnitTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/FlowControlUnitTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.LongAdder;
 import static org.jgroups.Message.TransientFlag.DONT_LOOPBACK;
 
 /**
- * Tests blocking in UFC / MFC (https://issues.jboss.org/browse/JGRP-1665)
+ * Tests blocking in UFC / MFC (https://issues.redhat.com/browse/JGRP-1665)
  * @author Bela Ban
  * @since  3.4
  */

--- a/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/GMS_MergeTest.java
@@ -270,7 +270,7 @@ public class GMS_MergeTest {
      * <li>B: {B, C}
      * <li>C: {B, C}
      * </ol>
-     * JIRA: https://jira.jboss.org/jira/browse/JGRP-1031
+     * JIRA: https://issues.redhat.com/browse/JGRP-1031
      * @throws Exception
      */
     static void _testMergeAsymmetricPartitions(boolean use_flush_props, String cluster_name) throws Exception {
@@ -378,7 +378,7 @@ public class GMS_MergeTest {
      * <li>A: {A,B}
      * <li>B: {B}
      * </ol>
-     * JIRA: https://jira.jboss.org/jira/browse/JGRP-1031
+     * JIRA: https://issues.redhat.com/browse/JGRP-1031
      */
     static void _testMergeAsymmetricPartitions2(boolean use_flush_props, String cluster_name) throws Exception {
         JChannel[] channels=null;

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK2_RetransmissionTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * Tests thata there aren't unnecessary retransmissions caused by the retransmit task in NAKACK<p/>
- * https://issues.jboss.org/browse/JGRP-1539
+ * https://issues.redhat.com/browse/JGRP-1539
  * @author Bela Ban
  * @since 3.3
  */

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_RetransmitTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_RetransmitTest.java
@@ -19,7 +19,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * Tests large retransmissions (https://issues.jboss.org/browse/JGRP-1868). Multicast equivalent to
+ * Tests large retransmissions (https://issues.redhat.com/browse/JGRP-1868). Multicast equivalent to
  * {@link org.jgroups.protocols.UNICAST_RetransmitTest}
  * @author Bela Ban
  * @since  3.6
@@ -67,7 +67,7 @@ public class NAKACK_RetransmitTest {
      * TP.max_bundle_size, leading to endless retransmissions. With JGRP-1868 resolved, the receiver should get
      * all messages.
      * <p/>
-     * https://issues.jboss.org/browse/JGRP-1868
+     * https://issues.redhat.com/browse/JGRP-1868
      */
     public void testLargeRetransmission() throws Exception {
         a.setReceiver(new MyReceiver());

--- a/tests/junit-functional/org/jgroups/protocols/NAKACK_SET_DIGEST_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/NAKACK_SET_DIGEST_Test.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Tests setting of digest NAKACK.down(SET_DIGEST), JIRA issue is https://jira.jboss.org/jira/browse/JGRP-1060
+ * Tests setting of digest NAKACK.down(SET_DIGEST), JIRA issue is https://issues.redhat.com/browse/JGRP-1060
  * @author Bela Ban
  */
 @Test(groups=Global.FUNCTIONAL)
@@ -71,7 +71,7 @@ public class NAKACK_SET_DIGEST_Test {
         nak.down(new Event(Event.SET_DIGEST, d1));
         digest=(Digest)nak.down(Event.GET_DIGEST_EVT);
         System.out.println("digest = " + digest);
-        assert digest.capacity() == 3; // https://jira.jboss.org/jira/browse/JGRP-1060
+        assert digest.capacity() == 3; // https://issues.redhat.com/browse/JGRP-1060
         assert digest.containsAll(a, b, c);
     }
 

--- a/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/SYM_ENCRYPT_Test.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Tests use cases for {@link SYM_ENCRYPT} described in https://issues.jboss.org/browse/JGRP-2021.
+ * Tests use cases for {@link SYM_ENCRYPT} described in https://issues.redhat.com/browse/JGRP-2021.
  * Make sure you create the keystore before running this test (ant make-keystore).
  * @author Bela Ban
  * @since  4.0

--- a/tests/junit-functional/org/jgroups/protocols/TCPPING_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/TCPPING_Test.java
@@ -22,7 +22,7 @@ public class TCPPING_Test {
 
     @AfterMethod protected void destroy() {Util.close(ch);}
 
-    /** Tests https://issues.jboss.org/browse/JGRP-2168 */
+    /** Tests https://issues.redhat.com/browse/JGRP-2168 */
     public void testSettingInitialHostsProgrammatically() throws Exception {
         TCP transport=new TCP();
         transport.setBindAddress(InetAddress.getLoopbackAddress());

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_ConnectionTests.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_ConnectionTests.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 
 /**
  * Tests unilateral closings of UNICAST connections. The test scenarios are described in doc/design/UNICAST2.txt.
- * Some of the tests may fail occasionally until https://issues.jboss.org/browse/JGRP-1594 is fixed
+ * Some of the tests may fail occasionally until https://issues.redhat.com/browse/JGRP-1594 is fixed
  * @author Bela Ban
  */
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
@@ -155,7 +155,7 @@ public class UNICAST_ConnectionTests {
         sendAndCheck(a, b_addr, 10, r2);
     }
 
-    /** Tests concurrent reception of multiple messages with a different conn_id (https://issues.jboss.org/browse/JGRP-1347) */
+    /** Tests concurrent reception of multiple messages with a different conn_id (https://issues.redhat.com/browse/JGRP-1347) */
     @Test(dataProvider="configProvider")
     public void testMultipleConcurrentResets(Class<? extends UNICAST3> unicast) throws Exception {
         setup(unicast);

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_DropFirstAndLastTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_DropFirstAndLastTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Tests UNICAST2. Created to test the last-message-dropped problem, see https://issues.jboss.org/browse/JGRP-1548.
+ * Tests UNICAST2. Created to test the last-message-dropped problem, see https://issues.redhat.com/browse/JGRP-1548.
  * @author Bela Ban
  * @since  3.3
  */
@@ -47,7 +47,7 @@ public class UNICAST_DropFirstAndLastTest {
 
     /**
      * A sends unicast messages 1-5 to B, but we drop message 5. The code in
-     * https://issues.jboss.org/browse/JGRP-1548 now needs to make sure message 5 is retransmitted to B
+     * https://issues.redhat.com/browse/JGRP-1548 now needs to make sure message 5 is retransmitted to B
      * within a short time period, and we don't have to rely on the stable task to kick in.
      */
     @Test(dataProvider="configProvider")
@@ -69,7 +69,7 @@ public class UNICAST_DropFirstAndLastTest {
 
     /**
      * A sends unicast message 1 to B, but we drop message 1. The code in
-     * https://issues.jboss.org/browse/JGRP-1563 now needs to make sure message 1 is retransmitted to B
+     * https://issues.redhat.com/browse/JGRP-1563 now needs to make sure message 1 is retransmitted to B
      * within a short time period, and we don't have to rely on the stable task to kick in.
      */
     @Test(dataProvider="configProvider")

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_DroppedAckTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_DroppedAckTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 /**
  * Tests that unicast messages are not endlessly retransmitted when an ACK is dropped
- * (https://issues.jboss.org/browse/JGRP-1578)
+ * (https://issues.redhat.com/browse/JGRP-1578)
  * @author Bela Ban
  * @since  3.3
  */

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Tests the UNICAST3 protocol for OOB msgs, tests http://jira.jboss.com/jira/browse/JGRP-377 and
+ * Tests the UNICAST3 protocol for OOB msgs, tests https://issues.redhat.com/browse/JGRP-377 and
  * https://issues.jboss.org/browse/JGRP-2327
  * @author Bela Ban
  */

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_OOB_Test.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 /**
  * Tests the UNICAST3 protocol for OOB msgs, tests https://issues.redhat.com/browse/JGRP-377 and
- * https://issues.jboss.org/browse/JGRP-2327
+ * https://issues.redhat.com/browse/JGRP-2327
  * @author Bela Ban
  */
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
@@ -51,7 +51,7 @@ public class UNICAST_OOB_Test {
 
     /**
      Tests the case where B sends B1 and B2, but A receives B2 first (discards it) and requests retransmission of B1.
-     JIRA: https://issues.jboss.org/browse/JGRP-2327
+     JIRA: https://issues.redhat.com/browse/JGRP-2327
      */
     public void testSecondMessageReceivedFirstRegular() throws Exception {
         _testSecondMessageReceivedFirst(false, false);

--- a/tests/junit-functional/org/jgroups/protocols/UNICAST_RetransmitTest.java
+++ b/tests/junit-functional/org/jgroups/protocols/UNICAST_RetransmitTest.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Tests large retransmissions (https://issues.jboss.org/browse/JGRP-1868)
+ * Tests large retransmissions (https://issues.redhat.com/browse/JGRP-1868)
  * @author Bela Ban
  * @since  3.6
  */
@@ -42,7 +42,7 @@ public class UNICAST_RetransmitTest {
      * TP.max_bundle_size, leading to endless retransmissions. With JGRP-1868 resolved, the receiver should get
      * all messages.
      * <p/>
-     * https://issues.jboss.org/browse/JGRP-1868
+     * https://issues.redhat.com/browse/JGRP-1868
      */
     public void testLargeRetransmission() throws Exception {
         MyReceiver receiver=new MyReceiver();

--- a/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Tests https://issues.jboss.org/browse/JGRP-1429
+ * Tests https://issues.redhat.com/browse/JGRP-1429
  * @author Bela Ban
  * @since 3.1
  */

--- a/tests/junit-functional/org/jgroups/tests/BaseLeaveTest.java
+++ b/tests/junit-functional/org/jgroups/tests/BaseLeaveTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 /**
  * Tests graceful leaves of multiple members, especially coord and next-in-line.
  * Nodes are leaving gracefully so no merging is expected.<br/>
- * Reproducer for https://issues.jboss.org/browse/JGRP-2293.
+ * Reproducer for https://issues.redhat.com/browse/JGRP-2293.
  *
  * @author Radoslav Husar
  * @author Bela Ban

--- a/tests/junit-functional/org/jgroups/tests/BuffersTest.java
+++ b/tests/junit-functional/org/jgroups/tests/BuffersTest.java
@@ -497,7 +497,7 @@ public class BuffersTest {
         assert bufs.limit() == 4;
 
         // copy the buffers which have not yet been written so that we can reuse buffers (not needed if buffers are already copies)
-        bufs.copy(); // https://issues.jboss.org/browse/JGRP-1991
+        bufs.copy(); // https://issues.redhat.com/browse/JGRP-1991
 
         makeSpace(bufs);
         assert bufs.position() == 0;

--- a/tests/junit-functional/org/jgroups/tests/ClusterSplitLockTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ClusterSplitLockTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.AssertJUnit.*;
 
-/** Tests https://issues.jboss.org/browse/JGRP-2234 */
+/** Tests https://issues.redhat.com/browse/JGRP-2234 */
 @Test(groups = {Global.FUNCTIONAL, Global.EAP_EXCLUDED}, timeOut = 60000, dataProvider="createLockingProtocol")
 public class ClusterSplitLockTest {
     private static final int        MEMBERS = 3;

--- a/tests/junit-functional/org/jgroups/tests/ConfiguratorTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ConfiguratorTest.java
@@ -131,7 +131,7 @@ public class ConfiguratorTest {
 
 
 
-    /** Tests that vars are substituted correctly when creating a channel programmatically (https://issues.jboss.org/browse/JGRP-1908) */
+    /** Tests that vars are substituted correctly when creating a channel programmatically (https://issues.redhat.com/browse/JGRP-1908) */
     public void testProgrammaticCreationAndVariableSubstitution() throws Exception {
         try {
             System.setProperty("person.name", "Bela");

--- a/tests/junit-functional/org/jgroups/tests/DeltaViewTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DeltaViewTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 
 /**
- * Tests DeltaViews (https://issues.jboss.org/browse/JGRP-2159)
+ * Tests DeltaViews (https://issues.redhat.com/browse/JGRP-2159)
  * @author Bela Ban
  * @since  4.0.1
  */

--- a/tests/junit-functional/org/jgroups/tests/DiscoveryTest.java
+++ b/tests/junit-functional/org/jgroups/tests/DiscoveryTest.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 
 /**
- * Tests a leak in Discovery.ping_responses (https://issues.jboss.org/browse/JGRP-1983)
+ * Tests a leak in Discovery.ping_responses (https://issues.redhat.com/browse/JGRP-1983)
  * @author Bela Ban
  * @since  3.6.7
  */
@@ -41,7 +41,7 @@ public class DiscoveryTest {
     @AfterMethod protected void destroy() {Util.close(d, c, b, a);}
 
 
-    /** Makes sure the leak caused by https://issues.jboss.org/browse/JGRP-1983 is not present anymore */
+    /** Makes sure the leak caused by https://issues.redhat.com/browse/JGRP-1983 is not present anymore */
     public void testLeakFromCoord() throws Exception {
         testLeak(a);
     }

--- a/tests/junit-functional/org/jgroups/tests/FalseSuspicionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/FalseSuspicionTest.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 
 /**
- * Tests false suspicions and UNSUSPECT events (https://issues.jboss.org/browse/JGRP-1922)
+ * Tests false suspicions and UNSUSPECT events (https://issues.redhat.com/browse/JGRP-1922)
  * @author Bela Ban
  * @since  3.6.4
  */

--- a/tests/junit-functional/org/jgroups/tests/FragTest.java
+++ b/tests/junit-functional/org/jgroups/tests/FragTest.java
@@ -105,7 +105,7 @@ public class FragTest {
     /**
      * Tests potential ordering violation by sending small, unfragmented messages, followed by a large message
      * which generates 3 fragments, followed by a final small message. Verifies that the message assembled from the
-     * 3 fragments is in the right place and not at the end. JIRA=https://issues.jboss.org/browse/JGRP-1648
+     * 3 fragments is in the right place and not at the end. JIRA=https://issues.redhat.com/browse/JGRP-1648
      */
     public void testMessageOrdering(Class<? extends Fragmentation> frag_clazz) throws Exception {
         setup(frag_clazz);
@@ -132,7 +132,7 @@ public class FragTest {
         }
     }
 
-    /* Tests https://issues.jboss.org/browse/JGRP-1973 */
+    /* Tests https://issues.redhat.com/browse/JGRP-1973 */
     public void testFragCorruption(Class<? extends Fragmentation> frag_clazz) throws Exception {
         setup(frag_clazz);
         final String message="this message is supposed to get fragmented by A and defragmented by B";

--- a/tests/junit-functional/org/jgroups/tests/FrozenCoordinatorTest.java
+++ b/tests/junit-functional/org/jgroups/tests/FrozenCoordinatorTest.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 
 /**
  * Tests original coordinator not being marked as coord, and firstOfAllClients() failing
- * (https://issues.jboss.org/browse/JGRP-2262)
+ * (https://issues.redhat.com/browse/JGRP-2262)
  * @author Bela Ban
  * @since  4.0.12
  */

--- a/tests/junit-functional/org/jgroups/tests/HeadersResizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/HeadersResizeTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.jgroups.Message.Flag.OOB;
 
 /**
- * Tests unnecessary resizing of headers (https://issues.jboss.org/browse/JGRP-2120)
+ * Tests unnecessary resizing of headers (https://issues.redhat.com/browse/JGRP-2120)
  * @author Bela Ban
  * @since  4.0
  */

--- a/tests/junit-functional/org/jgroups/tests/JmxTest.java
+++ b/tests/junit-functional/org/jgroups/tests/JmxTest.java
@@ -93,7 +93,7 @@ public class JmxTest {
         assert (int)val == 0;
     }
 
-    /** Tests https://issues.jboss.org/browse/JGRP-2393 */
+    /** Tests https://issues.redhat.com/browse/JGRP-2393 */
     public void testDuplicateName() throws Exception {
         try(JChannel ch=new JChannel(Util.getTestStack()).name("A")) {
             JmxConfigurator.registerChannel(ch, server, "domain", "cluster", false);

--- a/tests/junit-functional/org/jgroups/tests/LockServiceConcurrencyTest.java
+++ b/tests/junit-functional/org/jgroups/tests/LockServiceConcurrencyTest.java
@@ -55,7 +55,7 @@ public class LockServiceConcurrencyTest {
         Util.close(b,a);
     }
 
-    /** Tests JIRA https://issues.jboss.org/browse/JGRP-1679 */
+    /** Tests JIRA https://issues.redhat.com/browse/JGRP-1679 */
     // @Test(invocationCount=100,dataProvider="createLockingProtocol")
     public void testConcurrentClientLocks(Class<? extends Locking> locking_class) throws Exception {
         init(locking_class);

--- a/tests/junit-functional/org/jgroups/tests/MergeTest4.java
+++ b/tests/junit-functional/org/jgroups/tests/MergeTest4.java
@@ -371,7 +371,7 @@ public class MergeTest4 {
         }
     }
 
-    /** Tests the scenario described by Karim in https://issues.jboss.org/browse/JGRP-1876 */
+    /** Tests the scenario described by Karim in https://issues.redhat.com/browse/JGRP-1876 */
     public void testJGRP_1876() throws Exception {
         e=createChannel("E", true);
         f=createChannel("F", true);
@@ -427,7 +427,7 @@ public class MergeTest4 {
     }
 
 
-    /** Tests the scenario described by Dan in https://issues.jboss.org/browse/JGRP-1876 */
+    /** Tests the scenario described by Dan in https://issues.redhat.com/browse/JGRP-1876 */
     public void testJGRP_1876_Dan() throws Exception {
         Util.close(d,c,b,a);
         s=createChannel("S", true);
@@ -478,7 +478,7 @@ public class MergeTest4 {
     }
 
 
-    /** Tests the scenario described by Dan in https://issues.jboss.org/browse/JGRP-1876; INFO messages are injected */
+    /** Tests the scenario described by Dan in https://issues.redhat.com/browse/JGRP-1876; INFO messages are injected */
     public void testJGRP_1876_Dan2() throws Exception {
         Util.close(d,c,b,a);
         s=createChannel("S", false);

--- a/tests/junit-functional/org/jgroups/tests/MergeTest5.java
+++ b/tests/junit-functional/org/jgroups/tests/MergeTest5.java
@@ -22,7 +22,7 @@ import static org.jgroups.util.Util.printViews;
 
 
 /**
- * Tests https://issues.jboss.org/browse/JGRP-2092:
+ * Tests https://issues.redhat.com/browse/JGRP-2092:
  */
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
 public class MergeTest5 {
@@ -39,7 +39,7 @@ public class MergeTest5 {
     @AfterMethod void tearDown() throws Exception {Util.close(a,b,c);}
 
     /**
-     * Tests https://issues.jboss.org/browse/JGRP-2092:
+     * Tests https://issues.redhat.com/browse/JGRP-2092:
      <pre>
      Host A view: B,A,C (where B should be coordinator)
      Host B view: C,A,B (where C should be coordinator)

--- a/tests/junit-functional/org/jgroups/tests/MergeTest6.java
+++ b/tests/junit-functional/org/jgroups/tests/MergeTest6.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 
 /**
- * Tests merging with a dead merge leader https://issues.jboss.org/browse/JGRP-2276:
+ * Tests merging with a dead merge leader https://issues.redhat.com/browse/JGRP-2276:
  */
 @Test(groups=Global.FUNCTIONAL,singleThreaded=true)
 public class MergeTest6 {

--- a/tests/junit-functional/org/jgroups/tests/MergerTest.java
+++ b/tests/junit-functional/org/jgroups/tests/MergerTest.java
@@ -166,7 +166,7 @@ public class MergerTest {
      * B: ACB
      * C: ACB
      * D: BACD
-     * Test case is https://issues.jboss.org/browse/JGRP-1451
+     * Test case is https://issues.redhat.com/browse/JGRP-1451
      */
     public void testOverlappingMerge4() {
         Map<Address,View> map=new HashMap<>();

--- a/tests/junit-functional/org/jgroups/tests/Relay2Test.java
+++ b/tests/junit-functional/org/jgroups/tests/Relay2Test.java
@@ -83,7 +83,7 @@ public class Relay2Test {
     
     /**
      * Tests that routes are correctly registered after a partition and a subsequent merge
-     * (https://issues.jboss.org/browse/JGRP-1524)
+     * (https://issues.redhat.com/browse/JGRP-1524)
      */
     public void testMissingRouteAfterMerge() throws Exception {
         a=createNode(LON, "A", LON_CLUSTER, null);
@@ -340,7 +340,7 @@ public class Relay2Test {
     /**
      * Cluster A,B,C in LON and X,Y,Z in SFO. A, B, X and Y are site masters (max_site_masters: 2).
      * Verifies that messages sent by C in the LON site are received in the correct order by all members of the SFO site
-     * despite using multiple site masters. JIRA: https://issues.jboss.org/browse/JGRP-2112
+     * despite using multiple site masters. JIRA: https://issues.redhat.com/browse/JGRP-2112
      */
     public void testSenderOrderWithMultipleSiteMasters() throws Exception {
         MyReceiver<Object> rx=new MyReceiver<>().rawMsgs(true).verbose(true),

--- a/tests/junit-functional/org/jgroups/tests/ServerUnitTest.java
+++ b/tests/junit-functional/org/jgroups/tests/ServerUnitTest.java
@@ -187,7 +187,7 @@ public class ServerUnitTest {
 
     /**
      * A connects to B and B connects to A at the same time. This test makes sure we only have <em>one</em> connection,
-     * not two, e.g. a spurious connection. Tests http://jira.jboss.com/jira/browse/JGRP-549.<p/>
+     * not two, e.g. a spurious connection. Tests https://issues.redhat.com/browse/JGRP-549.<p/>
      * Turned concurrent test into a simple sequential test. We're going to replace this code with NIO2 soon anyway...
      */
     public void testReuseOfConnection() throws Exception {

--- a/tests/junit-functional/org/jgroups/tests/SizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SizeTest.java
@@ -420,7 +420,7 @@ public class SizeTest {
     }
 
 
-    /** Tests a MergeView whose subgroups are *not* a subset of the members (https://issues.jboss.org/browse/JGRP-1707) */
+    /** Tests a MergeView whose subgroups are *not* a subset of the members (https://issues.redhat.com/browse/JGRP-1707) */
     public void testMergeViewWithNonMatchingSubgroups() throws Exception {
         Address[] mbrs=Util.createRandomAddresses(6);
         Address a=mbrs[0],b=mbrs[1],c=mbrs[2],d=mbrs[3],e=mbrs[4],f=mbrs[5];

--- a/tests/junit-functional/org/jgroups/tests/TableTest.java
+++ b/tests/junit-functional/org/jgroups/tests/TableTest.java
@@ -1522,7 +1522,7 @@ public class TableTest {
     }
 
     // Tests purge(40) followed by purge(20) - the second purge() should be ignored
-    // https://issues.jboss.org/browse/JGRP-1872
+    // https://issues.redhat.com/browse/JGRP-1872
     public void testPurgeLower() {
         Table<Integer> table=new Table<>(3, 10, 0);
         for(int i=1; i <= 30; i++)

--- a/tests/junit-functional/org/jgroups/tests/TcpServerTest.java
+++ b/tests/junit-functional/org/jgroups/tests/TcpServerTest.java
@@ -13,7 +13,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 
 /**
- * Tests https://issues.jboss.org/browse/JGRP-2350
+ * Tests https://issues.redhat.com/browse/JGRP-2350
  * @author Bela Ban
  * @since  4.1.1
  */

--- a/tests/junit/org/jgroups/tests/ConcurrentStartupTestWithState.java
+++ b/tests/junit/org/jgroups/tests/ConcurrentStartupTestWithState.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * Tests concurrent startup and message sending directly after joining. See doc/design/ConcurrentStartupTest.txt
  * for details. This will only work 100% correctly with FLUSH support.<br/>
- * [1] http://jira.jboss.com/jira/browse/JGRP-236
+ * [1] https://issues.redhat.com/browse/JGRP-236
  * @author bela
  */
 

--- a/tests/junit/org/jgroups/tests/FlushTest.java
+++ b/tests/junit/org/jgroups/tests/FlushTest.java
@@ -46,7 +46,7 @@ public class FlushTest {
         checkEventStateTransferSequence(receivers[0]);
     }
 
-    /** Tests issue #1 in http://jira.jboss.com/jira/browse/JGRP-335 */
+    /** Tests issue #1 in https://issues.redhat.com/browse/JGRP-335 */
     public void testJoinFollowedByUnicast() throws Exception {
         JChannel a=null, b=null;
         try {
@@ -70,7 +70,7 @@ public class FlushTest {
     }
 
     /**
-     * Tests issue #2 in http://jira.jboss.com/jira/browse/JGRP-335
+     * Tests issue #2 in https://issues.redhat.com/browse/JGRP-335
      */
     public void testStateTransferFollowedByUnicast() throws Exception {
         JChannel a=null, b=null;
@@ -223,7 +223,7 @@ public class FlushTest {
     }
 
     /**
-     * Tests http://jira.jboss.com/jira/browse/JGRP-661
+     * Tests https://issues.redhat.com/browse/JGRP-661
      */
     public void testPartialFlush() throws Exception {
         JChannel a=null, b=null;

--- a/tests/junit/org/jgroups/tests/GossipRouterTest.java
+++ b/tests/junit/org/jgroups/tests/GossipRouterTest.java
@@ -44,7 +44,7 @@ public class GossipRouterTest {
     }
 
     /**
-     * Tests the following scenario (http://jira.jboss.com/jira/browse/JGRP-682):
+     * Tests the following scenario (https://issues.redhat.com/browse/JGRP-682):
      * - First node is started with tunnel.xml, cannot connect
      * - Second node is started *with* GossipRouter
      * - Now first node should be able to connect and first and second node should be able to merge into a group

--- a/tests/junit/org/jgroups/tests/JoinTest.java
+++ b/tests/junit/org/jgroups/tests/JoinTest.java
@@ -97,7 +97,7 @@ public class JoinTest extends ChannelTestBase {
     /**
      * Tests the case where we send a JOIN-REQ, but get back a JOIN-RSP after GMS.join_timeout, so we've already
      * started another discovery. Tests whether the discovery process is cancelled correctly.
-     * http://jira.jboss.com/jira/browse/JGRP-621
+     * https://issues.redhat.com/browse/JGRP-621
      */
     public void testDelayedJoinResponse() throws Exception {
         final long JOIN_TIMEOUT=2000, DELAY_JOIN_REQ=4000;

--- a/tests/junit/org/jgroups/tests/LargeStateTransferTest.java
+++ b/tests/junit/org/jgroups/tests/LargeStateTransferTest.java
@@ -16,9 +16,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * Tests transfer of large states (http://jira.jboss.com/jira/browse/JGRP-225).
+ * Tests transfer of large states (https://issues.redhat.com/browse/JGRP-225).
  * Note that on Mac OS, FRAG2.frag_size and max_bundling_size in the transport should be less than 16'000 due to
- * http://jira.jboss.com/jira/browse/JGRP-560. As alternative, increase the MTU of the loopback device to a value
+ * https://issues.redhat.com/browse/JGRP-560. As alternative, increase the MTU of the loopback device to a value
  * greater than max_bundle_size, e.g.
  * ifconfig lo0 mtu 65000
  * @author Bela Ban

--- a/tests/junit/org/jgroups/tests/NAKACK_Test.java
+++ b/tests/junit/org/jgroups/tests/NAKACK_Test.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * Tests the NAKACK protocol for OOB and regular msgs, tests http://jira.jboss.com/jira/browse/JGRP-379
+ * Tests the NAKACK protocol for OOB and regular msgs, tests https://issues.redhat.com/browse/JGRP-379
  * @author Bela Ban
  */
 @Test(groups=Global.STACK_DEPENDENT,singleThreaded=true)
@@ -37,7 +37,7 @@ public class NAKACK_Test extends ChannelTestBase {
 
 
     /**
-     * Tests http://jira.jboss.com/jira/browse/JGRP-379: we send 1, 2, 3, 4(OOB) and 5 to the cluster.
+     * Tests https://issues.redhat.com/browse/JGRP-379: we send 1, 2, 3, 4(OOB) and 5 to the cluster.
      * Message with seqno 3 is discarded two times, so retransmission will make the receivers receive it *after* 4.
      * Note that OOB messages *destroys* FIFO ordering (or whatever ordering properties are set) !
      */

--- a/tests/junit/org/jgroups/tests/OOBTest.java
+++ b/tests/junit/org/jgroups/tests/OOBTest.java
@@ -57,7 +57,7 @@ public class OOBTest extends ChannelTestBase {
 
     /**
      * Tests sending 1, 2 (OOB) and 3, where they are received in the order 1, 3, 2. Message 3 should not get delivered
-     * until message 4 is received (http://jira.jboss.com/jira/browse/JGRP-780)
+     * until message 4 is received (https://issues.redhat.com/browse/JGRP-780)
      */
     public void testRegularAndOOBUnicasts() throws Exception {
         DISCARD discard=new DISCARD();
@@ -184,7 +184,7 @@ public class OOBTest extends ChannelTestBase {
     }
 
     /**
-     * Tests https://jira.jboss.org/jira/browse/JGRP-1079
+     * Tests https://issues.redhat.com/browse/JGRP-1079
      */
     public void testOOBMessageLoss() throws Exception {
         Util.close(b); // we only need 1 channel
@@ -214,7 +214,7 @@ public class OOBTest extends ChannelTestBase {
     }
 
     /**
-     * Tests https://jira.jboss.org/jira/browse/JGRP-1079 for unicast messages
+     * Tests https://issues.redhat.com/browse/JGRP-1079 for unicast messages
      */
     public void testOOBUnicastMessageLoss() throws Exception {
         MyReceiver receiver=new MySleepingReceiver("B", 1000);

--- a/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
+++ b/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
@@ -16,7 +16,7 @@ import java.util.*;
 
 /**
  * Tests overlapping merges, e.g. A: {A,B}, B: {A,B} and C: {A,B,C}. Tests unicast as well as multicast seqno tables.<br/>
- * Related JIRA: https://jira.jboss.org/jira/browse/JGRP-940
+ * Related JIRA: https://issues.redhat.com/browse/JGRP-940
  * @author Bela Ban
  */
 @Test(groups=Global.STACK_DEPENDENT,singleThreaded=true)

--- a/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
+++ b/tests/junit/org/jgroups/tests/OverlappingMergeTest.java
@@ -282,7 +282,7 @@ public class OverlappingMergeTest extends ChannelTestBase {
 
 
     /**
-     * Test the following scenario (https://issues.jboss.org/browse/JGRP-1451):
+     * Test the following scenario (https://issues.redhat.com/browse/JGRP-1451):
      * - A: {A,C,B}
      * - B: {A,C,B}
      * - C: {A,C,B}

--- a/tests/junit/org/jgroups/tests/OverlappingUnicastMergeTest.java
+++ b/tests/junit/org/jgroups/tests/OverlappingUnicastMergeTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 /**
  * Tests overlapping merges, e.g. A: {A,B}, B: {A,B} and C: {A,B,C}. Tests unicast tables<br/>
- * Related JIRA: https://jira.jboss.org/jira/browse/JGRP-940
+ * Related JIRA: https://issues.redhat.com/browse/JGRP-940
  * @author Bela Ban
  */
 @Test(groups=Global.STACK_DEPENDENT,singleThreaded=true)

--- a/tests/junit/org/jgroups/tests/SequencerMergeTest.java
+++ b/tests/junit/org/jgroups/tests/SequencerMergeTest.java
@@ -41,7 +41,7 @@ public class SequencerMergeTest {
 
     /**
      * Tests a merge between {A} and {B,C,D}, plus a concurrent multicast.
-     * https://issues.jboss.org/browse/JGRP-1468
+     * https://issues.redhat.com/browse/JGRP-1468
      */
     public void testMergeAndSendOrdering() throws Exception {
         // Create subgroup {A}:
@@ -129,7 +129,7 @@ public class SequencerMergeTest {
 
     /**
      * Tests a merge between {D,A} and {B,C,D}.
-     * https://issues.jboss.org/browse/JGRP-1484
+     * https://issues.redhat.com/browse/JGRP-1484
      */
     public void testMergeWithParticipant() throws Exception {
         a=create("A", false);

--- a/tests/stress/org/jgroups/tests/RemoteGetStressTest.java
+++ b/tests/stress/org/jgroups/tests/RemoteGetStressTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Tests https://issues.jboss.org/browse/JGRP-1675
+ * Tests https://issues.redhat.com/browse/JGRP-1675
  * @author Bela Ban
  * @since  3.5
  */


### PR DESCRIPTION
This fixes all broken links that are now spitting out errors:

* http://jira.jboss.com/jira/browse/JGRP
* https://jira.jboss.org/jira/browse/JGRP

and updates the https://issues.jboss.org to the new location saving an unnecessary redirect.