### PR TITLE
JGRP-2626 Fix X509Token Initialization

### DIFF
--- a/conf/auth_X509.xml
+++ b/conf/auth_X509.xml
@@ -12,10 +12,10 @@
     <pbcast.STABLE/>
     <FRAG2/>
     <AUTH auth_class="org.jgroups.auth.X509Token"
-        auth_value="chris"
-        keystore_path="/home/bela/JGroups/keystore/defaultStore.keystore"
-        keystore_password="changeit"
-        cert_alias="test"
-        cipher_type="RSA"/>
+        auth_token.auth_value="chris"
+        auth_token.keystore_path="/home/bela/JGroups/keystore/defaultStore.keystore"
+        auth_token.keystore_password="changeit"
+        auth_token.cert_alias="test"
+        auth_token.cipher_type="RSA"/>
     <pbcast.GMS/>
 </config>

--- a/conf/auth_krb5.xml
+++ b/conf/auth_krb5.xml
@@ -13,9 +13,9 @@
     <UNICAST3 />
     <pbcast.STABLE />
     <AUTH auth_class="org.jgroups.auth.Krb5Token"
-          client_principal_name="martin"
-          client_password="Password99"
-          service_principal_name="cluster1" />
+          auth_token.client_principal_name="martin"
+          auth_token.client_password="Password99"
+          auth_token.service_principal_name="cluster1" />
     <pbcast.GMS />
     <UFC />
     <MFC />

--- a/conf/auth_regex.xml
+++ b/conf/auth_regex.xml
@@ -24,9 +24,9 @@
 
     <!-- Allow only hosts in the 192.168 or 10.5 network to join -->
      <AUTH auth_class="org.jgroups.auth.RegexMembership"
-          match_string="(192\.168|10\.5)\.\d{1,3}\.\d{1,3}(:\d{1,5})?"
-          match_ip_address="true"
-          match_logical_name="false"  />
+          auth_token.match_string="(192\.168|10\.5)\.\d{1,3}\.\d{1,3}(:\d{1,5})?"
+          auth_token.match_ip_address="true"
+          auth_token.match_logical_name="false"  />
     <pbcast.GMS/>
     <UFC/>
     <MFC/>

--- a/src/org/jgroups/protocols/AUTH.java
+++ b/src/org/jgroups/protocols/AUTH.java
@@ -69,14 +69,17 @@ public class AUTH extends Protocol {
         super.init();
         if(auth_token == null)
             throw new IllegalStateException("no authentication mechanism configured");
-        if(auth_token instanceof X509Token) {
-            X509Token tmp=(X509Token)auth_token;
-            tmp.setCertificate();
-        }
+
         auth_token.init();
     }
 
     public void start() throws Exception {
+        if(auth_token instanceof X509Token) {
+            log.debug("X509Token detected. Initializing certificates");
+            X509Token tmp=(X509Token)auth_token;
+            tmp.setCertificate();
+        }
+
         super.start();
         if(auth_token != null)
             auth_token.start();


### PR DESCRIPTION
 - Move the initialization of the X509Token to AUTH.start() method instead of AUTH.init() method since the certificate properties are not defined yet when the init() method is called;
 - Adjust the sample AUTH configurations to include the auth_token. prefix;