### PR TITLE
Fix trace format in Relayer class

### DIFF
--- a/src/org/jgroups/protocols/relay/Relayer.java
+++ b/src/org/jgroups/protocols/relay/Relayer.java
@@ -254,7 +254,7 @@ public class Relayer {
 
             // remove all routes which were dropped between the old and new view:
             if(!removed_routes.isEmpty() && log.isTraceEnabled())
-                log.trace("%s: removing routes %s from routing table", removed_routes);
+                log.trace("%s: removing routes %s from routing table", channel.getAddress(), removed_routes);
             removed_routes.forEach(routes.keySet()::remove);
 
             if(!down.isEmpty())


### PR DESCRIPTION
Some logs messages use `relay.getAddress()` and others `channel.getAddress()`. I'm not sure if I chose the correct one.