### PR TITLE
JGRP-2807 Allow setting bundler instance

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -550,13 +550,15 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
 
     public Bundler           getBundler()             {return bundler;}
 
-    /** Installs a bundler. Needs to be done before the channel is connected */
+    /** Installs a bundler */
     public <T extends TP> T setBundler(Bundler bundler) {
-        if(bundler != null)
-            this.bundler=bundler;
+        if(this.bundler != null)
+            this.bundler.stop();
+        bundler.init(this);
+        bundler.start();
+        this.bundler=bundler;
         return (T)this;
     }
-
 
     public ThreadPool getThreadPool() {
         return thread_pool;
@@ -771,8 +773,10 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
             msg_factory=clazz.getDeclaredConstructor().newInstance();
         }
 
-        bundler=createBundler(bundler_type, getClass());
-        bundler.init(this);
+        if (bundler == null) {
+            bundler=createBundler(bundler_type, getClass());
+            bundler.init(this);
+        }
     }
 
 

--- a/tests/junit-functional/org/jgroups/protocols/RED_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/RED_Test.java
@@ -91,7 +91,6 @@ public class RED_Test {
         transport.getProtocolStack().removeProtocol(UNICAST3.class);
         retval.getProtocolStack().insertProtocolInStack(red, transport, ProtocolStack.Position.ABOVE);
         bundler=new DelayBundler();
-        bundler.init(transport);
         transport.setBundler(bundler);
         ((GMS)retval.getProtocolStack().findProtocol(GMS.class)).setJoinTimeout(5);
         return retval;

--- a/tests/junit-functional/org/jgroups/tests/HeadersResizeTest.java
+++ b/tests/junit-functional/org/jgroups/tests/HeadersResizeTest.java
@@ -39,8 +39,6 @@ public class HeadersResizeTest {
 
     public void testResizing() throws Exception {
         BatchingBundler bundler=new BatchingBundler();
-        TP transport=a.getProtocolStack().getTransport();
-        bundler.init(transport);
         a.getProtocolStack().getTransport().setBundler(bundler);
 
         MyReceiver receiver=new MyReceiver();


### PR DESCRIPTION
This change allows setting the bundler instance on TP allowing it to be configured programmatically. Previously it had to be set by class name or it would be overwritten during init.