### PR TITLE
Remove semicolon from if statement

### DIFF
--- a/src/org/jgroups/protocols/pbcast/GMS.java
+++ b/src/org/jgroups/protocols/pbcast/GMS.java
@@ -563,7 +563,7 @@ public class GMS extends Protocol implements DiagnosticsHandler.ProbeHandler {
             }
         }
         catch(TimeoutException e) {
-            if(log_collect_msgs);
+            if(log_collect_msgs)
                 log.warn("%s: failed to collect all ACKs (expected=%d) for view %s after %d ms, missing %d ACKs from %s",
                          local_addr, ack_collector.expectedAcks(), new_view.getViewId(), System.currentTimeMillis()-start,
                          ack_collector.size(), ack_collector.printMissing());


### PR DESCRIPTION
It appears that this was only supposed to log when log_collect_msgs is true, but an accidental semicolon resulted in the log statement always running.