### PR TITLE
build: Fix non-deterministic build, version of the org.codehaus.mojo:…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
            <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>build-helper-maven-plugin</artifactId>
+              <version>3.6.1</version>
               <executions>
                  <execution>
                     <id>add-source</id>


### PR DESCRIPTION
…build-helper-maven-plugin plugin needs to be defined explicitly.