### PR TITLE
Fix NPE when data is null in Discovery

### DIFF
--- a/src/org/jgroups/protocols/Discovery.java
+++ b/src/org/jgroups/protocols/Discovery.java
@@ -361,7 +361,7 @@ public abstract class Discovery extends Protocol {
                 if(max_rank_to_reply > 0 && hdr.initialDiscovery() && Util.getRank(view, local_addr) > max_rank_to_reply)
                     return null;
                 // Only send a response if hdr.mbrs is not empty and contains myself. Otherwise, always send my info
-                if(data.stream().anyMatch(pd -> pd.mbrs() != null && pd.mbrs().contains(local_addr)))
+                if (data != null && data.stream().map(PingData::mbrs).filter(Objects::nonNull).anyMatch(mbrs -> mbrs.contains(local_addr)))
                     return null;
                 PhysicalAddress physical_addr=(PhysicalAddress)down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
                 PingData p=new PingData(local_addr, is_server, NameCache.get(local_addr), physical_addr).coord(is_coord);


### PR DESCRIPTION
We are getting this exception in runtime when application starts and discovery is scheduled.

```
Exception in thread "jgroups-6,aaaaaaaaaaaa-1111" java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "data" is null
	at org.jgroups.protocols.Discovery.handle(Discovery.java:364)
	at org.jgroups.protocols.Discovery.up(Discovery.java:299)
	at org.jgroups.protocols.TP.passMessageUp(TP.java:1188)
	at org.jgroups.util.SubmitToThreadPool$SingleLoopbackHandler.run(SubmitToThreadPool.java:77)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Reason for that might be a regression after refactoring: null-check for data was removed and stream method cannot be called anymore.