### PR TITLE
Unchecked exceptions from JChannel

### DIFF
--- a/src/org/jgroups/JGroupsException.java
+++ b/src/org/jgroups/JGroupsException.java
@@ -1,0 +1,19 @@
+package org.jgroups;
+
+/**
+ * Base class for JGroups exceptions.
+ * 
+ * @since  5.5
+ */
+public class JGroupsException extends RuntimeException {
+
+    private static final long serialVersionUID = -1357346823441443746L;
+
+    public JGroupsException(String message) {
+        super(message);
+    }
+
+    public JGroupsException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/org/jgroups/StateTransferException.java
+++ b/src/org/jgroups/StateTransferException.java
@@ -8,18 +8,14 @@ package org.jgroups;
  * @since 2.6
  * 
  */
-public class StateTransferException extends Exception {
+public class StateTransferException extends JGroupsException {
     private static final long serialVersionUID=-4070956583392020498L;
-
-    public StateTransferException(){    
-    }
 
     public StateTransferException(String reason){
         super(reason);        
     }
 
-    public StateTransferException(String reason,Throwable cause) {
-        super(reason, cause);        
+    public StateTransferException(Throwable cause) {
+        super(cause);        
     }
-
 }

--- a/src/org/jgroups/SuspectedException.java
+++ b/src/org/jgroups/SuspectedException.java
@@ -7,13 +7,16 @@ package org.jgroups;
  * @since 2.0
  * @author Bela Ban
  */
-public class SuspectedException extends Exception {
-    final Object suspect;
+public class SuspectedException extends RuntimeException {
+    private static final long serialVersionUID = -6663279911010545655L;
+    protected final Address member;
 
-    private static final long serialVersionUID=-6663279911010545655L;
+    public SuspectedException(Address member) {
+        super("SuspectedException");
+        this.member=member;
+    }
 
-    public SuspectedException()                {this.suspect=null;}
-    public SuspectedException(Object suspect)  {this.suspect=suspect;}
-
-    public String toString() {return "SuspectedException";}
+    public String toString() {
+        return getMessage() + ": member=" + member;
+    }
 }

--- a/src/org/jgroups/UnreachableException.java
+++ b/src/org/jgroups/UnreachableException.java
@@ -15,12 +15,6 @@ public class UnreachableException extends RuntimeException {
         this.member=member;
     }
 
-    public UnreachableException(String msg, Address member) {
-        super(msg);
-        this.member=member;
-    }
-
-
     public String toString() {
         return getMessage() + ": member=" + member;
     }

--- a/src/org/jgroups/stack/ProtocolStack.java
+++ b/src/org/jgroups/stack/ProtocolStack.java
@@ -504,7 +504,7 @@ public class ProtocolStack extends Protocol {
      *                      is not found
      * @exception Exception Will be thrown when the new protocol cannot be created, or inserted.
      */
-    public void insertProtocol(Protocol prot, Position position, String neighbor_prot) throws Exception {
+    public void insertProtocol(Protocol prot, Position position, String neighbor_prot) {
         if(neighbor_prot == null) throw new IllegalArgumentException("neighbor_prot is null");
         Protocol neighbor=findProtocol(neighbor_prot);
         if(neighbor == null)
@@ -548,7 +548,7 @@ public class ProtocolStack extends Protocol {
         }
     }
 
-    public void insertProtocol(Protocol prot, Position position, Class<? extends Protocol> neighbor_prot) throws Exception {
+    public void insertProtocol(Protocol prot, Position position, Class<? extends Protocol> neighbor_prot) {
         if(neighbor_prot == null) throw new IllegalArgumentException("neighbor_prot is null");
         Protocol neighbor=findProtocol(neighbor_prot);
         if(neighbor == null)
@@ -561,7 +561,7 @@ public class ProtocolStack extends Protocol {
 
 
     @SafeVarargs
-    public final void insertProtocol(Protocol prot, Position position, Class<? extends Protocol>... neighbor_prots) throws Exception {
+    public final void insertProtocol(Protocol prot, Position position, Class<? extends Protocol>... neighbor_prots) {
         if(neighbor_prots == null) throw new IllegalArgumentException("neighbor_prots is null");
         Protocol neighbor=findProtocol(neighbor_prots);
         if(neighbor == null)


### PR DESCRIPTION
Following the discussion https://github.com/jgroups-extras/jgroups-raft/issues/353#issuecomment-2838630118, here is a rough initial proposal for not throwing checked exceptions from JChannel.
The idea is that `JGroupsException` is either a wrapper around any checked exception, or the base exception for any specific exception (e.g. `StateTransferException`).
Please feedback or close. 😅 