### PR TITLE
Use thread pool or factory for suspect events

### DIFF
--- a/src/org/jgroups/protocols/BasicTCP.java
+++ b/src/org/jgroups/protocols/BasicTCP.java
@@ -209,7 +209,10 @@ public abstract class BasicTCP extends TP implements Receiver, ConnectionListene
                 log.debug("%s: connection closed by peer %s (IP=%s), sending up a suspect event",
                           local_addr, peer, peer_ip);
             Event suspect=new Event(Event.SUSPECT, List.of(peer));
-            up_prot.up(suspect);
+            Runnable r=() -> up_prot.up(suspect);
+            boolean rc=thread_pool.execute(r);
+            if(!rc)
+                getThreadFactory().newThread(r).start();
             num_suspect_events.increment();
         }
     }


### PR DESCRIPTION
Nitpicking... but this changes to use thread pool or factory for suspect events for correct thread namings.