### PR TITLE
Make ensureCapacity public on ByteArrayDataOutputStream

### DIFF
--- a/src/org/jgroups/util/ByteArrayDataOutputStream.java
+++ b/src/org/jgroups/util/ByteArrayDataOutputStream.java
@@ -93,7 +93,7 @@ public class ByteArrayDataOutputStream extends BaseDataOutputStream {
     }
 
     /** Grows the buffer; whether it grow linearly or exponentially depends on grow_exponentially */
-    protected void ensureCapacity(int bytes) {
+    public void ensureCapacity(int bytes) {
         int minCapacity=pos+bytes;
 
         if(minCapacity - buf.length > 0) {


### PR DESCRIPTION
Making the method public so people implementing a custom message marshaller can use this method to ensure the byte[] is large enough before doing other operations.