### PR TITLE
JGRP-2808 Make TP rename all bundler threads

### DIFF
--- a/src/org/jgroups/protocols/Bundler.java
+++ b/src/org/jgroups/protocols/Bundler.java
@@ -42,5 +42,7 @@ public interface Bundler {
     int             getMaxSize();
     default Bundler setMaxSize(int s) {return this;}
 
+    default void renameThread() {}
+
     default void resetStats() {}
 }

--- a/src/org/jgroups/protocols/PerDestinationBundler.java
+++ b/src/org/jgroups/protocols/PerDestinationBundler.java
@@ -67,7 +67,7 @@ public class PerDestinationBundler implements Bundler {
     protected Address                       local_addr;
     protected final Map<Address,SendBuffer> dests=Util.createConcurrentMap();
     protected static final Address          NULL=new NullAddress();
-
+    protected static final String           THREAD_NAME="pd-bundler";
 
     public int     size() {
         return dests.values().stream().map(SendBuffer::size).reduce(0, Integer::sum);
@@ -200,7 +200,7 @@ public class PerDestinationBundler implements Bundler {
         public SendBuffer start() {
             if(running)
                 stop();
-            bundler_thread=transport.getThreadFactory().newThread(this, "pd-bundler"); // new Thread(this, "pd-bundler");
+            bundler_thread=transport.getThreadFactory().newThread(this, THREAD_NAME);
             running=true;
             bundler_thread.start();
             return this;
@@ -213,6 +213,9 @@ public class PerDestinationBundler implements Bundler {
                 tmp.interrupt();
         }
 
+        public void renameThread() {
+            transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread);
+        }
 
         protected void send(Message msg) throws Exception {
             queue.put(msg);

--- a/src/org/jgroups/protocols/RingBufferBundler.java
+++ b/src/org/jgroups/protocols/RingBufferBundler.java
@@ -56,7 +56,6 @@ public class RingBufferBundler extends BaseBundler {
     }
 
     public RingBuffer<Message> buf()                     {return rb;}
-    public Thread              getThread()               {return bundler_thread.getThread();}
     public int                 size()                    {return rb.size();}
     public int                 getQueueSize()            {return rb.size();}
     public int                 numSpins()                {return num_spins;}
@@ -83,6 +82,10 @@ public class RingBufferBundler extends BaseBundler {
 
     public void stop() {
         bundler_thread.stop();
+    }
+
+    public void renameThread() {
+        transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread.getThread());
     }
 
     public void send(Message msg) throws Exception {

--- a/src/org/jgroups/protocols/RingBufferBundlerLockless.java
+++ b/src/org/jgroups/protocols/RingBufferBundlerLockless.java
@@ -70,6 +70,9 @@ public class RingBufferBundlerLockless extends BaseBundler {
         bundler_thread.stop();
     }
 
+    public void renameThread() {
+        transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread.getThread());
+    }
 
     public void send(Message msg) throws Exception {
         if(msg == null)

--- a/src/org/jgroups/protocols/RingBufferBundlerLockless2.java
+++ b/src/org/jgroups/protocols/RingBufferBundlerLockless2.java
@@ -71,6 +71,9 @@ public class RingBufferBundlerLockless2 extends BaseBundler {
         bundler_thread.stop();
     }
 
+    public void renameThread() {
+        transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread.getThread());
+    }
 
     public void send(Message msg) throws Exception {
         if(msg == null)

--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -1491,18 +1491,16 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
     protected void setThreadNames() {
         if(diag_handler != null)
             diag_handler.setThreadNames();
-        if(bundler instanceof TransferQueueBundler)
-            thread_factory.renameThread(TransferQueueBundler.THREAD_NAME, ((TransferQueueBundler)bundler).getThread());
+        if(bundler != null)
+            bundler.renameThread();
     }
 
 
     protected void unsetThreadNames() {
         if(diag_handler != null)
             diag_handler.unsetThreadNames();
-        Thread thread=bundler instanceof TransferQueueBundler? ((TransferQueueBundler)bundler).getThread() :
-          bundler instanceof RingBufferBundler? ((RingBufferBundler)bundler).getThread() : null;
-        if(thread != null)
-            thread_factory.renameThread(TransferQueueBundler.THREAD_NAME, thread);
+        if(bundler != null)
+            bundler.renameThread();
     }
 
     protected void setInAllThreadFactories(String cluster_name, Address local_address, String pattern) {

--- a/src/org/jgroups/protocols/TransferQueueBundler.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler.java
@@ -52,8 +52,6 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
         this(new ArrayBlockingQueue<>(Util.assertPositive(capacity, "bundler capacity cannot be " + capacity)));
     }
 
-    public Thread                getThread()             {return bundler_thread;}
-
     @ManagedAttribute(description="Size of the queue")
     public int                   getQueueSize()          {return queue.size();}
 
@@ -96,6 +94,10 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
             }
         }
         drain();
+    }
+
+    public void renameThread() {
+        transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread);
     }
 
     public int size() {

--- a/src/org/jgroups/protocols/TransferQueueBundler2.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler2.java
@@ -83,8 +83,6 @@ public class TransferQueueBundler2 implements Bundler, Runnable {
         this(new ArrayBlockingQueue<>(assertPositive(capacity, "bundler capacity cannot be " + capacity)));
     }
 
-    public Thread                getThread()               {return bundler_thread;}
-
     public int                   getCapacity()       {return capacity;}
     public Bundler               setCapacity(int c)  {this.capacity=c; return this;}
     public int                   getMaxSize()        {return max_size;}
@@ -142,6 +140,10 @@ public class TransferQueueBundler2 implements Bundler, Runnable {
             }
         }
         drain();
+    }
+
+    public void renameThread() {
+        transport.getThreadFactory().renameThread(THREAD_NAME, bundler_thread);
     }
 
     public int size() {


### PR DESCRIPTION
This makes TP rename all bundler threads (previously only done for TransferQueueBundler+RingBufferBundler) and also makes TP not care about the specific bundler type being used
