### PR TITLE
JGRP-2657 SPI for ThreadCreator

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,7 @@
     <property name="build.properties.file" value="build.properties"/>
     <property file="${build.properties.file}"/>
     <property name="src.dir"               value="${root.dir}/src"/>
-    <property name="src-20.dir"            value="${root.dir}/mr/20/src"/>
+    <property name="src-19.dir"            value="${root.dir}/jdk/19/src"/>
     <property name="tests.dir"             value="${root.dir}/tests"/>
     <property name="other.dir"             value="${tests.dir}/other"/>
     <property name="junit.dir"             value="${tests.dir}/junit"/>
@@ -43,8 +43,11 @@
     <property name="ivy.version"           value="2.5.0" />
     <property name="project.pom"            value="${root.dir}/pom.xml"/>
     <property name="manifest"              value="${dist.dir}/MANIFEST.MF"/>
+    <condition property="jdk-19">
+        <javaversion exactly="19"/>
+    </condition>
     <condition property="jdk-20">
-        <javaversion atleast="20"/>
+        <javaversion exactly="20"/>
     </condition>
 
 
@@ -165,17 +168,27 @@
         </javac>
     </target>
 
-    <target name="compile-20" depends="prepare" description="Compiles all Java files that require JDK 20" if="jdk-20">
-        <mkdir dir="${compile.dir}/META-INF/versions/20"/>
-        <javac destdir="${compile.dir}/META-INF/versions/20" release="20"
+    <target name="compile-19" depends="prepare" description="Compiles all Java files that require JDK 19" if="jdk-19">
+        <mkdir dir="${compile.dir}"/>
+        <javac destdir="${compile.dir}" release="19"
                classpathref="jg.classpath" includeantruntime="false" debug="on"
                includes="org/jgroups/**">
-             <compilerarg line="--enable-preview --release 20"/>
-             <src path="${src-20.dir}"/>
+             <compilerarg line="--enable-preview --release 19"/>
+             <src path="${src-19.dir}"/>
         </javac>
     </target>
 
-    <target name="compile" depends="prepare,compile-11,compile-20" description="Compiles all Java files">
+    <target name="compile-20" depends="prepare" description="Compiles all Java files that require JDK 20" if="jdk-20">
+        <mkdir dir="${compile.dir}"/>
+        <javac destdir="${compile.dir}" release="20"
+               classpathref="jg.classpath" includeantruntime="false" debug="on"
+               includes="org/jgroups/**">
+            <compilerarg line="--enable-preview --release 20"/>
+            <src path="${src-19.dir}"/>
+        </javac>
+    </target>
+
+    <target name="compile" depends="prepare,compile-11,compile-19,compile-20" description="Compiles all Java files">
         <set-version/>
     </target>
 
@@ -219,6 +232,7 @@
         <copy todir="${compile.dir}/">
             <fileset dir="${conf.dir}" includes="*.properties, *.xml">
                 <include name="scripts/**"/>
+                <include name="META-INF/services/**"/>
                 <exclude name="log4j*.xml"/>
                 <exclude name="settings.xml"/>
             </fileset>
@@ -236,7 +250,7 @@
 
 
     <target name="jgroups.jar" description="Creates the jgroups.jar (includes everything)"
-            depends="compile-plus-essential-unittests,compile-20,make-schema,make-keystore-no-compile,create-manifest,copy-conf-dir">
+            depends="compile-plus-essential-unittests,compile-19,compile-20,make-schema,make-keystore-no-compile,create-manifest,copy-conf-dir">
         <mkdir dir="${dist.dir}"/>
         <mkdir dir="${compile.dir}/META-INF"/>
         <jar destfile="${dist.dir}/jgroups-${version}.jar" basedir="${compile.dir}" manifest="${dist.dir}/MANIFEST.MF">
@@ -273,7 +287,7 @@
         <jar jarfile="${dist.dir}/jgroups-${version}-sources.jar"
              basedir="${src.dir}"
              manifest="${dist.dir}/MANIFEST.MF">
-            <fileset dir="${src-20.dir}"/>
+            <fileset dir="${src-19.dir}"/>
         </jar>
     </target>
 

