### PR TITLE
[5.3.x] [JGRP-2971] VERIFY_SUSPECT2 can create spurious suspect events

### DIFF
--- a/src/org/jgroups/protocols/VERIFY_SUSPECT2.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT2.java
@@ -8,16 +8,16 @@ import org.jgroups.annotations.ManagedAttribute;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.AttributeType;
 import org.jgroups.stack.Protocol;
-import org.jgroups.util.DefaultThreadFactory;
 import org.jgroups.util.MessageBatch;
+import org.jgroups.util.TimeScheduler;
 import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -47,13 +47,13 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
     @ManagedAttribute(description="Is the verifying task is running?")
     protected boolean                 running;
 
-    protected ExecutorService         thread_pool; // single-threaded+queue, runs the task when suspects are added
+    protected TimeScheduler           timer;
 
+    private Future<?>                 suspectsThread;
 
 
     @ManagedAttribute(description = "List of currently suspected members")
     public synchronized String getSuspects() {return suspects.toString();}
-
 
 
 
@@ -124,35 +124,18 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
      * SUSPECT events, then moves suspects from the queue to the bucket. Runs until the queue and bucket are both empty.
      */
     public void run() {
-        List<Address> suspected_mbrs=new ArrayList<>();
-        while(running) {
-            long target_time=System.currentTimeMillis() + timeout;
-            do {
-                LockSupport.parkUntil(target_time);
-            }
-            while(System.currentTimeMillis() < target_time);
+        List<Entry> suspected_mbrs=new ArrayList<>();
+        synchronized(this) {
+            long currentMillis=System.currentTimeMillis();
+            suspects.stream().filter(e -> e.target_time <= currentMillis).forEach(suspected_mbrs::add);
+            suspected_mbrs.forEach(suspects::remove);
+        }
 
-            suspected_mbrs.clear();
-            synchronized(this) {
-                suspects.forEach(e -> {
-                    if(e.target_time <= target_time)
-                        suspected_mbrs.add(e.suspect);
-                });
-                suspects.removeIf(e -> e.target_time <= target_time);
-            }
-
-            if(!suspected_mbrs.isEmpty()) {
-                log.debug("%s: sending up SUSPECT(%s)", local_addr, suspected_mbrs);
-                up_prot.up(new Event(Event.SUSPECT, suspected_mbrs));
-            }
-            else {
-                synchronized(this) {
-                    if(suspects.isEmpty()) {
-                        running=false;
-                        break;
-                    }
-                }
-            }
+        // send event up for suspect being found.
+        if(!suspected_mbrs.isEmpty()) {
+            List<Address> suspectedAddresses = suspected_mbrs.stream().map(Entry::suspect).collect(Collectors.toList());
+            log.debug("%s: sending up SUSPECT(%s)", local_addr, suspected_mbrs);
+            up_prot.up(new Event(Event.SUSPECT, suspectedAddresses));
         }
     }
 
@@ -191,10 +174,8 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
     protected void verifySuspect(Collection<Address> mbrs) {
         if(mbrs == null || mbrs.isEmpty())
             return;
-        if(addSuspects(mbrs)) {
-            startTask(); // start timer before we send out are you dead messages
-            log.trace("verifying that %s %s dead", mbrs, mbrs.size() == 1? "is" : "are");
-        }
+        addSuspects(mbrs);
+
         for(Address mbr: mbrs) {
             for(int i=0; i < num_msgs; i++) {
                 Message msg=new EmptyMessage(mbr).setFlag(Message.TransientFlag.DONT_BLOCK)
@@ -210,13 +191,14 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
      * @param list The list of suspected members
      * @return true if the timer needs to be started, or false otherwise
      */
-    protected synchronized boolean addSuspects(Collection<Address> list) {
+    protected synchronized void addSuspects(Collection<Address> list) {
         if(list == null || list.isEmpty())
-            return false;
+            return;
 
-        long target_time=getCurrentTimeMillis();
+        long target_time=System.currentTimeMillis() + timeout;
         List<Entry> tmp=list.stream().map(a -> new Entry(a, target_time)).collect(Collectors.toList());
-        return suspects.addAll(tmp);
+        suspects.addAll(tmp);
+        log.debug("verifying that %s %s dead", suspects, suspects.size() == 1? "is" : "are");
     }
 
     protected synchronized boolean removeSuspect(Address suspect) {
@@ -233,43 +215,32 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
         }
     }
 
-
-    protected synchronized void startTask() {
-        if(!running) {
-            running=true;
-            thread_pool.execute(this);
-        }
-    }
-
     @GuardedBy("lock")
     protected void stopThreadPool() {
-        if(thread_pool != null)
-            thread_pool.shutdown();
     }
 
     public void init() throws Exception {
         super.init();
-        ThreadFactory f=new DefaultThreadFactory(this.getClass().getSimpleName() + ".Runner", true, true);
-        thread_pool=new ThreadPoolExecutor(0, 1, // max 1 thread, started each time a suspect is added
-                                           0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), f);
+        timer=getTransport().getTimer();
     }
 
+    @Override public synchronized void start() throws Exception {
+        log.debug("%s: VERIFY_SUSPECT2 is being started", local_addr);
+        running=true;
+        if(suspectsThread == null)
+            suspectsThread = timer.scheduleAtFixedRate(this, timeout, timeout, TimeUnit.MILLISECONDS);
+    }
 
-    public synchronized void stop() {
+    @Override public synchronized void stop() {
+        log.debug("%s: VERIFY_SUSPECT2 is being shutdown", local_addr);
+        running=false;
+        if(suspectsThread!=null) {
+            suspectsThread.cancel(true);
+            suspectsThread=null;
+        }
         suspects.clear();
     }
 
-    public void destroy() {
-        stopThreadPool();
-        synchronized(this) {
-            running=false;
-        }
-        super.destroy();
-    }
-
-    private static long getCurrentTimeMillis() {
-        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
-    }
     /* ----------------------------- End of Private Methods -------------------------------- */
 
     protected static class Entry implements Comparable<Entry> {
@@ -288,6 +259,10 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
             return Objects.equals(suspect, other.suspect);
         }
 
+        public Address suspect() {
+            return suspect;
+        }
+
         public int hashCode() {
             return suspect.hashCode();
         }
@@ -297,7 +272,7 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
         }
 
         protected long expiry() {
-            return target_time - getCurrentTimeMillis();
+            return target_time - System.currentTimeMillis();
         }
 
         public int compareTo(Entry o) {

--- a/src/org/jgroups/protocols/VERIFY_SUSPECT2.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT2.java
@@ -187,9 +187,8 @@ public class VERIFY_SUSPECT2 extends Protocol implements Runnable {
 
 
     /**
-     * Adds suspected members to the suspect list. Returns true if a member is not present and the timer is not running.
+     * Adds suspected members to the suspect list.
      * @param list The list of suspected members
-     * @return true if the timer needs to be started, or false otherwise
      */
     protected synchronized void addSuspects(Collection<Address> list) {
         if(list == null || list.isEmpty())

--- a/tests/junit-functional/log4j2.properties
+++ b/tests/junit-functional/log4j2.properties
@@ -1,0 +1,8 @@
+# The root logger with appender name 
+rootLogger = DEBUG, STDOUT
+  
+# Assign STDOUT a valid appender & define its layout  
+appender.console.name = STDOUT
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %msg%n  

--- a/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
+++ b/tests/junit-functional/org/jgroups/protocols/VERIFY_SUSPECT_Test.java
@@ -10,9 +10,13 @@ import org.jgroups.util.Util;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 
 /**
  * Tests https://issues.redhat.com/browse/JGRP-1429
@@ -22,8 +26,8 @@ import java.util.stream.Stream;
 @Test(groups=Global.TIME_SENSITIVE,singleThreaded=true)
 public class VERIFY_SUSPECT_Test {
     protected static final Address a=Util.createRandomAddress("A"), b=Util.createRandomAddress("B");
-    protected static final long VIEW_ACK_COLLECTION_TIMEOUT=10000;
-    protected long       start;
+    protected static final long    VIEW_ACK_COLLECTION_TIMEOUT=10000;
+    protected long                 start;
 
 
     public void testTimer() {
@@ -95,33 +99,57 @@ public class VERIFY_SUSPECT_Test {
         assert map.size() == 1 && map.containsKey(b);
     }
 
+    /**
+     * in this case we send two different all suspect events at the same time
+     * so it should land in two windows and therefore two events
+     */
+    public void testMultipleSuspectEventsNextWindow() throws Exception {
+        JChannel[] channels = createChannels();
+        try {
+            CaptureProtocol capture = new CaptureProtocol(2, Event.SUSPECT);
+            ProtocolStack stack = channels[0].getProtocolStack();
+            stack.insertProtocol(capture, ProtocolStack.Position.ABOVE, VERIFY_SUSPECT2.class);
+
+            Address[] addrs=new Address[channels.length];
+            for(int i=0; i < channels.length; i++)
+                addrs[i]=channels[i].getAddress();
+
+            VERIFY_SUSPECT2 verify=channels[0].getProtocolStack().findProtocol(VERIFY_SUSPECT2.class);
+            TP transport=channels[0].getProtocolStack().getTransport();
+            // we ensure different windows
+            Suspecter s1=new Suspecter(List.of(addrs[1], addrs[2]), 500, transport), // this will expire at 1.5s (windows 2s)
+                    s2=new Suspecter(List.of(addrs[3], addrs[4]), 1200, transport); // this should expire at 2.2 s (windows 3s)
+            verify.stop();
+            verify.start(); // we ensure we start from T0 = 0s so the s1 get in the first window and s2 in the second
+            s1.start();
+            s2.start();
+
+            long st=System.nanoTime();
+            assert capture.await(5, TimeUnit.SECONDS)
+              : String.format("we expected 2 events, but received only %d", capture.count()); // you need to check when the view is 1
+            long time=System.nanoTime() - st;
+            System.out.printf("waited for %s\n", Util.printTime(time, TimeUnit.NANOSECONDS));
+        }
+        finally {
+            for(JChannel ch: channels)
+                Util.shutdown(ch);
+        }
+    }
 
     /**
      * {A,B,C,D,E}: at time T, {B,C} are suspected, then at time T+500 {D,E}. This results in 2 views V2={A,D,E}
      * and V3={A}. V2 will run into GMS.view_ack_collection_timeout, as acks from D and E are missing.
      * <p>
      * Issue: https://issues.redhat.com/browse/JGRP-2556
+     * in this case we send two different suspect events in the same window T0 and T0 +500 ms ... 
+     * so it should land in one window and therefore one event
      */
-    public void testMultipleSuspectEvents() throws Exception {
-        JChannel[] channels=new JChannel[5];
+    public void testMultipleSuspectEventsSameWindowDifferentTimes() throws Exception {
+        JChannel[] channels = createChannels();
         try {
-            for(int i=0; i < channels.length; i++) {
-                channels[i]=new JChannel(Util.getTestStack()).name(Character.toString(('A' + i)));
-                GMS gms=channels[i].getProtocolStack().findProtocol(GMS.class);
-                gms.printLocalAddress(false);
-                if(i == 0) { // only add VERIFY_SUSPECT2 to A
-                    ProtocolStack stack=channels[i].getProtocolStack();
-                    VERIFY_SUSPECT2 ver=new VERIFY_SUSPECT2().setTimeout(1000);
-                    stack.insertProtocol(ver, ProtocolStack.Position.ABOVE, Discovery.class);
-                    ver.init();
-                    ver.start();
-                    gms=stack.findProtocol(GMS.class);
-                    gms.setViewAckCollectionTimeout(VIEW_ACK_COLLECTION_TIMEOUT);
-                }
-                channels[i].connect(VERIFY_SUSPECT_Test.class.getSimpleName());
-            }
-            Util.waitUntilAllChannelsHaveSameView(10000, 500, channels);
-            System.out.printf("-- Channels: %s\n", Stream.of(channels).map(JChannel::getAddress).collect(Collectors.toList()));
+            CaptureProtocol capture = new CaptureProtocol(1, Event.SUSPECT);
+            ProtocolStack stack = channels[0].getProtocolStack();
+            stack.insertProtocol(capture, ProtocolStack.Position.ABOVE, VERIFY_SUSPECT2.class);
 
             Address[] addrs=new Address[channels.length];
             for(int i=0; i < channels.length; i++)
@@ -131,32 +159,120 @@ public class VERIFY_SUSPECT_Test {
             for(int i=1; i < channels.length; i++)
                 Util.shutdown(channels[i]);
 
-            channels[0].setReceiver(new Receiver() {
-                public void viewAccepted(View new_view) {
-                    System.out.printf("** view: %s\n", new_view);
-                }
-            });
-
             TP transport=channels[0].getProtocolStack().getTransport();
             // Inject SUSPECT(B,C) and SUSPECT(D,E) in 2 separate threads, spaced apart by a few ms:
+            // we ensure different windows
             Suspecter s1=new Suspecter(List.of(addrs[1], addrs[2]), 0, transport),
-              s2=new Suspecter(List.of(addrs[3], addrs[4]), 500, transport);
-            s1.setName("suspecter-1");
-            s2.setName("suspecter-2");
+                    s2=new Suspecter(List.of(addrs[3], addrs[4]), 100, transport);
             long start_time=System.currentTimeMillis();
             s1.start();
             s2.start();
             Util.waitUntil(VIEW_ACK_COLLECTION_TIMEOUT*2, 100, () -> channels[0].getView().size() == 1);
             long time=System.currentTimeMillis()-start_time;
             System.out.printf("%s: view=%s (took %d ms)\n", channels[0].getAddress(), channels[0].getView(), time);
+            assert capture.count() == 1 : String.format("should have received %d suspect events but got %d", 1, capture.count());
             assert time < VIEW_ACK_COLLECTION_TIMEOUT: String.format("took %d ms, but should have taken less than %d",
                                                                      time, VIEW_ACK_COLLECTION_TIMEOUT);
         }
         finally {
-            Util.close(channels);
+            for(JChannel ch: channels)
+                Util.shutdown(ch);
         }
     }
 
+    /**
+     * in this case we send two different all suspect events at the same time
+     * so it should land in one window and therefore one event
+     */
+    public void testMultipleSuspectEventsSameWindowAtOnce() throws Exception {
+        JChannel[] channels = createChannels();
+        try {
+            CaptureProtocol capture = new CaptureProtocol(1, Event.SUSPECT);
+            ProtocolStack stack = channels[0].getProtocolStack();
+            stack.insertProtocol(capture, ProtocolStack.Position.ABOVE, VERIFY_SUSPECT2.class);
+
+            Address[] addrs=new Address[channels.length];
+            for(int i=0; i < channels.length; i++)
+                addrs[i]=channels[i].getAddress();
+
+            // Now close B,C,D,E (this won't result in view changes as we have no failure detection protocol):
+            for(int i=1; i < channels.length; i++)
+                Util.shutdown(channels[i]);
+
+            TP transport=channels[0].getProtocolStack().getTransport();
+            // we ensure same window
+            Suspecter s1=new Suspecter(List.of(addrs[1], addrs[2], addrs[3], addrs[4]), 0, transport);
+            long start_time=System.currentTimeMillis();
+            s1.start();
+            Util.waitUntil(VIEW_ACK_COLLECTION_TIMEOUT*2, 100, () -> channels[0].getView().size() == 1);
+            long time=System.currentTimeMillis()-start_time;
+            System.out.printf("%s: view=%s (took %d ms)\n", channels[0].getAddress(), channels[0].getView(), time);
+            assert capture.count() == 1;
+            assert time < VIEW_ACK_COLLECTION_TIMEOUT: String.format("took %d ms, but should have taken less than %d",
+                                                                     time, VIEW_ACK_COLLECTION_TIMEOUT);
+        }
+        finally {
+            Util.close(channels[0]);
+        }
+    }
+
+    static class CaptureProtocol extends Protocol {
+        CountDownLatch latch;
+        int eventType;
+        final AtomicInteger count=new AtomicInteger();
+
+        public CaptureProtocol(int numberOfEvents, int eventType) {
+            this.latch = new CountDownLatch(numberOfEvents);
+            this.eventType = eventType;
+        }
+
+        public int count() {
+            return count.get();
+        }
+
+        @Override
+        public Object up(Event evt) {
+            if (evt.type() == eventType) {
+                count.incrementAndGet();
+                System.out.printf("suspect(%s): count=%d\n", evt.arg(), count.get());
+                latch.countDown();
+            }
+            return super.up(evt);
+        }
+
+        public boolean await(int timeout, TimeUnit unit) throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+    }
+
+    private static JChannel[] createChannels() throws Exception {
+        JChannel[] channels=new JChannel[5];
+
+        for(int i=0; i < channels.length; i++) {
+            channels[i]=new JChannel(Util.getTestStack()).name(Character.toString(('A' + i)));
+            GMS gms=channels[i].getProtocolStack().findProtocol(GMS.class);
+            gms.printLocalAddress(false).logViewWarnings(false);
+            if(i == 0) { // only add VERIFY_SUSPECT2 to A
+                ProtocolStack stack=channels[i].getProtocolStack();
+                VERIFY_SUSPECT2 ver=new VERIFY_SUSPECT2().setTimeout(1000);
+                stack.insertProtocol(ver, ProtocolStack.Position.ABOVE, Discovery.class);
+                ver.init();
+                ver.start();
+                gms.setViewAckCollectionTimeout(VIEW_ACK_COLLECTION_TIMEOUT);
+            }
+            channels[i].connect(VERIFY_SUSPECT_Test.class.getSimpleName());
+        }
+        Util.waitUntilAllChannelsHaveSameView(10000, 500, channels);
+        System.out.printf("-- Channels: %s\n", Stream.of(channels).map(JChannel::getAddress).collect(Collectors.toList()));
+
+        channels[0].setReceiver(new Receiver() {
+            public void viewAccepted(View new_view) {
+                System.out.printf("** view: %s\n", new_view);
+            }
+        });
+        return channels;
+    }
+    
     protected static class Suspecter extends Thread {
         protected final Collection<Address> suspected_mbrs;
         protected final long                sleep_time;
@@ -172,7 +288,11 @@ public class VERIFY_SUSPECT_Test {
             Util.sleep(sleep_time);
             System.out.printf("%s: injecting SUSPECT(%s)\n", Thread.currentThread(), suspected_mbrs);
             prot.up(new Event(Event.SUSPECT, suspected_mbrs));
-            System.out.printf("%s: done\n", Thread.currentThread());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Suspecter%s", suspected_mbrs);
         }
     }
 


### PR DESCRIPTION
- Using a timer to run the verification task rather than a separate thread pool. This allows us to use virtual threads if available

Cherry-picked https://github.com/belaban/JGroups/commit/7fc729e88b81b5119192f4defb9974e2495276fe