### PR TITLE
[JGRP-2987] Interlock in multiple jvm connection open/accept could lead to singleton cluster member even in normal network conditions

### DIFF
--- a/src/org/jgroups/blocks/cs/BaseServer.java
+++ b/src/org/jgroups/blocks/cs/BaseServer.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
@@ -75,8 +75,10 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
     protected int                             linger=-1;
     protected TimeService                     time_service;
     // to access the connection map, 1 lock / destination
-    protected final Map<Address,Lock>         locks=new ConcurrentHashMap<>();
-
+    protected final Map<Address, AddressLock> 
+                                              locks=new ConcurrentHashMap<>();
+    protected final Map<Address, ReentrantLock>
+                                              connect=new ConcurrentHashMap<>();
 
     protected BaseServer(ThreadFactory f, SocketFactory sf, int recv_buf_size) {
         this.factory=f;
@@ -161,7 +163,8 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         for(Connection c: conns.values())
             Util.close(c);
         conns.clear();
-        locks.clear();
+        // this causes a race condition with the locks
+//        locks.clear();
         conn_listeners.clear();
     }
 
@@ -290,25 +293,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
 
     /** Creates a new connection to dest, or returns an existing one */
     public Connection getConnection(Address dest) throws Exception {
-        Connection conn;
-        // keep FAST path on the most common case
-        if(connected(conn=conns.get(dest)))
-            return conn;
-
-        // we acquire a separate lock for each destination, so that connection/send attempts to destination D2
-        // are not blocked by connection/send attempts to destination D1 (https://issues.redhat.com/browse/JGRP-2905)
-        Lock lock=getLock(dest);
-        lock.lock();
-        try {
-            if(connected(conn=conns.get(dest)))
-                return conn;
-            conn=createConnection(dest);
-            handleOutgoingConnection(dest, conn);
-        }
-        finally {
-            lock.unlock();
-        }
-        return conn;
+        return handleOutgoingConnection(dest);
     }
 
     @GuardedBy("this")
@@ -345,45 +330,100 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         return false;
     }
 