--- a/conf/META-INF/services/org.jgroups.util.ThreadCreator$SPI
+++ b/conf/META-INF/services/org.jgroups.util.ThreadCreator$SPI
@@ -1,0 +1,3 @@
+# Order is important: from latest to earliest
+org.jgroups.util.jdkspecific.ThreadCreator19
+org.jgroups.util.jdkspecific.ThreadCreator11

--- a/jdk/19/src/org/jgroups/util/jdkspecific/ThreadCreator19.java
+++ b/jdk/19/src/org/jgroups/util/jdkspecific/ThreadCreator19.java
@@ -2,18 +2,19 @@ package org.jgroups.util.jdkspecific;
 
 import org.jgroups.logging.Log;
 import org.jgroups.util.ShutdownRejectedExecutionHandler;
+import org.jgroups.util.ThreadCreator;
 import org.jgroups.util.ThreadFactory;
 import org.jgroups.util.Util;
 
 import java.util.concurrent.*;
 
-public class ThreadCreator {
+public class ThreadCreator19 implements ThreadCreator.SPI {
 
-   public static boolean hasVirtualThreads() {
+   public boolean hasVirtualThreads() {
       return true;
    }
 
-   public static Thread createThread(Runnable target, String name, boolean createDaemons, boolean useVirtualThreads) {
+   public Thread createThread(Runnable target, String name, boolean createDaemons, boolean useVirtualThreads) {
       Thread t;
       if (useVirtualThreads) {
          t = Thread.ofVirtual().unstarted(target);
@@ -25,7 +26,7 @@ public class ThreadCreator {
       return t;
    }
 
-   public static ExecutorService createThreadPool(int min_threads, int max_threads, long keep_alive_time,
+   public ExecutorService createThreadPool(int min_threads, int max_threads, long keep_alive_time,
                                                   String rejection_policy,
                                                   BlockingQueue<Runnable> queue, final ThreadFactory factory,
                                                   boolean useVirtualThreads, Log log) {

--- a/pom.xml
+++ b/pom.xml
@@ -351,9 +351,6 @@
                             <!--classpathPrefix>libs/</classpathPrefix-->
                             <mainClass>org.jgroups.Version</mainClass>
                         </manifest>
-                        <manifestEntries>
-                            <Multi-Release>true</Multi-Release>
-                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
@@ -491,9 +488,39 @@
     </build>
     <profiles>
         <profile>
+            <id>jdk-19</id>
+            <activation>
+                <jdk>19</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.10.1</version>
+                        <executions>
+                            <execution>
+                                <id>jdk-19</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>19</release>
+                                    <buildDirectory>${project.build.directory}</buildDirectory>
+                                    <compileSourceRoots>${project.basedir}/jdk/19/src</compileSourceRoots>
+                                    <enablePreview>true</enablePreview>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>jdk-20</id>
             <activation>
-                <jdk>[20,)</jdk>
+                <jdk>20</jdk>
             </activation>
             <build>
                 <plugins>
@@ -511,8 +538,7 @@
                                 <configuration>
                                     <release>20</release>
                                     <buildDirectory>${project.build.directory}</buildDirectory>
-                                    <compileSourceRoots>${project.basedir}/mr/20/src</compileSourceRoots>
-                                    <multiReleaseOutput>true</multiReleaseOutput>
+                                    <compileSourceRoots>${project.basedir}/jdk/19/src</compileSourceRoots>
                                     <enablePreview>true</enablePreview>
                                 </configuration>
                             </execution>

--- a/src/org/jgroups/util/DefaultThreadFactory.java
+++ b/src/org/jgroups/util/DefaultThreadFactory.java
@@ -1,7 +1,6 @@
 package org.jgroups.util;
 
 import org.jgroups.logging.Log;
-import org.jgroups.util.jdkspecific.ThreadCreator;
 
 /**
  * Thread factory mainly responsible for naming of threads. Can be replaced by

--- a/src/org/jgroups/util/ThreadCreator.java
+++ b/src/org/jgroups/util/ThreadCreator.java
@@ -1,0 +1,64 @@
+package org.jgroups.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+
+import org.jgroups.blocks.Cache;
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+
+/**
+ * @since 14.0
+ **/
+public final class ThreadCreator {
+   private static final Log log = LogFactory.getLog(ThreadCreator.class);
+   private static final SPI INSTANCE = init();
+
+   static private SPI init() {
+      ServiceLoader<SPI> loader = ServiceLoader.load(SPI.class, ThreadCreator.class.getClassLoader());
+      Iterator<SPI> i = loader.iterator();
+      while (true) {
+         try {
+            SPI spi = i.next();
+            log.debug("Using ThreadCreator %s", spi.getClass().getSimpleName());
+            return spi;
+         } catch (ServiceConfigurationError | UnsupportedClassVersionError e) {
+            log.debug("Failed to initialize a ThreadCreator SPI", e);
+         } catch (NoSuchElementException e) {
+            throw new RuntimeException("Could not find a suitable SPI for " + SPI.class.getName());
+         }
+      }
+   }
+
+
+   public static boolean hasVirtualThreads() {
+      return INSTANCE.hasVirtualThreads();
+   }
+
+   public static Thread createThread(Runnable target, String name, boolean createDaemons, boolean useVirtualThreads) {
+      return INSTANCE.createThread(target, name, createDaemons, useVirtualThreads);
+   }
+
+   public static ExecutorService createThreadPool(int min_threads, int max_threads, long keep_alive_time,
+                                                  String rejection_policy,
+                                                  BlockingQueue<Runnable> queue, final ThreadFactory factory,
+                                                  boolean useVirtualThreads, Log log) {
+      return INSTANCE.createThreadPool(min_threads, max_threads, keep_alive_time, rejection_policy, queue, factory, useVirtualThreads, log);
+   }
+
+
+   public interface SPI {
+      boolean hasVirtualThreads();
+
+      Thread createThread(Runnable target, String name, boolean createDaemons, boolean useVirtualThreads);
+
+      ExecutorService createThreadPool(int min_threads, int max_threads, long keep_alive_time,
+                                       String rejection_policy,
+                                       BlockingQueue<Runnable> queue, final ThreadFactory factory,
+                                       boolean useVirtualThreads, Log log);
+   }
+}

--- a/src/org/jgroups/util/ThreadPool.java
+++ b/src/org/jgroups/util/ThreadPool.java
@@ -8,7 +8,6 @@ import org.jgroups.annotations.Property;
 import org.jgroups.conf.AttributeType;
 import org.jgroups.logging.Log;
 import org.jgroups.protocols.TP;
-import org.jgroups.util.jdkspecific.ThreadCreator;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -17,7 +17,6 @@ import org.jgroups.protocols.relay.SiteUUID;
 import org.jgroups.stack.IpAddress;
 import org.jgroups.stack.Protocol;
 import org.jgroups.stack.ProtocolStack;
-import org.jgroups.util.jdkspecific.ThreadCreator;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/src/org/jgroups/util/jdkspecific/ThreadCreator11.java
+++ b/src/org/jgroups/util/jdkspecific/ThreadCreator11.java
@@ -2,24 +2,25 @@ package org.jgroups.util.jdkspecific;
 
 import org.jgroups.logging.Log;
 import org.jgroups.util.ShutdownRejectedExecutionHandler;
+import org.jgroups.util.ThreadCreator;
 import org.jgroups.util.ThreadFactory;
 import org.jgroups.util.Util;
 
 import java.util.concurrent.*;
 
-public class ThreadCreator {
+public class ThreadCreator11 implements ThreadCreator.SPI {
 
-   public static boolean hasVirtualThreads() {
+   public boolean hasVirtualThreads() {
       return false;
    }
 
-   public static Thread createThread(Runnable target, String name, boolean createDaemons, boolean ignored) {
+   public Thread createThread(Runnable target, String name, boolean createDaemons, boolean ignored) {
       Thread t=new Thread(target, name);
       t.setDaemon(createDaemons);
       return t;
    }
 
-   public static ExecutorService createThreadPool(int min_threads,int max_threads,long keep_alive_time,
+   public ExecutorService createThreadPool(int min_threads,int max_threads,long keep_alive_time,
                                                   String rejection_policy,
                                                   BlockingQueue<Runnable> queue,final ThreadFactory factory,
                                                   boolean ignored, Log log) {


### PR DESCRIPTION
https://issues.redhat.com/browse/JGRP-2657

This reverts the JGroups JAR to a non-MR JAR. It uses Java's ServiceLoader to attempt to load alternate implementations of the `org.jgroups.util.ThreadCreator$SPI` interface until it finds one that works (i.e. doesn't cause a `ServiceConfigurationError` or an `UnsupportedClassVersionError`). 