### PR TITLE
allow to configure dns_record_type with a system property

### DIFF
--- a/src/org/jgroups/protocols/dns/DNS_PING.java
+++ b/src/org/jgroups/protocols/dns/DNS_PING.java
@@ -30,7 +30,8 @@ public class DNS_PING extends Discovery {
     @Property(description = "DNS Address. This property will be assembled with the 'dns://' prefix.  If this is specified, A records will be resolved through DnsContext.")
     protected String  dns_address = "";
 
-    @Property(description = "DNS Record type")
+    @Property(description = "DNS Record type",
+            systemProperty="jgroups.dns.dns_record_type")
     protected String  dns_record_type = DEFAULT_DNS_RECORD_TYPE;
 
     @Property(description = "A comma-separated list of DNS queries for fetching members",


### PR DESCRIPTION
My setup is a set of Keycloak 18.0.2 clusters in an environment with nomad and consul. We're using DNS_PING with SRV records for a long time now and the JGroups setup is pretty simple:

```
JGROUPS_DISCOVERY_PROTOCOL=dns.DNS_PING
JGROUPS_DISCOVERY_PROPERTIES="dns_query="${dns_query}",dns_record_type="SRV""
JGROUPS_TRANSPORT_STACK="tcp"
```

When migrating this to Keycloak 23.0.7, I found that the dns_record_type separated with a comma is not supported anymore. With the documentation I found on the internet and discussions and issue in the JGroups, Infinispan, Keycloak github projects, I failed to get SRV records running with something straight-forward like this:

```
<infinispan ...>

    <jgroups>
        <stack name="dns-ping">
            <dns.DNS_PING dns_record_type="SRV"
                          dns_query="${dns_query}"/>
            <TCP diag.enabled="true"
                 bind_addr="GLOBAL"
                 external_addr="{{ env "NOMAD_IP_jgroupscluster" }}"
                 external_port="{{ env "NOMAD_HOST_PORT_jgroupscluster" }}"/>
        </stack>
    </jgroups>

    <cache-container name="keycloak">
        <transport stack="dns-ping"...
```

When looking at org.jgroups.protocols.dns.DNS_PING I found that only a tiny tweak is necessary to reduce all this down to

```
KC_CACHE=ispn
KC_CACHE_STACK=kubernetes
JAVA_OPTS_APPEND="-Djgroups.dns.dns_query=${dns_query} -Djgroups.dns.dns_record_type=SRV
```

This works fine for me since some days.

@belaban I'd be really happy if you include this in an upcoming 5.2.x release