### PR TITLE
do not default to very old protocols, let the jvm pick a secure value

### DIFF
--- a/src/org/jgroups/util/TLS.java
+++ b/src/org/jgroups/util/TLS.java
@@ -21,9 +21,9 @@ public class TLS implements Lifecycle {
     @Property(description="Enables TLS; when true, SSL sockets will be used instead of regular sockets")
     protected boolean          enabled;
 
-    @Property(description="One or more TLS protocol names to use, e.g. TLSv1.2. Setting this requires " +
+    @Property(description="One or more TLS protocol names to use, e.g. TLSv1.3. Setting this requires " +
       "configuring key and trust stores")
-    protected String[]         protocols={"TLSv1.2"};
+    protected String[]         protocols;
 
     @Property(description="The list of cipher suites")
     protected String[]         cipher_suites;


### PR DESCRIPTION
TLS 1.2 is fairly old and better alternatives are available. It seems better to rely on the defaults of oracle than to to manually downgrade settings.