### PR TITLE
Add single-argument method version for binary compatibility

### DIFF
--- a/src/org/jgroups/protocols/Discovery.java
+++ b/src/org/jgroups/protocols/Discovery.java
@@ -636,6 +636,10 @@ public abstract class Discovery extends Protocol {
         return list;
     }
 
+    public static ByteArray marshal(PingData data) {
+       return marshal(new PingData[] {data});
+    }
+
     public static ByteArray marshal(PingData ... list) {
         return marshal(List.of(list));
     }


### PR DESCRIPTION
A [recent commit](https://github.com/belaban/JGroups/commit/40a615e45c0550d5f91b4fd8c01a3b4950d9e5be) in 5.3.2 broke the binary compatibility with modules like JGroups K8S. It's no longer possible to use JGroups K8S 2.0.1 with JGroups 5.3.2:

```java
Caused by: java.lang.NoSuchMethodError: 'org.jgroups.util.ByteArray org.jgroups.protocols.kubernetes.KUBE_PING.marshal(org.jgroups.protocols.PingData)'
        at org.jgroups.protocols.kubernetes.KUBE_PING.findMembers(KUBE_PING.java:278)
        at org.jgroups.protocols.Discovery.callFindMembersInAllDiscoveryProtocols(Discovery.java:393)
        at org.jgroups.protocols.Discovery.findMembers(Discovery.java:240)
        at org.jgroups.protocols.Discovery.down(Discovery.java:430)
        at org.jgroups.protocols.MERGE3.down(MERGE3.java:268)
        at org.jgroups.protocols.VERIFY_SUSPECT.down(VERIFY_SUSPECT.java:102)
        at org.jgroups.protocols.BARRIER.down(BARRIER.java:138)
        at org.jgroups.protocols.pbcast.NAKACK2.down(NAKACK2.java:635)
        at org.jgroups.protocols.UNICAST3.down(UNICAST3.java:653)
        at org.jgroups.protocols.pbcast.STABLE.down(STABLE.java:275)
        at org.jgroups.protocols.pbcast.ClientGmsImpl.joinInternal(ClientGmsImpl.java:67)
        at org.jgroups.protocols.pbcast.ClientGmsImpl.joinWithStateTransfer(ClientGmsImpl.java:41)
        at org.jgroups.protocols.pbcast.GMS.down(GMS.java:898)
        at org.jgroups.protocols.FlowControl.down(FlowControl.java:201)
        at org.jgroups.stack.Protocol.down(Protocol.java:309)
        at org.jgroups.protocols.FRAG2.down(FRAG2.java:103)
        at org.jgroups.protocols.pbcast.STATE_TRANSFER.down(STATE_TRANSFER.java:205)
        at org.jgroups.stack.ProtocolStack.down(ProtocolStack.java:947)
        at org.jgroups.JChannel.down(JChannel.java:601)
        at org.jgroups.JChannel._connect(JChannel.java:803)
        at org.jgroups.JChannel.connect(JChannel.java:373)
        at org.jgroups.JChannel.connect(JChannel.java:346)
```

This PR adds back the static `ByteArray marshal(PingData)` method and delegates calls to the new varargs-version one.