-    public void handleOutgoingConnection(Address dest, Connection conn) throws Exception {
+    public Connection handleOutgoingConnection(Address dest) throws Exception {
+        Connection conn = null;
+        // keep FAST path on the most common case
+        if(connected(conn=conns.get(dest)))
+            return conn;
+
+        AddressLock address_lock=getAddressLock(dest);
+        ReentrantLock connect_lock=getConnectLock(dest);
+
+        // we acquire a separate lock for each destination, so that connection/send attempts to destination D2
+        // are not blocked by connection/send attempts to destination D1 (https://issues.redhat.com/browse/JGRP-2905)
+        connect_lock.lock();
+        address_lock.lock();
         try {
+            conn=conns.get(dest);
+            if(connected(conn))
+                return conn;
+            conn=createConnection(dest);
             log.trace("%s: connecting to %s", local_addr, dest);
             conn.connect(dest);
-            log.trace("%s: established connection to %s", local_addr, dest);
-            notifyConnectionEstablished(conn);
-            conn.start();
-            replaceConnection(dest, conn);
+            connect_lock.unlock();
+            conn.waitForAck();
+            if (conn.isConnected()) {
+                log.trace("%s: connection was established to %s", local_addr, dest);
+                replaceConnection(dest, conn);
+                conn.start();
+                notifyConnectionEstablished(conn);
+            }
+            else {
+                log.trace("%s: connection was rejected by %s, waiting for a connection to be produced", local_addr, dest);
+                address_lock.waitForConnection();
+                conn = conns.get(dest);
+            }
         }
         catch(Exception connect_ex) {
+            log.debug("%s: connection exception %s %s", local_addr, dest, connect_ex.getMessage());
             removeConnectionIfPresent(dest, conn); // removes and closes the conn
             throw connect_ex;
         }
+        finally {
+            address_lock.unlock();
+            if (connect_lock.isHeldByCurrentThread()) {
+                connect_lock.unlock();
+            }
+        }
+
+        if (conn == null || conn.isClosed()) {
+            throw new IOException("Was not possible to get an outgoing connection to " + dest);
+        }
+        return conn;
     }
 
     public void handleIncomingConnection(Address peer_addr, Connection conn) throws Exception {
         boolean close_conn=false;
-        Lock lock=getLock(peer_addr);
-        lock.lock();
+        ReentrantLock connect_lock=getConnectLock(peer_addr);
+        AddressLock address_lock=getAddressLock(peer_addr);
+        log.trace("%s: processing incoming connection from %s", local_addr, peer_addr);
+        connect_lock.lock();
         try {
-            boolean conn_exists=hasConnection(peer_addr),
-              replace=conn_exists && local_addr.compareTo(peer_addr) < 0; // bigger conn wins
+            // we check if there is an outgoing connection creation
+            if (!address_lock.tryLock()) {
+                log.trace("%s: inter lock incoming connection from %s", local_addr, peer_addr);
+                boolean replace=local_addr.compareTo(peer_addr) < 0; // bigger conn wins
+                if (!replace) {
+                    log.trace("%s: inter lock rejected connection from %s %s", local_addr, peer_addr, explanation(replace));
+                    conn.nack();
+                    close_conn=true; // keep our existing conn, reject accept() and close client_sock
+                    return;
+                } else {
+                    log.trace("%s: inter lock accepted connection from %s %s", local_addr, peer_addr, explanation(replace));
+                    // if we need to replace or new creation we wait for the lock as it will happen.
+                    conn.ack();
+                    address_lock.lock();
+                }
+            } else {
+                log.trace("%s: acking connection to %s", local_addr, peer_addr);
+                conn.ack();
+            }
 
-            if(!conn_exists || replace) {
-                notifyConnectionEstablished(conn);
-                conn.start();
-                replaceConnection(peer_addr, conn); // closes old conn
-                log.trace("%s: accepted connection from %s", local_addr, peer_addr);
-            }
-            else {
-                log.trace("%s: rejected connection from %s %s", local_addr, peer_addr, explanation(conn_exists, replace));
-                close_conn=true; // keep our existing conn, reject accept() and close client_sock
-            }
+            log.trace("%s: accepted connection from %s", local_addr, peer_addr);
+            replaceConnection(peer_addr, conn); // closes old conn
+            conn.start();
+            notifyConnectionEstablished(conn);
         }
         finally {
-            lock.unlock();
+            address_lock.produceConnection();
+            //  this is required as lock might not be hold by this thread (rejected situation)
+            address_lock.unlock();
+
+            connect_lock.unlock();
+            // we clean up the connection if required.
+            if(close_conn)
+                Util.close(conn); // closing the connection outside the lock scope (might block if TLS)
         }
-        if(close_conn)
-            Util.close(conn); // closing the connection outside the lock scope (might block if TLS)
     }
 
     public BaseServer addConnectionListener(ConnectionListener cl) {
@@ -418,7 +458,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         if(address == null || conn == null)
             return;
         Connection tmp=null;
-        Lock lock=getLock(address);
+        AddressLock lock=getAddressLock(address);
         lock.lock();
         try {
             Connection existing=conns.get(address);
@@ -463,7 +503,6 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
             return;
         Map<Address,Connection> copy=new HashMap<>(conns);
         conns.keySet().retainAll(current_mbrs);
-        locks.keySet().retainAll(current_mbrs);
         copy.keySet().removeAll(current_mbrs);
         for(Map.Entry<Address,Connection> e: copy.entrySet()) {
             PhysicalAddress key=(PhysicalAddress)e.getKey();
@@ -538,9 +577,12 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         }
     }
 
-    protected Lock getLock(Address dest) {
-        Lock l=locks.get(dest);
-        return l != null? l : locks.computeIfAbsent(dest, __ -> new ReentrantLock());
+    protected AddressLock getAddressLock(Address dest) {
+        return locks.computeIfAbsent(dest, __ -> new AddressLock());
+    }
+
+    protected ReentrantLock getConnectLock(Address dest) {
+        return connect.computeIfAbsent(dest, __ -> new ReentrantLock());
     }
 
     protected static boolean connected(Connection c) {
@@ -568,17 +610,15 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
 
 
 
-    protected static String explanation(boolean connection_existed, boolean replace) {
+    protected static String explanation(boolean replace) {
         StringBuilder sb=new StringBuilder();
-        if(connection_existed) {
-            sb.append(" (connection existed");
-            if(replace)
-                sb.append(" but was replaced because my address is lower)");
-            else
-                sb.append(" and my address won as it's higher)");
-        }
+
+        sb.append(" (connection processed");
+        if(replace)
+            sb.append(" but was replaced because my address is lower)");
         else
-            sb.append(" (connection didn't exist)");
+            sb.append(" and my address won as it's higher)");
+
         return sb.toString();
     }
 
@@ -624,4 +664,34 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         }
     }
 
+}
+
+class AddressLock {
+    ReentrantLock lock = new ReentrantLock();
+    Condition waitingForConnection = lock.newCondition();
+
+    public void lock () {
+        lock.lock();
+    }
+
+    public boolean tryLock () throws InterruptedException {
+        return lock.tryLock();
+    }
+
+    public void unlock () {
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
+    }
+
+    public void waitForConnection() throws InterruptedException{
+        waitingForConnection.await(5, TimeUnit.SECONDS);
+    }
+
+    public void produceConnection() {
+        if (lock.isHeldByCurrentThread()) {
+            lock.hasWaiters(waitingForConnection);
+            waitingForConnection.signalAll();
+        }
+    }
 }

--- a/src/org/jgroups/blocks/cs/Connection.java
+++ b/src/org/jgroups/blocks/cs/Connection.java
@@ -13,6 +13,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Represents a connection to a peer
  */
 public abstract class Connection implements Closeable {
+    public static final byte[] MSG_ACK= { 'o', 'k' };
+    public static final byte[] MSG_NACK= { 'k', 'o'};
+    public static final int MSG_LENGTH=MSG_ACK.length;
+
     public static final byte[] cookie= { 'b', 'e', 'l', 'a' };
     public static final int    GRACEFUL_CLOSE=-5;
     protected BaseServer       server;
@@ -48,4 +52,8 @@ public abstract class Connection implements Closeable {
     public boolean isExpired(long now) {
         return server.connExpireTime() > 0 && now - last_access >= server.connExpireTime();
     }
+
+    abstract public void ack() throws Exception;
+    abstract public void nack() throws Exception;
+    abstract public void waitForAck() throws Exception;
 }

--- a/src/org/jgroups/blocks/cs/NioClient.java
+++ b/src/org/jgroups/blocks/cs/NioClient.java
@@ -16,7 +16,7 @@ import java.nio.channels.Selector;
  */
 public class NioClient extends NioBaseServer implements Client {
     protected Address       remote_addr; // the address of the server (needs to be set before connecting)
-    protected NioConnection conn;        // connection to the server
+    protected Connection conn;        // connection to the server
 
 
     /**
@@ -111,12 +111,7 @@ public class NioClient extends NioBaseServer implements Client {
     protected void doStart() throws Exception {
         super.start();
         selector=Selector.open();
-        conn=createConnection(remote_addr);
-        conn.connect(remote_addr, false);
-        local_addr=conn.localAddress();
-        if(use_peer_connections)
-            conn.sendLocalAddress(local_addr);
-        conn.start();
+        conn=handleOutgoingConnection(remote_addr);
         acceptor=factory.newThread(new Acceptor(), "NioClient.Acceptor [srv=" + remote_addr + "]");
         acceptor.setDaemon(true);
         acceptor.start();

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -12,6 +12,7 @@ import org.jgroups.util.Util;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
@@ -381,6 +382,49 @@ public class NioConnection extends Connection {
         return length_buf;
     }
 
+    @Override
+    public void ack() {
+        try {
+            this.send(ByteBuffer.wrap(MSG_ACK), false);
+        } catch (Exception e) {
+            throw new UncheckedIOException("error during acking the tcp connection", new IOException(e));
+        }
+    }
 
+    @Override
+    public void nack() {
+        try {
+            this.send(ByteBuffer.wrap(MSG_NACK), false);
+        } catch(Exception e) {
+            throw new UncheckedIOException("error during nacking the tcp connection", new IOException(e));
+        }
+    }
+
+    @Override
+    public void waitForAck() throws Exception {
+        byte []waitForAck = new byte[2];
+        ByteBuffer buf = ByteBuffer.allocate(waitForAck.length);
+        int length = 0;
+        long timeout = System.currentTimeMillis() + 5000;
+        while(length < waitForAck.length 
+                && !Thread.currentThread().isInterrupted()
+                && System.currentTimeMillis() < timeout) {
+            int numberOfBytes = channel.read(buf);
+            if (numberOfBytes > 0){
+                length += numberOfBytes;
+            }
+        }
+
+        if (length < waitForAck.length) {
+            waitForAck = MSG_NACK;
+        } else {
+            buf.flip();
+            buf.get(waitForAck);
+        }
+
+        if (!Arrays.equals(MSG_ACK, waitForAck) && length == waitForAck.length) {
+            doClose();
+        }
+    }
 
 }

--- a/src/org/jgroups/blocks/cs/TcpClient.java
+++ b/src/org/jgroups/blocks/cs/TcpClient.java
@@ -1,12 +1,13 @@
 package org.jgroups.blocks.cs;
 
-import org.jgroups.Address;
-import org.jgroups.stack.IpAddress;
-import org.jgroups.util.*;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+
+import org.jgroups.Address;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.DefaultSocketFactory;
+import org.jgroups.util.DefaultThreadFactory;
 
 /**
  * Client for servers based on TCP
@@ -15,7 +16,7 @@ import java.nio.ByteBuffer;
  */
 public class TcpClient extends TcpBaseServer implements Client, ConnectionListener {
     protected Address       remote_addr; // the address of the server (needs to be set before connecting)
-    protected TcpConnection conn;        // connection to the server
+    protected Connection conn;        // connection to the server
 
 
      /**
@@ -114,14 +115,8 @@ public class TcpClient extends TcpBaseServer implements Client, ConnectionListen
 
     protected void doStart() throws Exception {
         super.start();
-        conn=createConnection(remote_addr).useLockToSend(use_lock_to_send);
+        conn=handleOutgoingConnection(remote_addr);
         addConnectionListener(this);
-        conn.connect(remote_addr, false);
-        local_addr=conn.localAddress();
-        if(use_peer_connections)
-            conn.sendLocalAddress(local_addr);
-        notifyConnectionEstablished(conn);
-        conn.start(); // starts the receiver thread
     }
 
     protected void doStop(boolean graceful) {

--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -390,4 +390,43 @@ public class TcpConnection extends Connection {
         Util.close(out,in);
         connected=false;
     }
+
+    @Override
+    public void ack() throws Exception {
+        out.write(MSG_ACK);
+        flush();
+    }
+
+    @Override
+    public void nack() throws Exception {
+        out.write(MSG_NACK);
+        flush();
+    }
+
+    @Override
+    public void waitForAck() throws Exception {
+        byte [] waitForAck = new byte[MSG_LENGTH];
+        int totalRead = 0;
+        long timeout = System.currentTimeMillis() + 5000;
+        while(totalRead < MSG_LENGTH
+                && !Thread.currentThread().isInterrupted()
+                && System.currentTimeMillis() < timeout) {
+            if(!(sock instanceof SSLSocket) && in.available() > 0) {
+                int bytesToBeRead = Math.min(in.available(), MSG_LENGTH - totalRead);
+                int bytesRead = in.read(waitForAck, totalRead, bytesToBeRead);
+                totalRead += bytesRead;
+            }
+            else if (sock instanceof SSLSocket) {
+                // SSL is non blocking so it won't block at read
+                int bytesToBeRead = MSG_LENGTH - totalRead;
+                int bytesRead = in.read(waitForAck, totalRead, bytesToBeRead);
+                totalRead += bytesRead;
+            }
+
+        }
+        // we only close if we read the flag from it.
+        if (Arrays.equals(waitForAck, MSG_NACK) && totalRead == MSG_LENGTH) {
+            doClose();
+        }
+    }
 }

--- a/src/org/jgroups/blocks/cs/TcpServer.java
+++ b/src/org/jgroups/blocks/cs/TcpServer.java
@@ -96,8 +96,8 @@ public class TcpServer extends TcpBaseServer {
      *  putting it in conns. When the thread should stop, it is interrupted by the thread creator */
     protected class Acceptor implements Runnable {
         public void run() {
+            Socket client_sock=null;
             while(!srv_sock.isClosed() && !Thread.currentThread().isInterrupted()) {
-                Socket client_sock=null;
                 try {
                     client_sock=srv_sock.accept();
                     handleAccept(client_sock);
@@ -107,8 +107,11 @@ public class TcpServer extends TcpBaseServer {
                         break;
                     if(log_accept_error)
                         log.warn(Util.getMessage("AcceptError"), local_addr, client_sock, ex);
-                    Util.close(client_sock);
                 }
+            }
+            // we do the close outside the loop
+            if (client_sock != null && client_sock.isConnected()) {
+                Util.close(client_sock);
             }
         }
 

--- a/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/ServerTest.java
@@ -61,7 +61,6 @@ public class ServerTest extends BMNGRunner {
         b.usePeerConnections(use_peer_conns);
         A=a.localAddress();
         B=b.localAddress();
-        assert A.compareTo(B) < 0;
         a.receiver(receiver_a=new MyReceiver("A"));
         a.start();
         b.receiver(receiver_b=new MyReceiver("B"));

--- a/tests/junit-functional/org/jgroups/tests/EnableSuspectEventsTest.java
+++ b/tests/junit-functional/org/jgroups/tests/EnableSuspectEventsTest.java
@@ -89,7 +89,7 @@ public class EnableSuspectEventsTest {
             // Check the views on the remaining nodes
             System.out.print("   Checking remaining nodes:\n");
             Util.waitUntil(5000, 100,
-                           () -> channels.stream().map(JChannel::view).allMatch(v -> v.size() == 2),
+                           () -> channels.stream().map(JChannel::view).allMatch(v -> v.size() == NUM_NODES - 1),
                            () -> String.format("all views must have 2 members: %s", print(channels)));
             System.out.printf("%s\n", print(channels));
 

--- a/tests/junit-functional/org/jgroups/tests/ServerTests.java
+++ b/tests/junit-functional/org/jgroups/tests/ServerTests.java
@@ -60,7 +60,6 @@ public class ServerTests {
     protected void setup(BaseServer one, BaseServer two, boolean use_peer_conns) throws Exception {
         a=one.usePeerConnections(use_peer_conns);
         b=two.usePeerConnections(use_peer_conns);
-        assert a.localAddress().compareTo(b.localAddress()) < 0;
         a.receiver(receiver_a=new MyReceiver("A").verbose(false));
         a.start();
         b.receiver(receiver_b=new MyReceiver("B").verbose(false));
@@ -82,7 +81,7 @@ public class ServerTests {
     public void testSimpleSend(BaseServer a, BaseServer b) throws Exception {
         setup(a,b);
         send(STRING_A, a, b.localAddress());
-        check(receiver_b.getList(), STRING_A);
+        check(receiver_b, STRING_A);
     }
 
 
@@ -95,14 +94,14 @@ public class ServerTests {
         waitForOpenConns(1, a, b);
         assert a.getNumOpenConnections() == 1 : "number of connections for conn_a: " + a.getNumOpenConnections();
         assert b.getNumOpenConnections() == 1 : "number of connections for conn_b: " + b.getNumOpenConnections();
-        check(receiver_b.getList(),"hello");
+        check(receiver_b,"hello");
 
         send("hello", b, a.localAddress());
         waitForOpenConns(1, a, b);
         assert a.getNumOpenConnections() == 1 : "number of connections for conn_a: " + a.getNumOpenConnections();
         assert b.getNumOpenConnections() == 1 : "number of connections for conn_b: " + b.getNumOpenConnections();
-        check(receiver_b.getList(), "hello");
-        check(receiver_a.getList(), "hello");
+        check(receiver_b, "hello");
+        check(receiver_a, "hello");
     }
 
 
@@ -132,8 +131,9 @@ public class ServerTests {
     }
 
 
-    protected static void check(List<String> list, String expected_str) {
-        Util.waitUntilTrue(10000, 100, () -> !list.isEmpty());
+    protected static void check(MyReceiver receiver, String expected_str) {
+        Util.waitUntilTrue(10000, 100, () -> receiver.size() > 0);
+        List<String> list = receiver.getList();
         assert !list.isEmpty() && list.get(0).equals(expected_str) : " list: " + list + ", expected " + expected_str;
     }
 


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/JGRP-2987

This aims to provide to provide a procedure to avoid rejecting outgoing connections when 2 nodes try to connect to each other
A->B and B->A
When this happen while the algorithm resolves correctly and it is consistent eventually could cause nodes to not detect during bootstrap the cluster and create singleton members.
This provides 2 different locks
1. to hold the critial section of the connection
2. to hold the critical section of producing a connection.

So when and outoing connection and incoming connection happens:
1. the incoming connection comes first. We take that one and the outgoing connection is retrieved by conns.
2. the outgoing connection comes first. In this case if both ends reaches at the same time we need to wait till the connection is established. and then perform the accept /rejection algorithm. The way to detect the deadlock is that the connection will wait for the ack while the lock is still held by the outgoing connection. in that momment we can ensure is a deadlock. Once the deadlock is resolved we can lock the connection production and set as valid. the outgoing connection will wait till the connection is ready.