### PR TITLE
Programmatic config of diag handler

### DIFF
--- a/src/org/jgroups/stack/DiagnosticsHandler.java
+++ b/src/org/jgroups/stack/DiagnosticsHandler.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * @since 3.0
  */
 
-public class DiagnosticsHandler extends ReceiverAdapter implements Closeable {
+public class DiagnosticsHandler extends ReceiverAdapter {
     public static final String         UDP_THREAD_NAME="UdpDiagHandler";
     public static final String         TCP_THREAD_NAME="TcpDiagHandler";
 
@@ -63,9 +63,9 @@ public class DiagnosticsHandler extends ReceiverAdapter implements Closeable {
     protected MulticastSocket          udp_mcast_sock;        // receiving of mcast packets when UDP is used
     protected DatagramSocket           udp_ucast_sock;        // sending of UDP responses
     protected final Set<ProbeHandler>  handlers=new CopyOnWriteArraySet<>();
-    protected final Log                log;
-    protected final SocketFactory      socket_factory;
-    protected final ThreadFactory      thread_factory;
+    protected Log                      log=LogFactory.getLog(DiagnosticsHandler.class);
+    protected SocketFactory            socket_factory=new DefaultSocketFactory();
+    protected ThreadFactory            thread_factory=new DefaultThreadFactory("diag", true, true);
     protected Function<Boolean,String> print_headers=b -> "";
     protected Function<String,Boolean> same_cluster=b -> true;
 
@@ -82,20 +82,10 @@ public class DiagnosticsHandler extends ReceiverAdapter implements Closeable {
         return this;
     }
 
-    /** Constructor used for standalone apps (without a JGroups stack) */
-    public DiagnosticsHandler() throws Exception {
-        this(LogFactory.getLog(DiagnosticsHandler.class), new DefaultSocketFactory(),
-             new DefaultThreadFactory("diag", true, true));
-        Configurator.setDefaultAddressValues(this, Util.getIpStackType());
-    }
 
-    public DiagnosticsHandler(Log log, SocketFactory socket_factory, ThreadFactory thread_factory) {
-        this.log=log;
-        this.socket_factory=socket_factory;
-        this.thread_factory=thread_factory;
-    }
-
-
+    public DiagnosticsHandler     log(Log l)                                  {log=l; return this;}
+    public DiagnosticsHandler     socketFactory(SocketFactory f)              {socket_factory=f; return this;}
+    public DiagnosticsHandler     threadFactory(ThreadFactory f)              {thread_factory=f; return this;}
     public boolean                isEnabled()                                 {return enabled;}
     public DiagnosticsHandler     setEnabled(boolean f)                       {enabled=f; return this;}
     public DiagnosticsHandler     setMcastAddress(InetAddress a)              {this.mcast_addr=a; return this;}

--- a/src/org/jgroups/stack/GossipRouter.java
+++ b/src/org/jgroups/stack/GossipRouter.java
@@ -184,7 +184,8 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener,
     }
 
     public GossipRouter init() throws Exception {
-        diag=new DiagnosticsHandler(log, socket_factory, thread_factory)
+        diag=new DiagnosticsHandler()
+          .log(log).socketFactory(socket_factory).threadFactory(thread_factory)
           .registerProbeHandler(this)
           .printHeaders(b -> String.format("GossipRouter [addr=%s, cluster=GossipRouter, version=%s]\n",
                                            localAddress(), Version.description));
@@ -245,7 +246,8 @@ public class GossipRouter extends ReceiverAdapter implements ConnectionListener,
         catch(Exception ex) {
             log.error(Util.getMessage("MBeanDeRegistrationFailed"), ex);
         }
-        Util.close(diag, server);
+        diag.stop();
+        Util.close(server);
         log.debug("router stopped");
     }
 


### PR DESCRIPTION
This change allows fluent programmatic configuration of the diagnostic handler. E.g.:

```java
new JChannel(List.of(
  new TCP()
      .setDiagnosticsHandler(new DiagnosticsHandler()
          .enableUdp(false)
          .enableTcp(true)),
  new MPING(),
  new NAKACK4(),
  new UNICAST4(),
  new GMS()));
```