### PR TITLE
[5.2.x] JGRP-2835 Do not log warn during normal shutdown.

### DIFF
--- a/src/org/jgroups/protocols/TransferQueueBundler.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler.java
@@ -88,7 +88,12 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
         if(tmp != null) {
             tmp.interrupt();
             if(tmp.isAlive()) {
-                try {tmp.join(500);} catch(InterruptedException e) {}
+                try {
+                    tmp.join(500);
+                }
+                catch(InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
         drain();
@@ -110,7 +115,7 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
     }
 
     public void run() {
-        while(running) {
+        while(!Thread.currentThread().isInterrupted()) {
             Message msg=null;
             try {
                 if((msg=queue.take()) == null)
@@ -131,6 +136,9 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
                     avg_fill_count.add(count);
                     sendBundledMessages();
                 }
+            }
+            catch(InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
             catch(Throwable t) {
                 log.warn("%s: failed sending message: %s", transport.addr(), t);

--- a/src/org/jgroups/protocols/TransferQueueBundler2.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler2.java
@@ -138,7 +138,12 @@ public class TransferQueueBundler2 implements Bundler, Runnable {
         if(tmp != null) {
             tmp.interrupt();
             if(tmp.isAlive()) {
-                try {tmp.join(500);} catch(InterruptedException e) {}
+                try {
+                    tmp.join(500);
+                }
+                catch(InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
         drain();
@@ -154,7 +159,7 @@ public class TransferQueueBundler2 implements Bundler, Runnable {
     }
 
     public void run() {
-        while(running) {
+        while(!Thread.currentThread().isInterrupted()) {
             Message msg=null;
             try {
                 if((msg=queue.take()) == null)
@@ -179,7 +184,11 @@ public class TransferQueueBundler2 implements Bundler, Runnable {
                     sendBundledMessages();
                 }
             }
+            catch(InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             catch(Throwable t) {
+                log.warn("%s: failed sending message: %s", transport.addr(), t);
             }
         }
     }


### PR DESCRIPTION
Fix interrupt handling.

https://issues.redhat.com/browse/JGRP-2835