### PR TITLE
JDBC_PING2 null address with ExtendedUUID

### DIFF
--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -1920,7 +1920,7 @@ public class Util {
             return String.format("%s%s:%s:%s", SITE_UUID_PREFIX, su.toStringLong(), su.getName(), su.getSite());
         }
         Class<? extends Address> cl=addr.getClass();
-        if(UUID.class.equals(cl))
+        if(UUID.class.equals(cl) || ExtendedUUID.class.equals(cl))
             return String.format("%s%s", UUID_PREFIX, ((UUID)addr).toStringLong());
         if(IpAddress.class.equals(cl))
             return String.format("%s%s", IP_PREFIX, addr);


### PR DESCRIPTION
Upgrading from 5.2.29 to 5.4.6, successfully implemented NAKACK4 and UNICAST4.
Changing from JDBC_PING to JDBC_PING2 get the error "Cannot insert the value NULL into column 'ADDRESS'"
at org.jgroups.protocols.JDBC_PING2.insert(JDBC_PING2.java:353) ~[jgroups-5.4.6.Final.jar:5.4.6.Final]

Investigation showed that Util.addressToString() returning null because addr.getClass() is ExtendedUUID and not a UUID.
