### PR TITLE
Optimized sending in TCP_NIO2

### DIFF
--- a/src/org/jgroups/blocks/cs/BaseServer.java
+++ b/src/org/jgroups/blocks/cs/BaseServer.java
@@ -69,6 +69,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
     @Deprecated(since="5.4.4",forRemoval=true)
     protected boolean                         use_acks;
     @ManagedAttribute(description="Log a stack trace when a connection is closed")
+    protected boolean                         use_lock_to_send=true; // e.g. a single sender doesn't need to acquire the send_lock
     protected boolean                         log_details=true;
     protected int                             sock_conn_timeout=1000;      // max time in millis to wait for Socket.connect() to return
     protected boolean                         tcp_nodelay=false;
@@ -105,6 +106,8 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
     public BaseServer       usePeerConnections(boolean flag)        {this.use_peer_connections=flag; return this;}
     public static boolean   useAcks()                               {return false;}
     public BaseServer       useAcks(boolean ignored)                {return this;}
+    public boolean          useLockToSend()                         {return use_lock_to_send;}
+    public BaseServer       useLockToSend(boolean u)                {this.use_lock_to_send=u; return this;}
     public boolean          logDetails()                            {return log_details;}
     public BaseServer       logDetails(boolean l)                   {log_details=l; return this;}
     public int              socketConnectionTimeout()               {return sock_conn_timeout;}
@@ -200,6 +203,26 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
             this.receiver.receive(sender, buf);
     }
 
+    public void send(Collection<? extends Address> dests, byte[] data, int offset, int length) throws Exception {
+        for(Address dest: dests) {
+            try {
+                send(dest, data, offset, length);
+            } catch(Throwable t) {
+                log.error(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, t);
+            }
+        }
+    }
+
+    public void send(Collection<? extends Address> dests, ByteBuffer data) throws Exception {
+        for(Address dest: dests) {
+            try {
+                send(dest, data.duplicate());
+            } catch(Throwable t) {
+                log.error(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, t);
+            }
+        }
+    }
+
     public void receive(Address sender, DataInput in, int len) throws Exception {
         // https://issues.redhat.com/browse/JGRP-2523: check if max_length has been exceeded
         if(max_length > 0 && len > max_length)
@@ -220,7 +243,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
             return;
 
         if(dest == null) {
-            sendToAll(data, offset, length);
+            send(conns.keySet(), data, offset, length);
             return;
         }
 
@@ -246,7 +269,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
             return;
 
         if(dest == null) {
-            sendToAll(data);
+            send(conns.keySet(), data);
             return;
         }
 
@@ -510,6 +533,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         return s;
     }
 
+    @Deprecated(since="5.5.6",forRemoval=true)
     public void sendToAll(byte[] data, int offset, int length) {
         for(Map.Entry<Address,Connection> entry: conns.entrySet()) {
             Connection conn=entry.getValue();
@@ -524,6 +548,7 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         }
     }
 
