### PR TITLE
Fix maven build stability by removing incorrect <requirements> elemen…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,6 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <prerequisites>
-        <maven>3.0.4</maven>
-    </prerequisites>
-
     <repositories>
         <repository>
             <id>jboss-public-repository-group</id>
@@ -99,8 +95,6 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
-
-
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
…t - maven version is correctly already being enforced by maven-enforcer-plugin.

Avoids the [WARNING] The project org.jgroups:jgroups:jar:5.3.1.Final-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html