### PR TITLE
Use a platform thread with NioServer in FD_SOCK2 for JDK <25

### DIFF
--- a/src/org/jgroups/protocols/FD_SOCK2.java
+++ b/src/org/jgroups/protocols/FD_SOCK2.java
@@ -321,9 +321,19 @@ public class FD_SOCK2 extends Protocol implements Receiver, ConnectionListener, 
     }
 
     protected NioServer createServer(int[] bind_ports) {
+        ThreadFactory threadFactory = getThreadFactory();
+        if (threadFactory instanceof DefaultThreadFactory dft && dft.useVirtualThreads() && Runtime.version().feature() < 25) {
+            // With JDK < 25, the EPollSelectorImpl.doSelect keeps the virtual thread busy,
+            // preventing the carrier thread to be used by other virtual threads
+            // It is a problem with systems with a low CPU count.
+            // It can be removed after JGroups adopts JDK 25 as minimum version.
+            threadFactory = new LazyThreadFactory("jgroups", true, true)
+                    .useVirtualThreads(false)
+                    .log(log);
+        }
         for(int bind_port: bind_ports) {
             try {
-                return new NioServer(getThreadFactory(), getSocketFactory(), bind_addr, bind_port, bind_port,
+                return new NioServer(threadFactory, getSocketFactory(), bind_addr, bind_port, bind_port,
                                      external_addr, external_port, 0, "jgroups.nio.server.fd_sock");
             }
             catch(Exception ignored) {


### PR DESCRIPTION
Looking at stack traces, it seems EPollSelectorImpl.doSelect never blocks and keeps the virtual thread "pinned" to the carrier thread

It can be observed with the Draw demo. Setting the JVM options `-Djdk.virtualThreadScheduler.parallelism=1 -Djdk.virtualThreadScheduler.maxPoolSize=1`, which forces the JVM to use a single carrier thread, the demo does not work, and no other node can join. **Note, this affects applications running with JDK < 25** 

With `OpenJDK Runtime Environment Temurin-21.0.8+9 (build 21.0.8+9-LTS)`, the stack trace shows:

```
#42 "NioServer.Selector [/127.0.0.1:7900]-6,draw,pedro-desktop-6500" virtual
      java.base/sun.nio.ch.EPoll.wait(Native Method)
      java.base/sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:121)
      java.base/sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:130)
      java.base/sun.nio.ch.SelectorImpl.select(SelectorImpl.java:147)
      org.jgroups.blocks.cs.NioBaseServer$Acceptor.doSelect(NioBaseServer.java:169)
      org.jgroups.blocks.cs.NioBaseServer$Acceptor.run(NioBaseServer.java:123)
      java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
```

With `OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)`, the EPollSelectorImpl.doSelect has been patched and parks the virtual thread.

```
#36 "NioServer.Selector [/127.0.0.1:7901]-6,draw,pedro-desktop-37567" virtual WAITING 2026-01-15T18:19:04.378511174Z
    at java.base/java.lang.VirtualThread.park(VirtualThread.java:738)
    at java.base/java.lang.System$1.parkVirtualThread(System.java:2284)
    at java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:367)
    at java.base/sun.nio.ch.Poller.poll(Poller.java:197)
    at java.base/sun.nio.ch.Poller.pollSelector(Poller.java:161)
    at java.base/sun.nio.ch.EPollSelectorImpl.untimedPoll(EPollSelectorImpl.java:146)
    at java.base/sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:111)
    at java.base/sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:130)
    - locked <sun.nio.ch.Util$2@5069e038>
    - locked <sun.nio.ch.EPollSelectorImpl@a310d5b>
    at java.base/sun.nio.ch.SelectorImpl.select(SelectorImpl.java:147)
    at org.jgroups.blocks.cs.NioBaseServer$Acceptor.doSelect(NioBaseServer.java:169)
    at org.jgroups.blocks.cs.NioBaseServer$Acceptor.run(NioBaseServer.java:123)
    at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
```

Let me know if you have other suggestion to work around the problem.