### PR TITLE
JGRP-2711 Relayer#getSiteNames isn't returning all the sites available

### DIFF
--- a/src/org/jgroups/protocols/relay/Relayer.java
+++ b/src/org/jgroups/protocols/relay/Relayer.java
@@ -143,7 +143,8 @@ public class Relayer {
     }
 
     protected List<String> getSiteNames() {
-        return new ArrayList<>(routes.keySet());
+        return Stream.concat(Stream.of(relay.site), routes.keySet().stream())
+                .collect(Collectors.toList());
     }
 
     protected synchronized List<Route> getRoutes(String ... excluded_sites) {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/JGRP-2711

It fixes most of the tests in Infinispan test suite. I still have a hand full of failures to look at. 