### PR TITLE
Improvement for DataInput/DataOutput

### DIFF
--- a/src/org/jgroups/util/ByteArrayDataInputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataInputStream.java
@@ -168,48 +168,39 @@ public class ByteArrayDataInputStream extends InputStream implements DataInput {
     }
 
     public short readShort() throws IOException {
-        int ch1=read();
-        int ch2=read();
-        if ((ch1 | ch2) < 0)
-            throw new EOFException();
-        return (short)((ch1 << 8) + (ch2 << 0));
+        return (short) readUnsignedShort();
     }
 
     public int readUnsignedShort() throws IOException {
-        int ch1=read();
-        int ch2=read();
-        if ((ch1 | ch2) < 0)
-            throw new EOFException();
-        return (ch1 << 8) + (ch2 << 0);
+        var index = pos;
+        var array = buf;
+        if (index + 2 > limit) {
+            throw new IOException();
+        }
+        pos += 2;
+        return ((array[index] & 0xFF) << 8) + (array[index + 1] & 0xFF);
     }
 
     public char readChar() throws IOException {
-        int ch1=read();
-        int ch2=read();
-        if ((ch1 | ch2) < 0)
-            throw new EOFException();
-        return (char)((ch1 << 8) + (ch2 << 0));
+        return (char) readUnsignedShort();
     }
 
     public int readInt() throws IOException {
-        int ch1=read();
-        int ch2=read();
-        int ch3=read();
-        int ch4=read();
-        if ((ch1 | ch2 | ch3 | ch4) < 0)
-            throw new EOFException();
-        return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+        var index = pos;
+        if (index + 4 > limit) {
+            throw new IOException();
+        }
+        pos += 4;
+        return (int) Util.INT_ARRAY_VIEW.get(buf, index);
     }
 
     public long readLong() throws IOException {
-        return (((long)read() << 56) +
-          ((long)(read() & 0xff) << 48) +
-          ((long)(read() & 0xff) << 40) +
-          ((long)(read() & 0xff) << 32) +
-          ((long)(read() & 0xff) << 24) +
-          ((read() & 0xff) << 16) +
-          ((read() & 0xff) <<  8) +
-          ((read() & 0xff) <<  0));
+        var index = pos;
+        if (index + 8 > limit) {
+            throw new IOException();
+        }
+        pos += 8;
+        return (long) Util.LONG_ARRAY_VIEW.get(buf, index);
     }
 
     public float readFloat() throws IOException {

--- a/src/org/jgroups/util/ByteArrayDataOutputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataOutputStream.java
@@ -35,6 +35,34 @@ public class ByteArrayDataOutputStream extends BaseDataOutputStream {
     public boolean                   growExponentially()          {return grow_exponentially;}
     public ByteArrayDataOutputStream growExponentially(boolean b) {grow_exponentially=b; return this;}
 
+    @Override
+    public void writeChar(int v) {
+        writeShort((short) v);
+    }
+
+    @Override
+    public void writeInt(int v) {
+        ensureCapacity(4);
+        Util.INT_ARRAY_VIEW.set(buf, pos, v);
+        pos += 4;
+    }
+
+    @Override
+    public void writeLong(long v) {
+        ensureCapacity(8);
+        Util.LONG_ARRAY_VIEW.set(buf, pos, v);
+        pos += 8;
+    }
+
+    @Override
+    public void writeShort(int v) {
+        ensureCapacity(2);
+        var array = buf;
+        var index = pos;
+        array[index] = (byte) ((v >> 8) & 0xFF);
+        array[index + 1] = (byte) (v & 0xFF);
+        pos += 2;
+    }
 
     public void write(int b) {
         ensureCapacity(1);

--- a/src/org/jgroups/util/Util.java
+++ b/src/org/jgroups/util/Util.java
@@ -24,12 +24,15 @@ import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import java.io.*;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.management.*;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.*;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.security.MessageDigest;
@@ -128,6 +131,9 @@ public class Util {
     protected static final SplittableRandom         RANDOM=new SplittableRandom();
 
     protected static final Function<String,List<Address>> FUNC=__ -> new ArrayList<>();
+
+    public static final VarHandle LONG_ARRAY_VIEW = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
+    public static final VarHandle INT_ARRAY_VIEW = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
 
     static {
 


### PR DESCRIPTION
Improve the read/write of integers and longs in classes ByteArrayDataInputStream and ByteArrayDataOutputStream

### Performance

JMH benchmark: https://github.com/pruivo/playground/tree/master/jgrp-data-input-output

Environment
```
# JMH version: 1.37
# VM version: JDK 21.0.5, OpenJDK 64-Bit Server VM, 21.0.5+11-LTS
# CPU: 6-core AMD Ryzen 5 5600X 
```

**JGroups 5.4.7**
```
Benchmark                            (seed)  Mode  Cnt  Score   Error  Units
JGroupsDataBenchmark.testReadInt       8096  avgt    5  1.163 ± 0.129  ns/op
JGroupsDataBenchmark.testReadLong      8096  avgt    5  1.707 ± 0.136  ns/op
JGroupsDataBenchmark.testReadShort     8096  avgt    5  0.730 ± 0.135  ns/op
JGroupsDataBenchmark.testWriteInt      8096  avgt    5  2.544 ± 0.197  ns/op
JGroupsDataBenchmark.testWriteLong     8096  avgt    5  6.645 ± 0.884  ns/op
JGroupsDataBenchmark.testWriteShort    8096  avgt    5  1.655 ± 0.244  ns/op
```

**This pull request**
```
Benchmark                            (seed)  Mode  Cnt  Score   Error  Units
JGroupsDataBenchmark.testReadInt       8096  avgt    5  0.657 ± 0.031  ns/op
JGroupsDataBenchmark.testReadLong      8096  avgt    5  0.665 ± 0.053  ns/op
JGroupsDataBenchmark.testReadShort     8096  avgt    5  0.674 ± 0.019  ns/op
JGroupsDataBenchmark.testWriteInt      8096  avgt    5  0.879 ± 0.049  ns/op
JGroupsDataBenchmark.testWriteLong     8096  avgt    5  0.874 ± 0.043  ns/op
JGroupsDataBenchmark.testWriteShort    8096  avgt    5  1.465 ± 0.203  ns/op
```

### Notes

@belaban I did the same optimization in ProtoStream a while back. I know nanoseconds are nothing in the big picture but it is better than nothing.

Try it out in your machine and let me know the results! 