### PR TITLE
JGRP-2847 Simplify for custom transports to send to multiple destinations

### DIFF
--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -1381,6 +1381,7 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
             }
         }
 
+        List<PhysicalAddress> dests = new ArrayList<>(mbrs.size());
         for(Address mbr: mbrs) {
             if(local_send_successful && local_transport != null && local_transport.isLocalMember(mbr))
                 continue; // skip if local transport sent the message successfully
@@ -1392,19 +1393,27 @@ public abstract class TP extends Protocol implements DiagnosticsHandler.ProbeHan
                 missing.add(mbr);
                 continue;
             }
-            try {
-                if(!Objects.equals(local_physical_addr, target))
-                    sendUnicast(target, buf, offset, length);
-            }
-            catch(SocketException | SocketTimeoutException sock_ex) {
-                log.debug(Util.getMessage("FailureSendingToPhysAddr"), local_addr, mbr, sock_ex);
-            }
-            catch(Throwable t) {
-                log.error(Util.getMessage("FailureSendingToPhysAddr"), local_addr, mbr, t);
-            }
+            if (!Objects.equals(local_physical_addr, target))
+                dests.add(target);
         }
+        if (!dests.isEmpty())
+            sendUnicasts(dests, buf, offset, length);
         if(missing != null)
             fetchPhysicalAddrs(missing);
+    }
+
+    protected void sendUnicasts(List<PhysicalAddress> dests, byte[] data, int offset, int length) throws Exception {
+        for(PhysicalAddress dest: dests) {
+            try {
+                sendUnicast(dest, data, offset, length);
+            }
+            catch(SocketException | SocketTimeoutException sock_ex) {
+                log.debug(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, sock_ex);
+            }
+            catch(Throwable t) {
+                log.error(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, t);
+            }
+        }
     }
 
 


### PR DESCRIPTION
This change gives a convenient method to override to allow a custom transport to convert data (to e.g. a direct buffer) only once before sending to multiple destinations