### PR TITLE
Test case for JGRP-2647.

### DIFF
--- a/src/org/jgroups/protocols/FD_SOCK2.java
+++ b/src/org/jgroups/protocols/FD_SOCK2.java
@@ -128,6 +128,9 @@ public class FD_SOCK2 extends Protocol implements Receiver, ConnectionListener, 
     public int         getPortRange()                    {return port_range;}
     public FD_SOCK2    setPortRange(int p)               {this.port_range=p; return this;}
 
+    public int         getOffset()                       {return offset;}
+    public FD_SOCK2    setOffset(int o)                  {this.offset=o; return this;}
+
     @ManagedAttribute(description="Actual port the server is listening on")
     public int getActualBindPort() {
         Address addr=srv != null? srv.localAddress() : null;

--- a/tests/junit-functional/org/jgroups/protocols/FD_SOCK2_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/FD_SOCK2_Test.java
@@ -1,0 +1,45 @@
+package org.jgroups.protocols;
+
+import java.util.logging.Logger;
+
+import org.jgroups.Global;
+import org.jgroups.JChannel;
+import org.jgroups.util.Util;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link FD_SOCK2} not closing its sockets within the {@link FD_SOCK2#stop()} call and subsequently failing
+ * when subsequently started again (e.g. triggered by redeploy in WildFly). Reproducible by connecting and disconnecting
+ * the channel in a loop. Typically happens on a modern machine within seconds.
+ *
+ * @author Radoslav Husar
+ * @see <a href="https://issues.redhat.com/browse/JGRP-2647">JGRP-2647</a>
+ */
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true)
+public class FD_SOCK2_Test {
+
+    protected JChannel a;
+
+    public void testSocketClosing() throws Exception {
+        a = new JChannel(Util.getTestStack(
+                new FD_SOCK2().setPortRange(1).setOffset(1))
+        ).name("A");
+
+        for (int i = 0; i < 10_000; i++) {
+            try {
+                a.connect(FD_SOCK2_Test.class.getSimpleName());
+            } catch (Exception e) {
+                Logger.getLogger(FD_SOCK2_Test.class.getSimpleName()).info(String.format("FD_SOCK2 socket close test failed on run #%d", i));
+                throw e;
+            }
+
+            a.disconnect();
+        }
+    }
+
+    @AfterMethod
+    protected void destroy() {
+        Util.close(a);
+    }
+}


### PR DESCRIPTION
Adds test for [JGRP-2647](https://issues.redhat.com/browse/JGRP-2647). Exposes setters/getters. ~~Includes https://github.com/belaban/JGroups/pull/670.~~