### PR TITLE
JGRP-3001 Make SelectorProvider configurable via SocketFactory.

### DIFF
--- a/src/org/jgroups/blocks/cs/NioClient.java
+++ b/src/org/jgroups/blocks/cs/NioClient.java
@@ -7,7 +7,6 @@ import org.jgroups.util.*;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.Selector;
 
 /**
  * Client to access servers based on TCP_NIO2
@@ -110,7 +109,7 @@ public class NioClient extends NioBaseServer implements Client {
 
     protected void doStart() throws Exception {
         super.start();
-        selector=Selector.open();
+        selector=this.socket_factory.getSelectorProvider().openSelector();
         conn=createConnection(remote_addr);
         conn.connect(remote_addr, false);
         local_addr=conn.localAddress();
@@ -129,7 +128,7 @@ public class NioClient extends NioBaseServer implements Client {
             try {
                 conn.close(graceful);
             }
-            catch(IOException e) {
+            catch(IOException ignored) {
             }
         }
     }

--- a/src/org/jgroups/blocks/cs/NioServer.java
+++ b/src/org/jgroups/blocks/cs/NioServer.java
@@ -6,7 +6,6 @@ import org.jgroups.util.*;
 
 import java.net.InetAddress;
 import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
@@ -69,7 +68,7 @@ public class NioServer extends NioBaseServer {
         channel=Util.createServerSocketChannel(this.socket_factory, service_name, bind_addr,
                                                srv_port, end_port, recv_buf_size);
         channel.configureBlocking(false);
-        selector=Selector.open();
+        selector=this.socket_factory.getSelectorProvider().openSelector();
         acceptor=factory.newThread(new Acceptor(), "NioServer.Selector [" + channel.getLocalAddress() + "]");
         channel.register(selector, SelectionKey.OP_ACCEPT, null);
         local_addr=localAddress(bind_addr, channel.socket().getLocalPort(), external_addr, external_port);

--- a/src/org/jgroups/util/SocketFactory.java
+++ b/src/org/jgroups/util/SocketFactory.java
@@ -11,9 +11,11 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
 
 /**
- * Factory to create various types of sockets. For socket creation, a <em>service name</em> can be passed as argument:
+ * Factory to create various types of sockets and NIO selector provider and channels.<p>
+ * For socket creation, a <em>service name</em> can be passed as argument:
  * an implementation could look up a service description (e.g. port) and create the socket, ignoring the passed port and
  * possibly also the bind address.<p>
  * Ephemeral ports can be created by passing 0 as port, or (if the port is ignored), an implementation could pass in
@@ -33,6 +35,14 @@ public interface SocketFactory {
     ServerSocket createServerSocket(String service_name, int port) throws IOException;
     ServerSocket createServerSocket(String service_name, int port, int backlog) throws IOException;
     ServerSocket createServerSocket(String service_name, int port, int backlog, InetAddress bindAddr) throws IOException;
+
+    /**
+     * Returns the {@link SelectorProvider} used to create NIO selectors.
+     * Override to use a custom provider (e.g. io_uring) in JGroups without changing the JVM-wide default.
+     */
+    default SelectorProvider getSelectorProvider() {
+        return SelectorProvider.provider();
+    }
 
     default SocketChannel createSocketChannel(String service_name) throws IOException {
         return SocketChannel.open();


### PR DESCRIPTION
Use getSelectorProvider() in both NioServer and NioClient instead of Selector.open() to allow custom NIO providers (e.g. io_uring) without changing the JVM-wide default.

Full backwards compatible; uses default method.

https://redhat.atlassian.net/browse/JGRP-3001