### PR TITLE
Fix for JGRP-2892

### DIFF
--- a/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
+++ b/src/org/jgroups/protocols/pbcast/ClientGmsImpl.java
@@ -70,10 +70,14 @@ public class ClientGmsImpl extends GmsImpl {
                 else {
                     Responses tmp=(Responses)gms.getDownProtocol().down(new Event(Event.FIND_INITIAL_MBRS, gms.getJoinTimeout()));
                     if(tmp != null) {
-                        final Responses r=responses;
-                        tmp.callback(pd -> r.addResponse(pd, true));
-                        responses.add(tmp, gms.getAddress());
-                        tmp.done();
+                        try {
+                            final Responses r=responses;
+                            tmp.callback(pd -> r.addResponse(pd, true));
+                            responses.add(tmp, gms.getAddress());
+                            tmp.waitFor(gms.join_timeout);
+                        } finally {
+                            tmp.done();
+                        }
                     }
                 }
 


### PR DESCRIPTION
The issue was caused by an early call to tmp.done(), which led to an infinite loop.

To fix this, we ensure tmp.done() is only called after tmp.waitFor(this.gms.join_timeout) completes: This change ensures that the discovery phase completes properly and avoids premature termination.