### PR TITLE
JGRP-2869 Failure detection protocol using existing sockets in TCP/TCP_NIO2

### DIFF
--- a/conf/jg-protocol-ids.xml
+++ b/conf/jg-protocol-ids.xml
@@ -65,6 +65,7 @@
     <class id="76" name="org.jgroups.protocols.NAKACK3"/>
     <class id="77" name="org.jgroups.protocols.NAKACK4"/>
     <class id="78" name="org.jgroups.protocols.UNICAST4"/>
+    <class id="79" name="org.jgroups.protocols.FD_SOCK3"/>
 
     <!-- IDs reserved for building blocks -->
     <class id="200" name="org.jgroups.blocks.RequestCorrelator"/> <!-- ID should be the same as Global.BLOCKS_START_ID -->

--- a/src/org/jgroups/Event.java
+++ b/src/org/jgroups/Event.java
@@ -54,6 +54,7 @@ public class Event {
     public static final int INSTALL_MERGE_VIEW                 = 114; // arg = MergeView
     public static final int IS_LOCAL_SITEMASTER                = 115; // arg = SiteMaster(site), returns true / false
     public static final int IS_LOCAL                           = 116; // arg = SiteAddress(site), returns true / false
+    public static final int MBR_DISCONNECTED                   = 117; // arg = Address (member)
 
     public static final int USER_DEFINED                       = 1000; // arg = <user def., e.g. evt type + data>
 

--- a/src/org/jgroups/protocols/FD_SOCK3.java
+++ b/src/org/jgroups/protocols/FD_SOCK3.java
@@ -1,0 +1,142 @@
+package org.jgroups.protocols;
+
+import java.util.Collection;
+import java.util.List;
+import org.jgroups.Address;
+import org.jgroups.Event;
+import org.jgroups.Membership;
+import org.jgroups.View;
+import org.jgroups.annotations.MBean;
+import org.jgroups.annotations.ManagedAttribute;
+import org.jgroups.annotations.ManagedOperation;
+import org.jgroups.conf.AttributeType;
+import org.jgroups.stack.Protocol;
+import org.jgroups.util.BoundedList;
+import org.jgroups.util.Util;
+
+/**
+ * Failure detection protocol based on disconnection events from TCP based transports.
+ * @author Christian Fredriksson
+ * @since 5.4.6
+ */
+@MBean(description="Failure detection protocol based on sockets connecting members")
+public class FD_SOCK3 extends Protocol {
+
+    @ManagedAttribute(description="Number of suspect events emitted",type=AttributeType.SCALAR)
+    protected int                            num_suspect_events;
+
+    @ManagedAttribute(description="True when this member is leaving the cluster, set to false when joining")
+    protected volatile boolean               shutting_down;
+
+    @ManagedAttribute(description="List of the current cluster members")
+    protected final Membership               members=new Membership();
+
+    @ManagedAttribute(description="List of currently suspected members")
+    protected final Membership               suspected_mbrs=new Membership();
+
+
+    protected final BoundedList<String>      suspect_history=new BoundedList<>(20);
+
+
+    public FD_SOCK3() {
+    }
+
+
+    @ManagedAttribute(description="The number of currently suspected members")
+    public int         getNumSuspectedMembers()          {return suspected_mbrs.size();}
+
+    @ManagedOperation(description="Print suspect history")
+    public String printSuspectHistory() {return String.join("\n", suspect_history);}
+
+
+    @Override
+    public void init() throws Exception {
+        TP tp=getTransport();
+        if(!(tp instanceof BasicTCP))
+            throw new IllegalStateException("FD_SOCK3 can only be used with TCP or TCP_NIO2");
+        if(((BasicTCP)tp).getConnExpireTime() > 0)
+            throw new IllegalStateException("FD_SOCK3 cannot be used with connection reaping");
+    }
+
+    @Override
+    public void stop() {
+        suspected_mbrs.clear();
+    }
+
+    public void resetStats() {
+        super.resetStats();
+        num_suspect_events=0;
+        suspect_history.clear();
+    }
+
+    @Override
+    public Object down(Event evt) {
+        switch(evt.getType()) {
+
+            case Event.UNSUSPECT:
+                unsuspect(evt.getArg());
+                break;
+
+            case Event.CONNECT:
+            case Event.CONNECT_WITH_STATE_TRANSFER:
+                shutting_down=false;
+                break;
+
+            case Event.DISCONNECT:
+                shutting_down=true;
+                break;
+
+            case Event.VIEW_CHANGE:
+                Object ret=down_prot.down(evt);
+                handleView(evt.arg());
+                return ret;
+        }
+        return down_prot.down(evt);
+    }
+
+    @Override
+    public Object up(Event evt) {
+        switch(evt.getType()) {
+            case Event.MBR_DISCONNECTED:
+                handleMbrDisconnected(evt.getArg());
+                break;
+        }
+        return up_prot.up(evt);
+    }
+
+    protected void handleView(View v) {
+        final List<Address> new_mbrs=v.getMembers();
+        members.set(new_mbrs);
+        suspected_mbrs.retainAll(new_mbrs);
+    }
+
+    protected void handleMbrDisconnected(Address member) {
+        if (!shutting_down)
+            suspect(member);
+    }
+
+    protected void suspect(Address suspect) {
+
+        suspect_history.add(String.format("%s: %s", Util.utcNow(), suspect));
+        suspected_mbrs.add(suspect);
+        Collection<Address> suspects_copy=suspected_mbrs.getMembers(); // returns a copy
+        if(suspects_copy.isEmpty())
+            return;
+
+        // Check if we're coord, then send up the stack, make a copy (https://issues.redhat.com/browse/JGRP-2552)
+        Membership eligible_mbrs=this.members.copy().remove(suspected_mbrs.getMembers());
+        if(eligible_mbrs.isCoord(local_addr)) {
+            log.debug("%s: suspecting %s", local_addr, suspects_copy);
+            up_prot.up(new Event(Event.SUSPECT, suspects_copy));
+            down_prot.down(new Event(Event.SUSPECT, suspects_copy));
+            if (stats)
+                num_suspect_events++;
+        }
+    }
+
+    protected void unsuspect(Address mbr) {
+        if(mbr == null)
+            return;
+        suspected_mbrs.remove(mbr);
+    }
+}

--- a/src/org/jgroups/protocols/TCP.java
+++ b/src/org/jgroups/protocols/TCP.java
@@ -131,6 +131,7 @@ public class TCP extends BasicTCP {
           .socketConnectionTimeout(sock_conn_timeout)
           .tcpNodelay(tcp_nodelay).linger(linger)
           .clientBindAddress(client_bind_addr).clientBindPort(client_bind_port).deferClientBinding(defer_client_bind_addr)
+          .addConnectionListener(this)
           .log(this.log).logDetails(this.log_details);
 
         if(send_buf_size > 0)

--- a/src/org/jgroups/protocols/TCP_NIO2.java
+++ b/src/org/jgroups/protocols/TCP_NIO2.java
@@ -1,4 +1,3 @@
-
 package org.jgroups.protocols;
 
 import org.jgroups.Address;
@@ -110,6 +109,7 @@ public class TCP_NIO2 extends BasicTCP {
           .socketConnectionTimeout(sock_conn_timeout)
           .tcpNodelay(tcp_nodelay).linger(linger)
           .clientBindAddress(client_bind_addr).clientBindPort(client_bind_port).deferClientBinding(defer_client_bind_addr)
+          .addConnectionListener(this)
           .log(this.log).logDetails(log_details);
         server.maxSendBuffers(max_send_buffers).usePeerConnections(true);
         server.copyOnPartialWrite(this.copy_on_partial_write).readerIdleTime(this.reader_idle_time);


### PR DESCRIPTION
Here's a proposal for a very simple failure detection protocol which is based on disconnection events from the existing sockets in TCP/TCP_NIO2.
It will only work with TCP/TCP_NIO2 but unlike FD_SOCK2 it does not require any additional ports to be opened.
Please provide feedback and if this makes sense to merge, also let me know how I add any neccessary documentation.