### PR TITLE
Added check not null for connection JDBC_PING.clearTable

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -348,25 +348,32 @@ public class JDBC_PING extends FILE_PING {
         }
     }
 
-
     protected void clearTable(String clustername) {
-        try(Connection conn=getConnection();
-            PreparedStatement ps=conn.prepareStatement(clear_sql)) {
-            // check presence of cluster_name parameter for backwards compatibility
-            if (clear_sql.indexOf('?') >= 0)
-                ps.setString(1, clustername);
-            else
-                log.debug("Please update your clear_sql to include cluster_name parameter.");
-            if(log.isTraceEnabled())
-                log.trace("%s: SQL for clearing the table: %s", local_addr, ps);
-            ps.execute();
-            log.debug("%s: cleared table for cluster %s", local_addr, clustername);
-        }
-        catch(SQLException e) {
-            log.error(Util.getMessage("ErrorClearingTable"), e);
+        final Connection conn = getConnection();
+        if (conn != null)
+        {
+            try (PreparedStatement ps = conn.prepareStatement(clear_sql))
+            {
+                // check presence of cluster_name parameter for backwards compatibility
+                if (clear_sql.indexOf('?') >= 0)
+                    ps.setString(1, clustername);
+                else
+                    log.debug("Please update your clear_sql to include cluster_name parameter.");
+                if (log.isTraceEnabled())
+                    log.trace("%s: SQL for clearing the table: %s", local_addr, ps);
+                ps.execute();
+                log.debug("%s: cleared table for cluster %s", local_addr, clustername);
+            }
+            catch (SQLException e)
+            {
+                log.error(Util.getMessage("ErrorClearingTable"), e);
+            }
+            finally
+            {
+                closeConnection(conn);
+            }
         }
     }
-
     
     protected void closeConnection(final Connection connection) {
         try {


### PR DESCRIPTION
if node doesn't have a connection of database when had changed the view - it can't return to cluster after resumption of access

i mean if i have 3 node - a, b, c and ping via jdbc_ping with turn on remove_all_data_on_view_change. Every node on self server. Node A loses connection to database and net - b and c create new view and delete a from table jgroupsping, but node a reckons than b and s left cluster and tries to create self view - but event view_change falls exception npe on method clearTable, because the connection is null. And after resumption of access node a can't to return in cluster b and c