### PR TITLE
Fix FD_SOCK2 startup log to show *:port instead of *.port

### DIFF
--- a/src/org/jgroups/protocols/FD_SOCK2.java
+++ b/src/org/jgroups/protocols/FD_SOCK2.java
@@ -163,7 +163,7 @@ public class FD_SOCK2 extends Protocol implements Receiver, ConnectionListener, 
         srv=createServer(bind_ports);
         srv.receiver(this).clientBindPort(client_bind_port).usePeerConnections(true).addConnectionListener(this).linger(linger);
         srv.start();
-        log.info("server listening on %s", bind_addr != null? srv.getChannel().getLocalAddress() : "*." + getActualBindPort());
+        log.info("server listening on %s", bind_addr != null? srv.getChannel().getLocalAddress() : "*:" + getActualBindPort());
     }
 
     public void stop() {


### PR DESCRIPTION
For some reason this always bothers me :)