+    @Deprecated(since="5.5.6",forRemoval=true)
     public void sendToAll(ByteBuffer data) {
         for(Map.Entry<Address,Connection> entry: conns.entrySet()) {
             Connection conn=entry.getValue();

--- a/src/org/jgroups/blocks/cs/NioBaseServer.java
+++ b/src/org/jgroups/blocks/cs/NioBaseServer.java
@@ -7,7 +7,9 @@ import org.jgroups.conf.AttributeType;
 import org.jgroups.util.SocketFactory;
 import org.jgroups.util.ThreadFactory;
 
+import java.nio.ByteBuffer;
 import java.nio.channels.*;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -36,6 +38,8 @@ public abstract class NioBaseServer extends BaseServer {
 
     protected boolean           use_direct_memory=true;
 
+    protected final Lock        mcast_send_lock=new ReentrantLock();
+    protected ByteBuffer        mcast_send_buf=ByteBuffer.allocateDirect(1024);
 
 
     protected NioBaseServer(ThreadFactory f, SocketFactory sf, int recv_buf_size) {
@@ -87,6 +91,58 @@ public abstract class NioBaseServer extends BaseServer {
             }
         }
         return sb.toString();
+    }
+
+
+    @Override
+    public void send(Address dest, ByteBuffer data) throws Exception {
+        try {
+            super.send(dest, data);
+        } catch(ClosedChannelException | CancelledKeyException ignored) {}
+    }
+
+    @Override
+    public void send(Address dest, byte[] data, int offset, int length) throws Exception {
+        try {
+            super.send(dest, data, offset, length);
+        } catch(ClosedChannelException | CancelledKeyException ignored) {}
+    }
+
+    @Override
+    public void send(Collection<? extends Address> dests, byte[] data, int offset, int length) throws Exception {
+        send(dests, ByteBuffer.wrap(data, offset, length));
+    }
+
+    @Override
+    public void send(Collection<? extends Address> dests, ByteBuffer data) throws Exception {
+        if (data.isDirect()) {
+            super.send(dests, data);
+            return;
+        }
+        boolean use_lock = use_lock_to_send;
+        if (use_lock) {
+            mcast_send_lock.lock();
+        }
+        try {
+            copyToMcastSendBuf(data);
+            super.send(dests, mcast_send_buf);
+        } finally {
+            if (use_lock) {
+                mcast_send_lock.unlock();
+            }
+        }
+    }
+
+    private ByteBuffer copyToMcastSendBuf(ByteBuffer buffer) {
+        if (buffer.remaining() > mcast_send_buf.capacity()) {
+            int newCapacity = Math.max(buffer.remaining(), mcast_send_buf.capacity() * 2);
+            mcast_send_buf = ByteBuffer.allocateDirect(newCapacity);
+        } else {
+            mcast_send_buf.clear();
+        }
+        mcast_send_buf.put(buffer);
+        mcast_send_buf.flip();
+        return mcast_send_buf;
     }
 
 

--- a/src/org/jgroups/blocks/cs/NioConnection.java
+++ b/src/org/jgroups/blocks/cs/NioConnection.java
@@ -17,6 +17,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
+import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -164,9 +165,8 @@ public class NioConnection extends Connection {
                     send_buf.copy(); // copy data on partial write as further writes might corrupt data (https://issues.redhat.com/browse/JGRP-1991)
                 partial_writes++;
             }
-        }
-        catch(Exception ex) {
-            if(!(ex instanceof SocketException || ex instanceof EOFException || ex instanceof ClosedChannelException))
+        } catch(Exception ex) {
+            if(!(ex instanceof SocketException || ex instanceof EOFException || ex instanceof ClosedChannelException || ex instanceof CancelledKeyException))
                 server.log.error("%s: failed sending message to %s: %s", server.localAddress(), peerAddress(), ex);
             throw ex;
         }

--- a/src/org/jgroups/blocks/cs/TcpBaseServer.java
+++ b/src/org/jgroups/blocks/cs/TcpBaseServer.java
@@ -15,7 +15,6 @@ public abstract class TcpBaseServer extends BaseServer {
     protected int     buffered_outputstream_size=8192;
     protected boolean non_blocking_sends;       // https://issues.redhat.com/browse/JGRP-2759
     protected int     max_send_queue=1024;      // when non_blocking, how many messages to queue max?
-    protected boolean use_lock_to_send=true;    // e.g. a single sender doesn't need to acquire the send_lock
 
     protected TcpBaseServer(ThreadFactory f, SocketFactory sf, int recv_buf_size) {
         super(f, sf, recv_buf_size);
@@ -38,8 +37,6 @@ public abstract class TcpBaseServer extends BaseServer {
     public TcpBaseServer nonBlockingSends(boolean b)        {this.non_blocking_sends=b; return this;}
     public int           maxSendQueue()                     {return max_send_queue;}
     public TcpBaseServer maxSendQueue(int s)                {this.max_send_queue=s; return this;}
-    public boolean       useLockToSend()                    {return use_lock_to_send;}
-    public TcpBaseServer useLockToSend(boolean u)           {this.use_lock_to_send=u; return this;}
 
 
 }

--- a/src/org/jgroups/demos/PubServer.java
+++ b/src/org/jgroups/demos/PubServer.java
@@ -47,7 +47,7 @@ public class PubServer implements Receiver {
     @Override
     public void receive(Address sender, ByteBuffer buf) {
         try {
-            server.send(null, buf);
+            server.send((Address)null, buf);
         }
         catch(Exception ex) {
             log.error("failed publishing message", ex);
@@ -57,7 +57,7 @@ public class PubServer implements Receiver {
     @Override
     public void receive(Address sender, byte[] buf, int offset, int length) {
         try {
-            server.send(null, buf, offset, length);
+            server.send((Address)null, buf, offset, length);
         }
         catch(Exception ex) {
             log.error("failed publishing message", ex);
@@ -67,7 +67,7 @@ public class PubServer implements Receiver {
     public void receive(Address sender, DataInput in, int length) throws Exception {
         byte[] buf=new byte[length];
         in.readFully(buf, 0, length);
-        server.send(null, buf, 0, buf.length);
+        server.send((Address)null, buf, 0, buf.length);
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/org/jgroups/protocols/BasicTCP.java
+++ b/src/org/jgroups/protocols/BasicTCP.java
@@ -96,6 +96,10 @@ public abstract class BasicTCP extends TP implements Receiver, ConnectionListene
       type=AttributeType.SCALAR)
     protected final LongAdder num_suspect_events=new LongAdder();
 
+    @Property(description="Acquire a lock, or not, when sending a message. A single sender thread such as in " +
+      "TransferQueueBundler or PerDestinationBundler can set this to false")
+    protected boolean   use_lock_to_send=true;
+
     protected final Predicate<PhysicalAddress> is_member=pa -> {
         Address addr=logical_addr_cache.getByValue(pa);
         return addr != null && members.contains(addr);
@@ -157,6 +161,8 @@ public abstract class BasicTCP extends TP implements Receiver, ConnectionListene
 
     public long        numSuspectEvents()               {return num_suspect_events.sum();}
 
+    public boolean     useLockToSend()                  {return use_lock_to_send;}
+    public BasicTCP    useLockToSend(boolean u)         {this.use_lock_to_send=u; return this;}
 
 
     public void init() throws Exception {
@@ -179,8 +185,14 @@ public abstract class BasicTCP extends TP implements Receiver, ConnectionListene
         }
     }
 
+    @Override
     public void sendUnicast(PhysicalAddress dest, byte[] data, int offset, int length) throws Exception {
         send(dest, data, offset, length);
+    }
+
+    @Override
+    protected void sendUnicasts(List<PhysicalAddress> dests, byte[] data, int offset, int length) throws Exception {
+        send(dests, data, offset, length);
     }
 
     public abstract String printConnections();
@@ -189,6 +201,8 @@ public abstract class BasicTCP extends TP implements Receiver, ConnectionListene
     public abstract BasicTCP clearConnections(boolean graceful);
 
     public abstract void send(Address dest, byte[] data, int offset, int length) throws Exception;
+
+    public abstract void send(Collection<? extends Address> dest, byte[] data, int offset, int length) throws Exception;
 
     public abstract void retainAll(Collection<Address> members);
 

--- a/src/org/jgroups/protocols/PerDestinationBundler.java
+++ b/src/org/jgroups/protocols/PerDestinationBundler.java
@@ -89,8 +89,8 @@ public class PerDestinationBundler extends BaseBundler implements Runnable {
     public void start() {
         super.start();
         local_addr=Objects.requireNonNull(transport.getAddress());
-        if(transport instanceof TCP tcp)
-            tcp.useLockToSend(!use_single_sender_thread); // https://issues.redhat.com/browse/JGRP-2901
+        if(transport instanceof BasicTCP basicTcp)
+            basicTcp.useLockToSend(!use_single_sender_thread); // https://issues.redhat.com/browse/JGRP-2901
         if(use_single_sender_thread) {
             if(single_thread_runner == null)
                 single_thread_runner=new Runner(transport.getThreadFactory(), THREAD_NAME, this, null).joinTimeout(0);

--- a/src/org/jgroups/protocols/TCP.java
+++ b/src/org/jgroups/protocols/TCP.java
@@ -50,10 +50,6 @@ public class TCP extends BasicTCP {
     @Property(description="Log a warning (or not) when ServerSocket.accept() throws an exception")
     protected boolean   log_accept_error=true; // https://issues.redhat.com/browse/JGRP-2540
 
-    @Property(description="Acquire a lock, or not, when sending a message. A single sender thread such as in " +
-      "TransferQueueBundler or PerDestinationBundler can set this to false")
-    protected boolean   use_lock_to_send=true;
-
     @Component(name="tls",description="Contains the attributes for TLS (SSL sockets) when enabled=true")
     protected TLS       tls=new TLS();
 
@@ -88,8 +84,6 @@ public class TCP extends BasicTCP {
     public TCP     nonBlockingSends(boolean b) {this.non_blocking_sends=b; return this;}
     public int     maxSendQueue()              {return max_send_queue;}
     public TCP     maxSendQueue(int s)         {this.max_send_queue=s; return this;}
-    public boolean useLockToSend()             {return use_lock_to_send;}
-    public TCP     useLockToSend(boolean u)    {this.use_lock_to_send=u; return this;}
 
     @ManagedAttribute(description="The number of connections",type=AttributeType.SCALAR,gauge=true)
     public int getOpenConnections() {
@@ -112,9 +106,16 @@ public class TCP extends BasicTCP {
             srv.socketFactory(factory);
     }
 
+    @Override
     public void send(Address dest, byte[] data, int offset, int length) throws Exception {
         if(srv != null)
             srv.send(dest, data, offset, length);
+    }
+
+    @Override
+    public void send(Collection<? extends Address> dests, byte[] data, int offset, int length) throws Exception {
+        if(srv != null)
+            srv.send(dests, data, offset, length);
     }
 
     public void retainAll(Collection<Address> members) {
@@ -140,8 +141,8 @@ public class TCP extends BasicTCP {
           .tcpNodelay(tcp_nodelay).linger(linger)
           .clientBindAddress(client_bind_addr).clientBindPort(client_bind_port).deferClientBinding(defer_client_bind_addr)
           .log(this.log).logDetails(this.log_details)
-          .addConnectionListener(this);
-        srv.useLockToSend(this.use_lock_to_send);
+          .addConnectionListener(this)
+          .useLockToSend(this.use_lock_to_send);
 
         if(send_buf_size > 0)
             srv.sendBufferSize(send_buf_size);

--- a/src/org/jgroups/protocols/TCP_NIO2.java
+++ b/src/org/jgroups/protocols/TCP_NIO2.java
@@ -9,8 +9,6 @@ import org.jgroups.annotations.Property;
 import org.jgroups.blocks.cs.NioServer;
 import org.jgroups.conf.AttributeType;
 
-import java.nio.channels.CancelledKeyException;
-import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
 
 /**
@@ -91,16 +89,16 @@ public class TCP_NIO2 extends BasicTCP {
         server.readerIdleTime(t);
     }
 
+    @Override
     public void send(Address dest, byte[] data, int offset, int length) throws Exception {
-        if(server != null) {
-            try {
-                server.send(dest, data, offset, length);
-            }
-            catch(ClosedChannelException | CancelledKeyException ignored) {}
-            catch(Throwable ex) {
-                log.trace("%s: failed sending message to %s: %s", local_addr, dest, ex);
-            }
-        }
+        if(server != null)
+            server.send(dest, data, offset, length);
+    }
+
+    @Override
+    public void send(Collection<? extends Address> dests, byte[] data, int offset, int length) throws Exception {
+        if(server != null)
+            server.send(dests, data, offset, length);
     }
 
     public void retainAll(Collection<Address> members) {
@@ -118,7 +116,8 @@ public class TCP_NIO2 extends BasicTCP {
           .log(this.log).logDetails(log_details);
         server.maxSendBuffers(max_send_buffers).usePeerConnections(true);
         server.copyOnPartialWrite(this.copy_on_partial_write).readerIdleTime(this.reader_idle_time)
-          .addConnectionListener(this);
+          .addConnectionListener(this)
+          .useLockToSend(this.use_lock_to_send);
 
         if(send_buf_size > 0)
             server.sendBufferSize(send_buf_size);

--- a/src/org/jgroups/protocols/TP.java
+++ b/src/org/jgroups/protocols/TP.java
@@ -11,8 +11,6 @@ import org.jgroups.util.*;
 
 import java.io.DataInput;
 import java.io.InterruptedIOException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -664,17 +662,8 @@ public abstract class TP extends TPConfig implements DiagnosticsHandler.ProbeHan
     }
 
     protected void sendUnicasts(List<PhysicalAddress> dests, byte[] data, int offset, int length) throws Exception {
-        for(PhysicalAddress dest: dests) {
-            try {
-                sendUnicast(dest, data, offset, length);
-            }
-            catch(SocketException | SocketTimeoutException sock_ex) {
-                log.trace(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, sock_ex);
-            }
-            catch(Throwable t) {
-                log.error(Util.getMessage("FailureSendingToPhysAddr"), local_addr, dest, t);
-            }
-        }
+        for(PhysicalAddress dest: dests)
+            sendUnicast(dest, data, offset, length);
     }
 
     protected void fetchPhysicalAddrs(List<Address> missing) {

--- a/src/org/jgroups/protocols/TransferQueueBundler.java
+++ b/src/org/jgroups/protocols/TransferQueueBundler.java
@@ -37,8 +37,9 @@ public class TransferQueueBundler extends BaseBundler implements Runnable {
     @Override
     public void init(TP transport) {
         super.init(transport);
+        if(transport instanceof BasicTCP basicTcp)
+            basicTcp.useLockToSend(false); // https://issues.redhat.com/browse/JGRP-2901
         if(transport instanceof TCP tcp) {
-            tcp.useLockToSend(false); // https://issues.redhat.com/browse/JGRP-2901
             int size=tcp.getBufferedOutputStreamSize();
             if(size < max_size) { // https://issues.redhat.com/browse/JGRP-2903
                 int new_size=max_size + Integer.BYTES;


### PR DESCRIPTION
Following up on #952, here's an idea to improve the _sending_ in `TCP_NIO2` by sending direct buffers.

Writing to direct buffers is supposedly slower than writing to heap memory, and in my limited tests I did get _less_ performance if I changed the bundler to write to direct memory.

When sending heap memory, the JDK keeps a single thread local direct ByteBuffer and which the heap memory is copied to before sending.
When sending unicast messages, this realistically means that there will be a single copy of a large chunk of heap memory to direct memory which is about as optimized as it can get.
But when sending multicast messages, the copy will be done _for each destination_ and this is what I try to improve here.

The change is simply to keep a single direct buffer in `NioBaseServer` which is used for multicast sending.
I reuse `use_lock_to_send` not lock around the multicast buffer, this should be improved.

This is not unlike what's mentioned in [JGRP-2998](https://redhat.atlassian.net/browse/JGRP-2998) but I can no longer find the possibility to comment there?