### PR TITLE
JGRP-2868 Util#loadClass throw NPE when getContextClassLoader is null

### DIFF
--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -3367,9 +3367,9 @@ public class Util {
      */
     public static Class<?> loadClass(String classname, ClassLoader preferredLoader) throws ClassNotFoundException {
         ClassNotFoundException exception = null;
-        List<ClassLoader> list=preferredLoader != null?
-          Arrays.asList(preferredLoader, Thread.currentThread().getContextClassLoader(), ClassLoader.getSystemClassLoader()) :
-          Arrays.asList(Thread.currentThread().getContextClassLoader(), ClassLoader.getSystemClassLoader());
+        List<ClassLoader> list = Stream.of(preferredLoader, Thread.currentThread().getContextClassLoader(), ClassLoader.getSystemClassLoader())
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
         for(ClassLoader loader: list) {
             try {
                 return loader.loadClass(classname);


### PR DESCRIPTION
https://issues.redhat.com/browse/JGRP-2868

@belaban We need this for 5.4.x and 5.3.x