### PR TITLE
CI: Update maven run goal to avoid 'skipExec' deprecation warning*; u…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build with Maven
-        # In order to support Windows PowerShell, a space between -D property=true is required.
-        run: mvn -B verify -D maven.test.skip.exec=true
+        # In order to support Windows PowerShell, a space between --define property=true is required.
+        run: mvn --batch-mode --no-transfer-progress verify --define skipTests=true


### PR DESCRIPTION
…se fully spelled out maven options; disable progress noisy output

* [WARNING]  Parameter 'skipExec' (user property 'maven.test.skip.exec') is deprecated: Use skipTests instead.