### PR TITLE
JGRP-2848 Composite message additions

### DIFF
--- a/src/org/jgroups/BaseMessage.java
+++ b/src/org/jgroups/BaseMessage.java
@@ -238,6 +238,19 @@ public abstract class BaseMessage implements Message {
 
         retval+=Global.SHORT_SIZE;  // number of headers
         retval+=Headers.marshalledSize(this.headers);
+        retval+=payloadSize();
+        return retval;
+    }
+
+    public int sizeNoAddrs(Address src) {
+        int retval=Global.BYTE_SIZE // leading byte
+          + Global.SHORT_SIZE;      // flags
+        if(sender != null && !sender.equals(src))
+            retval+=Util.size(sender);
+
+        retval+=Global.SHORT_SIZE;  // number of headers
+        retval+=Headers.marshalledSize(this.headers);
+        retval+=payloadSize();
         return retval;
     }
 
@@ -274,7 +287,7 @@ public abstract class BaseMessage implements Message {
     public void writeToNoAddrs(Address src, DataOutput out) throws IOException {
         byte leading=0;
 
-        boolean write_src_addr=src == null || sender != null && !sender.equals(src);
+        boolean write_src_addr=sender != null && !sender.equals(src);
 
         if(write_src_addr)
             leading=Util.setFlag(leading, SRC_SET);
@@ -341,5 +354,5 @@ public abstract class BaseMessage implements Message {
         return size > 0? new Header[size] : new Header[Util.DEFAULT_HEADERS];
     }
 
-
+    protected abstract int payloadSize();
 }

--- a/src/org/jgroups/BatchMessage.java
+++ b/src/org/jgroups/BatchMessage.java
@@ -118,12 +118,12 @@ public class BatchMessage extends BaseMessage implements Iterable<Message> {
         return String.format("%s, %d message(s)", super.toString(), getNumberOfMessages());
     }
 
-    public int size() {
-        int retval=super.size() + Global.INT_SIZE;
+    @Override protected int payloadSize() {
+        int retval=Global.INT_SIZE; // count
         retval+=Util.size(orig_src);
         if(msgs != null) {
             for(int i=0; i < index; i++)
-                retval+=msgs[i].size() + Global.SHORT_SIZE; // type
+                retval+=msgs[i].sizeNoAddrs(getSrc()) + Global.SHORT_SIZE; // type
         }
         return retval;
     }
@@ -140,7 +140,7 @@ public class BatchMessage extends BaseMessage implements Iterable<Message> {
             for(int i=0; i < index; i++) {
                 Message msg=msgs[i];
                 out.writeShort(msg.getType());
-                msg.writeToNoAddrs(this.src(), out);
+                msg.writeToNoAddrs(getSrc(), out);
             }
         }
     }

--- a/src/org/jgroups/BytesMessage.java
+++ b/src/org/jgroups/BytesMessage.java
@@ -227,11 +227,6 @@ public class BytesMessage extends BaseMessage {
     }
 
 
-    public int size() {
-        return super.size() +sizeOfPayload();
-    }
-
-
     /**
      * Copies the byte array. If offset and length are used (to refer to another array), the copy will contain only
      * the subset that offset and length point to, copying the subset into the new copy.<p/>
@@ -245,7 +240,7 @@ public class BytesMessage extends BaseMessage {
         return copy;
     }
 
-    protected int sizeOfPayload() {
+    @Override protected int payloadSize() {
         int retval=Global.INT_SIZE; // length
         if(array != null)
             retval+=length;         // number of bytes in the array

--- a/src/org/jgroups/CompositeMessage.java
+++ b/src/org/jgroups/CompositeMessage.java
@@ -3,7 +3,6 @@ package org.jgroups;
 
 
 import org.jgroups.util.ByteArray;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -118,11 +117,11 @@ public class CompositeMessage extends BaseMessage implements Iterable<Message> {
         return String.format("%s, %d message(s)", super.toString(), getNumberOfMessages());
     }
 
-    public int size() {
-        int retval=super.size() + Global.INT_SIZE; // length
+    @Override protected int payloadSize() {
+        int retval=Global.INT_SIZE; // count
         if(msgs != null) {
             for(int i=0; i < index; i++)
-                retval+=msgs[i].size() + Global.SHORT_SIZE; // type
+                retval+=msgs[i].sizeNoAddrs(getSrc()) + Global.SHORT_SIZE; // type
         }
         return retval;
     }
@@ -142,8 +141,7 @@ public class CompositeMessage extends BaseMessage implements Iterable<Message> {
             for(int i=0; i < index; i++) {
                 Message msg=msgs[i];
                 out.writeShort(msg.getType());
-                // msg.writeToNoAddrs(src(), out);
-                msg.writeTo(out);
+                msg.writeToNoAddrs(getSrc(), out);
             }
         }
     }
@@ -156,7 +154,7 @@ public class CompositeMessage extends BaseMessage implements Iterable<Message> {
                 short type=in.readShort();
                 Message msg=MessageFactory.create(type).setDest(getDest());
                 if(msg.getSrc() == null)
-                    msg.setSrc(src());
+                    msg.setSrc(getSrc());
                 msg.readFrom(in);
                 msgs[i]=msg;
             }

--- a/src/org/jgroups/EmptyMessage.java
+++ b/src/org/jgroups/EmptyMessage.java
@@ -40,4 +40,6 @@ public class EmptyMessage extends BaseMessage {
     public void                  readPayload(DataInput in) throws IOException, ClassNotFoundException {
         // no payload to read
     }
+
+    protected int                payloadSize() { return 0; }
 }

--- a/src/org/jgroups/FragmentedMessage.java
+++ b/src/org/jgroups/FragmentedMessage.java
@@ -35,7 +35,7 @@ public class FragmentedMessage extends BytesMessage { // we need the superclass'
     public boolean           hasArray()           {return false;}
     public boolean           hasPayload()         {return true;}
     public Supplier<Message> create()             {return FragmentedMessage::new;}
-    protected int            sizeOfPayload()      {return Global.INT_SIZE + length;}
+    protected int            payloadSize()        {return Global.INT_SIZE + length;}
 
     @Override
     protected Message copyPayload(Message copy) {

--- a/src/org/jgroups/LongMessage.java
+++ b/src/org/jgroups/LongMessage.java
@@ -60,8 +60,8 @@ public class LongMessage extends BaseMessage {
         value=Bits.readLongCompressed(in);
     }
 
-    public int size() {
-        return super.size() + Bits.size(value);
+    @Override protected int payloadSize() {
+        return Bits.size(value);
     }
 
     public String toString() {

--- a/src/org/jgroups/Message.java
+++ b/src/org/jgroups/Message.java
@@ -204,6 +204,9 @@ public interface Message extends SizeStreamable, Constructable<Message> {
      */
     int                  size();
 
+    /** Returns the exact size of the marshalled message without destination (and possibly source) address */
+    int                  sizeNoAddrs(Address src);
+
     /** Writes the message to an output stream excluding the destination (and possibly source) address */
     void                 writeToNoAddrs(Address src, DataOutput out) throws IOException;
 

--- a/src/org/jgroups/NioMessage.java
+++ b/src/org/jgroups/NioMessage.java
@@ -179,8 +179,6 @@ public class NioMessage extends BaseMessage {
 
     /* ----------------------------------- Interface Streamable  ------------------------------- */
 
-    public int size() {return super.size() +sizeOfPayload();}
-
     public String toString() {
         return String.format("%s %s", super.toString(), use_direct_memory_for_allocations? "(direct)" : "");
     }
@@ -191,7 +189,7 @@ public class NioMessage extends BaseMessage {
         return copy;
     }
 
-    protected int sizeOfPayload() {
+    @Override protected int payloadSize() {
         return Global.INT_SIZE + getLength() + Global.BYTE_SIZE; // for use_direct_memory_for_allocations
     }
 

--- a/src/org/jgroups/ObjectMessage.java
+++ b/src/org/jgroups/ObjectMessage.java
@@ -67,7 +67,7 @@ public class ObjectMessage extends BaseMessage {
     public boolean           hasPayload()                         {return obj != null;}
     public boolean           hasArray()                           {return false;}
     public int               getOffset()                          {return 0;}
-    public int               getLength()                          {return obj != null? objSize() : 0;}
+    public int               getLength()                          {return obj != null? payloadSize() : 0;}
     public byte[]            getArray()                           {throw new UnsupportedOperationException();}
     public ObjectMessage     setArray(byte[] b, int off, int len) {throw new UnsupportedOperationException();}
     public ObjectMessage     setArray(ByteArray buf)              {throw new UnsupportedOperationException();}
@@ -132,10 +132,6 @@ public class ObjectMessage extends BaseMessage {
         return isWrapped() || obj instanceof ObjectWrapperPrimitive? ((ObjectWrapperPrimitive)obj).getObject() : (T)obj;
     }
 
-    public int size() {
-        return super.size() + objSize();
-    }
-
     public void writePayload(DataOutput out) throws IOException {
         Util.writeGenericStreamable(obj, out);
     }
@@ -157,7 +153,7 @@ public class ObjectMessage extends BaseMessage {
         return super.toString() + String.format(", obj: %s", obj);
     }
 
-    protected int objSize() {
+    @Override protected int payloadSize() {
         return Util.size(obj);
     }
 }

--- a/src/org/jgroups/protocols/RingBufferBundler.java
+++ b/src/org/jgroups/protocols/RingBufferBundler.java
@@ -204,7 +204,7 @@ public class RingBufferBundler extends BaseBundler {
             if(msg != null && Objects.equals(dest, msg.getDest())) {
                 if(list != null)
                     list.add(msg);
-                int size=msg.size() + Global.SHORT_SIZE;
+                int size=msg.sizeNoAddrs(msg.getSrc()) + Global.SHORT_SIZE;
                 if(bytes + size > max_bundle_size)
                     break;
                 bytes+=size;

--- a/src/org/jgroups/protocols/RingBufferBundlerLockless.java
+++ b/src/org/jgroups/protocols/RingBufferBundlerLockless.java
@@ -222,7 +222,7 @@ public class RingBufferBundlerLockless extends BaseBundler {
         while(available_msgs > 0) {
             Message msg=buf[start_index];
             if(msg != null && Objects.equals(dest, msg.getDest())) {
-                int msg_size=msg.size() + Global.SHORT_SIZE;;
+                int msg_size=msg.sizeNoAddrs(msg.getSrc()) + Global.SHORT_SIZE;;
                 if(bytes + msg_size > max_bundle_size)
                     break;
                 bytes+=msg_size;

--- a/src/org/jgroups/protocols/RingBufferBundlerLockless2.java
+++ b/src/org/jgroups/protocols/RingBufferBundlerLockless2.java
@@ -207,7 +207,7 @@ public class RingBufferBundlerLockless2 extends BaseBundler {
         for(int i=start_index; i != end_index; i=increment(i)) {
             Message msg=buf[i];
             if(msg != null && msg != NULL_MSG && Objects.equals(dest, msg.getDest())) {
-                int msg_size=msg.size() + Global.SHORT_SIZE;
+                int msg_size=msg.sizeNoAddrs(msg.getSrc()) + Global.SHORT_SIZE;
                 if(bytes + msg_size > max_bundle_size)
                     break;
                 bytes+=msg_size;

--- a/tests/junit-functional/org/jgroups/tests/MessageFactoryTest.java
+++ b/tests/junit-functional/org/jgroups/tests/MessageFactoryTest.java
@@ -87,5 +87,9 @@ public class MessageFactoryTest {
 
         public void readPayload(DataInput in) throws IOException, ClassNotFoundException {
         }
+
+        protected int payloadSize() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
This change borrows the optimization from BatchMessage to not serialize dest and src for each message
This also fixes incorrect size being reported for BatchMessage and in various places where Message.writeToNoAddrs is used.