### PR TITLE
Refactor use of asIterator() to reduce required android SDK on master

### DIFF
--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -4741,7 +4741,10 @@ public class Util {
             for(NetworkInterface intf: interfaces) {
                 if(!isUp(intf)  /*!intf.isUp()*/)
                     continue;
-                intf.getInetAddresses().asIterator().forEachRemaining(addresses::add);
+                    Enumeration<InetAddress> inetAddresses = intf.getInetAddresses();
+                    while (inetAddresses.hasMoreElements()) {
+                        addresses.add(inetAddresses.nextElement());
+                    }
             }
         }
         catch(SocketException e) {


### PR DESCRIPTION
[asIterator](https://developer.android.com/reference/java/util/Enumeration#asIterator()) was introduced in android API 33. This restricts usage on older devices. 

This change was introduced in 5.3.2. There are network detection issues that existed in 5.3.1 but that were resolved between 5.3.2 and 5.3.9. 

Same as other pull request only targeting master