### PR TITLE
CI: JDK 21 is now GA.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and the latest EA JDK (if available).
-        java: [ 11, 17, 20, 21-ea ]
+        java: [ 11, 17, 21, 22-ea ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Well, it has been GA for a while now, but the `temurin` build just wasn't available to us here. Ready to go now.