### PR TITLE
JGRP-2810 Disallow setting queue in TransferQueueBundler constructor

### DIFF
--- a/src/org/jgroups/protocols/SimplifiedTransferQueueBundler.java
+++ b/src/org/jgroups/protocols/SimplifiedTransferQueueBundler.java
@@ -5,7 +5,6 @@ import org.jgroups.Message;
 import org.jgroups.util.Util;
 
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
 
 /**
  * This bundler uses the same logic as {@link TransferQueueBundler} but does not allocate
@@ -18,10 +17,6 @@ public class SimplifiedTransferQueueBundler extends TransferQueueBundler {
     protected int              curr;
 
     public SimplifiedTransferQueueBundler() {
-    }
-
-    public SimplifiedTransferQueueBundler(int capacity) {
-        super(new ArrayBlockingQueue<>(Util.assertPositive(capacity, "bundler capacity cannot be " + capacity)));
     }
 
     public int size() {

--- a/src/org/jgroups/protocols/TransferQueueBundler.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler.java
@@ -1,6 +1,5 @@
 package org.jgroups.protocols;
 
-
 import org.jgroups.Message;
 import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
@@ -42,14 +41,6 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
     protected static final String    THREAD_NAME="TQ-Bundler";
 
     public TransferQueueBundler() {
-    }
-
-    protected TransferQueueBundler(BlockingQueue<Message> queue) {
-        this.queue=queue;
-    }
-
-    public TransferQueueBundler(int capacity) {
-        this(new ArrayBlockingQueue<>(Util.assertPositive(capacity, "bundler capacity cannot be " + capacity)));
     }
 
     public Thread                getThread()             {return bundler_thread;}


### PR DESCRIPTION
Because it doesn't work as it's overwritten in start