### PR TITLE
Minor logging tweaks

### DIFF
--- a/src/org/jgroups/protocols/NAKACK4.java
+++ b/src/org/jgroups/protocols/NAKACK4.java
@@ -92,7 +92,7 @@ public class NAKACK4 extends ReliableMulticast {
         super.init();
         if(ack_threshold <= 0) {
             ack_threshold=capacity / 4;
-            log.info("defaulted ack_threshold to %d", ack_threshold);
+            log.debug("defaulted ack_threshold to %d", ack_threshold);
         }
     }
 

--- a/src/org/jgroups/protocols/UNICAST4.java
+++ b/src/org/jgroups/protocols/UNICAST4.java
@@ -93,7 +93,7 @@ public class UNICAST4 extends ReliableUnicast {
         super.init();
         if(ack_threshold <= 0) {
             ack_threshold=capacity / 4;
-            log.info("defaulted ack_threshold to %d", ack_threshold);
+            log.debug("defaulted ack_threshold to %d", ack_threshold);
         }
     }
 

--- a/src/org/jgroups/protocols/UnicastHeader.java
+++ b/src/org/jgroups/protocols/UnicastHeader.java
@@ -77,12 +77,13 @@ public class UnicastHeader extends Header {
     public UnicastHeader  timestamp(int ts)  {timestamp=ts; return this;}
 
     public String toString() {
-        StringBuilder sb=new StringBuilder();
+        StringBuilder sb=new StringBuilder("[");
         sb.append(type2Str(type)).append(", seqno=").append(seqno);
         sb.append(", conn_id=").append(conn_id);
         if(first) sb.append(", first");
         if(timestamp != 0)
             sb.append(", ts=").append(timestamp);
+        sb.append("]");
         return sb.toString();
     }
 

--- a/src/org/jgroups/protocols/UnicastHeader3.java
+++ b/src/org/jgroups/protocols/UnicastHeader3.java
@@ -76,12 +76,13 @@ public class UnicastHeader3 extends Header {
     public UnicastHeader3 timestamp(int ts) {timestamp=ts; return this;}
 
     public String toString() {
-        StringBuilder sb=new StringBuilder();
+        StringBuilder sb=new StringBuilder("[");
         sb.append(type2Str(type)).append(", seqno=").append(seqno);
         if(conn_id != 0) sb.append(", conn_id=").append(conn_id);
         if(first) sb.append(", first");
         if(timestamp != 0)
             sb.append(", ts=").append(timestamp);
+        sb.append("]");
         return sb.toString();
     }
 


### PR DESCRIPTION
This change makes UnicastHeader/3 toString() consistent with most other headers by wrapping in "[]" And changes two logs for new UNICAST4/NAKACK4 to debug to not be logged by default