### PR TITLE
JGRP-2838 Fix infinite loop in TCP when using use_acks

### DIFF
--- a/src/org/jgroups/blocks/cs/BaseServer.java
+++ b/src/org/jgroups/blocks/cs/BaseServer.java
@@ -17,6 +17,7 @@ import java.io.Closeable;
 import java.io.DataInput;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -302,11 +303,12 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
             try {
                 conn=getConnection(dest);
             }
-            catch(ConnectException | SSLException ex) {
+            catch(ConnectException | SocketTimeoutException | SSLException ex) {
                 throw ex;
             }
             catch(Exception ise) {
                 Util.sleepRandom(1, 100);
+                log.trace("%s: retrying connection to %s", local_addr, dest);
             }
         }
         while(!connected(conn));


### PR DESCRIPTION
```
2024-10-01 11:42:50.266+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: failed connecting to 10.244.15.77:7800: java.net.SocketTimeoutException: Connect timed out
2024-10-01 11:42:50.266+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: removed connection to 10.244.15.77:7800
2024-10-01 11:42:50.348+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: connecting to 10.244.15.77:7800
2024-10-01 11:42:52.351+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: failed connecting to 10.244.15.77:7800: java.net.SocketTimeoutException: Connect timed out
2024-10-01 11:42:52.351+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: removed connection to 10.244.15.77:7800
2024-10-01 11:42:52.395+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: connecting to 10.244.15.77:7800
2024-10-01 11:42:54.398+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: failed connecting to 10.244.15.77:7800: java.net.SocketTimeoutException: Connect timed out
2024-10-01 11:42:54.398+0000 [TQ-Bundler-7,app,app-5b57dcfd44-2n7wf-59692] TRACE org.jgroups.protocols.TCP [] [] - [trace] 10.244.8.175:7800: removed connection to 10.244.15.77:7800
```