### PR TITLE
add set cache method in Util

### DIFF
--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -4742,6 +4742,14 @@ public class Util {
             CACHED_ADDRESSES=null;
     }
 
+    /** This is a workaround for use within android. Sometimes the standard java methods do not return all the addresses. 
+     * This will allow for setting in android via the conectivity manager without needing to pass in the context.
+     * Also will allow android to update as connectivity changes.
+     */
+    public static void setCacheAddresses(List<NetworkInterface> interfaces, List<InetAddress> addresses) {
+        CACHED_INTERFACES=interfaces;
+        CACHED_ADDRESSES=addresses;
+    }
     /** Returns all addresses of all interfaces (that are up) that satisfy a given filter (ignored if null) */
     public static Collection<InetAddress> getAllAvailableAddresses(Predicate<InetAddress> filter) {
         Collection<InetAddress> cached_addresses=getAllAvailableAddresses();


### PR DESCRIPTION
When used on android mobile devices the standard java.net, network interfaces and address classes does not match the state of the Connectivity manager. for example when connectivity manager make a call back saying that an ip is available, Util.checkIfValidAddress(it,"") will throw an exception saying it is not valid. This is the case even if Util.resetCacheAddresses(true,true) is called first

Adding this method allow for the connectivity manager to make a call back like the following:
```kotlin
val networkCallback =  object : NetworkCallback() {
        override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
            linkProperties.linkAddresses.forEach {
                Log.d(TAG, "Link Address: ${it.address}")
            // This in theory, should be called when the network changes and should update to the most current.
            // Android for some reason does not reflect all the changes through the JDK
            Util.resetCacheAddresses(true,true)
            Log.d(TAG, "Valid Java Interfaces: ${Util.getAllAvailableInterfaces()}")
            Log.d(TAG, "Valid Java Address: ${Util.getAllAvailableAddresses(null)}")

            //This is a workaround to get the correct address that android does not reflect via the JDK
            Util.setCacheAddresses(
                // filtering may not be necessary. was beneficial in my case
                Util.getAllAvailableInterfaces().filter { it.supportsMulticast() }, 
                linkProperties.linkAddresses.map{it.address}.filter{it.isLinkLocalAddress.not() && it.isLoopbackAddress.not()}
            )

            // sanity check
            v4.forEach {
                Log.d(TAG, "Checking Link Address: ${it.hostAddress}")
                Util.checkIfValidAddress(it,"CHECK")
            }
            Log.d(TAG, "Valid Android Interfaces: ${Util.getAllAvailableInterfaces()}")
            Log.d(TAG, "Valid Android Address: ${Util.getAllAvailableAddresses(null)}")
        }

        override fun onAvailable(network: Network) {
            //Actions to take with connection available.
        }

        override fun onLost(network: Network) {
            //Actions to take with lost connection.
        }
    }

 connectivityManager.registerNetworkCallback(
            NetworkRequest.Builder().build(),
            networkCallback
        )
```