### PR TITLE
JGRP-3006 Fix log calls where exceptions are passed as format args instead of Throwable

### DIFF
--- a/src/org/jgroups/JChannel.java
+++ b/src/org/jgroups/JChannel.java
@@ -523,7 +523,7 @@ public class JChannel implements Closeable {
         if(target == null)
             target=determineCoordinator();
         if(Objects.equals(target, local_addr)) {
-            log.trace(local_addr + ": cannot get state from myself (" + target + "): probably the first member");
+            log.trace("%s: cannot get state from myself (%s): probably the first member", local_addr, target);
             return this;
         }
         state_promise.reset();

--- a/src/org/jgroups/auth/X509Token.java
+++ b/src/org/jgroups/auth/X509Token.java
@@ -149,7 +149,7 @@ public class X509Token extends AuthToken {
         this.cipher = Cipher.getInstance(this.cipher_type);
         this.certificate = (X509Certificate) store.getCertificate(this.cert_alias);
 
-        log.debug("certificate = " + this.certificate.toString());
+        log.debug("certificate = %s", this.certificate);
 
         this.cipher.init(Cipher.ENCRYPT_MODE, this.certificate);
         this.encryptedToken = this.cipher.doFinal(this.auth_value.getBytes());

--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -312,7 +312,7 @@ public class TcpConnection extends Connection {
                 }
                 else {
                     if(server.logDetails())
-                        server.log.warn("%s: failed handling message", server.local_addr, e);
+                        server.log.warn(server.local_addr + ": failed handling message", e);
                     else
                         server.log.warn("%s: failed handling message: %s", server.local_addr, e.getMessage());
                 }

--- a/src/org/jgroups/protocols/Encrypt.java
+++ b/src/org/jgroups/protocols/Encrypt.java
@@ -162,7 +162,7 @@ public abstract class Encrypt<E extends KeyStore.Entry> extends Protocol {
             return handleEncryptedMessage(msg);
         }
         catch(Exception e) {
-            log.warn("%s: exception occurred decrypting message", local_addr, e);
+            log.warn(local_addr + ": exception occurred decrypting message", e);
         }
         return null;
     }
@@ -203,7 +203,7 @@ public abstract class Encrypt<E extends KeyStore.Entry> extends Protocol {
             }
         }
         catch(InterruptedException e) {
-            log.error("%s: failed processing batch; discarding batch", local_addr, e);
+            log.error(local_addr + ": failed processing batch; discarding batch", e);
             // we need to drop the batch if we for example have a failure fetching a cipher, or else other messages
             // in the batch might make it up the stack, bypassing decryption! This is not an issue because encryption
             // is below NAKACK2 or UNICAST3, so messages will get retransmitted

--- a/src/org/jgroups/protocols/FORK.java
+++ b/src/org/jgroups/protocols/FORK.java
@@ -205,7 +205,7 @@ public class FORK extends Protocol {
             }
         }
         catch(Throwable ex) {
-            log.error("%s: failed fetching state from main channel", local_addr, ex);
+            log.error(local_addr + ": failed fetching state from main channel", ex);
         }
     }
 
@@ -260,7 +260,7 @@ public class FORK extends Protocol {
         catch(EOFException ignored) {
         }
         catch(Throwable ex) {
-            log.error("%s: failed setting state in main channel", local_addr, ex);
+            log.error(local_addr + ": failed setting state in main channel", ex);
         }
     }
 

--- a/src/org/jgroups/protocols/MPING.java
+++ b/src/org/jgroups/protocols/MPING.java
@@ -243,7 +243,7 @@ public class MPING extends PING implements Runnable {
                 if ((Util.getIpStackType() == StackType.IPv4 && addr instanceof Inet4Address)
                   || (Util.getIpStackType() == StackType.IPv6 && addr instanceof Inet6Address)) {
                     s.joinGroup(tmp_mcast_addr, i);
-                    log.trace("joined " + tmp_mcast_addr + " on " + i.getName() + " (" + addr + ")");
+                    log.trace("joined %s on %s (%s)", tmp_mcast_addr, i.getName(), addr);
                     break;
                 }
             }

--- a/src/org/jgroups/protocols/PDC.java
+++ b/src/org/jgroups/protocols/PDC.java
@@ -164,7 +164,8 @@ public class PDC extends Protocol {
             return mapping;
         }
         catch(Exception e) {
-            log.debug("failed to read file : "+file.getAbsolutePath(), e);
+            if(log.isDebugEnabled())
+                log.debug("failed to read file : " + file.getAbsolutePath(), e);
             return null;
         }
         finally {

--- a/src/org/jgroups/protocols/SHARED_LOOPBACK.java
+++ b/src/org/jgroups/protocols/SHARED_LOOPBACK.java
@@ -62,7 +62,7 @@ public class SHARED_LOOPBACK extends TP {
         synchronized(routing_table) {
             Map<Address,SHARED_LOOPBACK> dests=routing_table.get(this.cluster_name);
             if(dests == null) {
-                log.trace("no destination found for " + this.cluster_name);
+                log.trace("no destination found for %s", this.cluster_name);
                 return;
             }
             targets=dests.entrySet().stream().filter(e -> !Objects.equals(local_addr, e.getKey()))
@@ -88,7 +88,7 @@ public class SHARED_LOOPBACK extends TP {
         synchronized(routing_table) {
             Map<Address,SHARED_LOOPBACK> dests=routing_table.get(cluster_name);
             if(dests == null) {
-                log.trace("no destination found for " + cluster_name);
+                log.trace("no destination found for %s", cluster_name);
                 return;
             }
             target=dests.get(dest);

--- a/src/org/jgroups/protocols/TCPGOSSIP.java
+++ b/src/org/jgroups/protocols/TCPGOSSIP.java
@@ -117,7 +117,7 @@ public class TCPGOSSIP extends Discovery implements RouterStub.MembersNotificati
             log.error(Util.getMessage("GroupaddrOrLocaladdrIsNullCannotRegisterWithGossipRouterS"));
         else {
             InetAddress bind_addr=getTransport().getBindAddress();
-            log.trace("registering " + local_addr + " under " + cluster_name + " with GossipRouter");
+            log.trace("registering %s under %s with GossipRouter", local_addr, cluster_name);
             stubManager.destroyStubs();
             PhysicalAddress physical_addr = (PhysicalAddress) down_prot.down(new Event(Event.GET_PHYSICAL_ADDRESS, local_addr));
             stubManager=new RouterStubManager(log, timer, cluster_name, local_addr, NameCache.get(local_addr), physical_addr, reconnect_interval)

--- a/src/org/jgroups/protocols/VERIFY_SUSPECT.java
+++ b/src/org/jgroups/protocols/VERIFY_SUSPECT.java
@@ -250,9 +250,9 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
             boolean rc=host.isReachable(intf, 0, (int)timeout);
             stop=getCurrentTimeMillis();
             if(rc) // success
-                log.trace("successfully received response from " + host + " (after " + (stop-start) + "ms)");
+                log.trace("successfully received response from %s (after %dms)", host, (stop-start));
             else { // failure
-                log.debug("failed pinging " + suspected_mbr + " after " + (stop-start) + "ms; passing up SUSPECT event");
+                log.debug("failed pinging %s after %dms; passing up SUSPECT event", suspected_mbr, (stop-start));
                 removeSuspect(suspected_mbr);
                 up_prot.up(new Event(Event.SUSPECT, Collections.singletonList(suspected_mbr)));
             }
@@ -301,7 +301,7 @@ public class VERIFY_SUSPECT extends Protocol implements Runnable {
     public void unsuspect(Address mbr) {
         boolean removed=mbr != null && removeSuspect(mbr);
         if(removed) {
-            log.trace("member " + mbr + " was unsuspected");
+            log.trace("member %s was unsuspected", mbr);
             down_prot.down(new Event(Event.UNSUSPECT, mbr));
             up_prot.up(new Event(Event.UNSUSPECT, mbr));
         }

--- a/src/org/jgroups/protocols/dns/AddressedDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/AddressedDNSResolver.java
@@ -49,7 +49,8 @@ public class AddressedDNSResolver extends DefaultDNSResolver {
                 }
             }
         } catch (NamingException ex) {
-            log.trace("no DNS records for query %s, ex: %a", dnsQuery, ex);
+            if(log.isTraceEnabled())
+                log.trace("no DNS records for query " + dnsQuery, ex);
         }
         return addresses;
     }

--- a/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
+++ b/src/org/jgroups/protocols/dns/DefaultDNSResolver.java
@@ -99,7 +99,8 @@ public class DefaultDNSResolver implements DNSResolver {
                 }
             }
         } catch (NamingException ex) {
-            log.trace("no DNS records for query " + dnsQuery, ex);
+            if(log.isTraceEnabled())
+                log.trace("no DNS records for query " + dnsQuery, ex);
         }
 
         return addresses;

--- a/src/org/jgroups/protocols/relay/Bridge.java
+++ b/src/org/jgroups/protocols/relay/Bridge.java
@@ -65,7 +65,7 @@ public class Bridge implements Receiver {
             if(!rel.hasRouteTo(r))
                 up.add(r);
         }
-        log.trace("[Relayer " + channel.getAddress() + "] view: " + new_view);
+        log.trace("[Relayer %s] view: %s", channel.getAddress(), new_view);
         for(Map.Entry<String,List<Address>> entry: sites.entrySet()) {
             String        key=entry.getKey();
             List<Address> val=entry.getValue();

--- a/src/org/jgroups/protocols/relay/RELAY.java
+++ b/src/org/jgroups/protocols/relay/RELAY.java
@@ -320,7 +320,7 @@ public abstract class RELAY extends Protocol {
         site_config=sites.get(site);
         if(site_config == null)
             throw new Exception("site configuration for \"" + site + "\" not found in " + config);
-        log.trace("site configuration:\n" + site_config);
+        log.trace("site configuration:\n%s", site_config);
         prots_above=getIdsAbove();
     }
 

--- a/src/org/jgroups/protocols/relay/RELAY2.java
+++ b/src/org/jgroups/protocols/relay/RELAY2.java
@@ -244,7 +244,7 @@ public class RELAY2 extends RELAY {
             if(cease_site_master) { // ceased being the site master: stop the relayer
                 is_site_master=false;
                 notifySiteMasterListener(false);
-                log.trace(local_addr + ": ceased to be site master; closing bridges");
+                log.trace("%s: ceased to be site master; closing bridges", local_addr);
                 if(relayer != null)
                     relayer.stop();
             }
@@ -469,7 +469,7 @@ public class RELAY2 extends RELAY {
 
     protected void startRelayer(Relayer2 rel, String bridge_name) {
         try {
-            log.trace(local_addr + ": became site master; starting bridges");
+            log.trace("%s: became site master; starting bridges", local_addr);
             rel.start(site_config.getBridges(), bridge_name, site);
         }
         catch(Throwable t) {

--- a/src/org/jgroups/protocols/relay/RELAY3.java
+++ b/src/org/jgroups/protocols/relay/RELAY3.java
@@ -230,7 +230,7 @@ public class RELAY3 extends RELAY {
             if(cease_site_master) { // ceased being the site master: stop the relayer
                 is_site_master=false;
                 notifySiteMasterListener(false);
-                log.trace(local_addr + ": ceased to be site master; closing bridges");
+                log.trace("%s: ceased to be site master; closing bridges", local_addr);
                 if(relayer != null)
                     relayer.stop();
             }
@@ -618,7 +618,7 @@ public class RELAY3 extends RELAY {
 
     protected CompletableFuture<Relayer> startRelayer(Relayer3 rel, String bridge_name) {
         try {
-            log.trace(local_addr + ": became site master; starting bridges");
+            log.trace("%s: became site master; starting bridges", local_addr);
             return rel.start(site_config, bridge_name, site);
         }
         catch(Throwable t) {

--- a/src/org/jgroups/protocols/relay/Relayer2.java
+++ b/src/org/jgroups/protocols/relay/Relayer2.java
@@ -37,7 +37,7 @@ public class Relayer2 extends Relayer {
     public void start(List<RelayConfig.BridgeConfig> bridge_configs, String bridge_name, final String my_site_id)
       throws Throwable {
         if(done) {
-            log.trace(relay.getAddress() + ": will not start the Relayer as stop() has been called");
+            log.trace("%s: will not start the Relayer as stop() has been called", relay.getAddress());
             return;
         }
         try {
@@ -63,7 +63,7 @@ public class Relayer2 extends Relayer {
         }
         finally {
             if(done) {
-                log.trace(relay.getAddress() + ": stop() was called while starting the relayer; stopping the relayer now");
+                log.trace("%s: stop() was called while starting the relayer; stopping the relayer now", relay.getAddress());
                 stop();
             }
         }
@@ -146,7 +146,7 @@ public class Relayer2 extends Relayer {
         /** The view contains a list of SiteUUIDs. Adjust the routing table based on the SiteUUIDs UUID and site */
         public void viewAccepted(View new_view) {
             this.view=new_view;
-            log.trace("[Relayer " + channel.getAddress() + "] view: " + new_view);
+            log.trace("[Relayer %s] view: %s", channel.getAddress(), new_view);
 
             Map<String,List<Address>> tmp=extract(new_view);
             Set<String>               down=new HashSet<>(routes.keySet());

--- a/src/org/jgroups/protocols/relay/Relayer3.java
+++ b/src/org/jgroups/protocols/relay/Relayer3.java
@@ -39,7 +39,7 @@ public class Relayer3 extends Relayer {
      */
     public CompletableFuture<Relayer> start(RelayConfig.SiteConfig site_cfg, String bridge_name, final String my_site_id) throws Throwable {
         if(done) {
-            log.trace(relay.getAddress() + ": will not start the Relayer as stop() has been called");
+            log.trace("%s: will not start the Relayer as stop() has been called", relay.getAddress());
             return CompletableFuture.completedFuture(this);
         }
         try {

--- a/src/org/jgroups/stack/Configurator.java
+++ b/src/org/jgroups/stack/Configurator.java
@@ -537,7 +537,7 @@ public record Configurator(ProtocolStack stack) {
                         throw new Exception("default could not be assigned for field " + propertyName + " in "
                                               + obj + " with default value " + defaultValue, e);
                     }
-                    log.debug("set property " + obj + "." + propertyName + " to default value " + converted);
+                    log.debug("set property %s.%s to default value %s", obj, propertyName, converted);
                 }
             }
         }

--- a/src/org/jgroups/stack/ProtocolStack.java
+++ b/src/org/jgroups/stack/ProtocolStack.java
@@ -595,7 +595,7 @@ public class ProtocolStack extends Protocol {
         Address local_address=getTransport() != null? getTransport().getAddress() : null;
         if(local_address != null)
             prot.setAddress(local_address);
-        log.debug("inserted " + prot + " at the top of the stack");
+        log.debug("inserted %s at the top of the stack", prot);
     }
 
 


### PR DESCRIPTION
For convenience, commit messages of all commits with reasoninig:


>  JGRP-3006 Fix log calls where exceptions are passed as format args instead of Throwable; e.g. throwing IllegalFormatConversionException
> 
>   When an exception is passed as a varargs format argument (3+ args), it uses the (String, Object...) overload instead of (String, Throwable), causing the stack trace to be silently lost.
>   Restructure these calls to use the (String, Throwable) overload so stack traces are properly logged.
> 
>   Also fixes AddressedDNSResolver which used the invalid %a format specifier on a Throwable, causing an IllegalFormatConversionException that was silently swallowed by the logger.
> 
>   Add guards for debug/trace log calls with string concatenation and Throwable as there is no format version of the method that accepts an exception
> 
>   Replace string concatenation with format strings in debug/trace log calls.
>   Eager string concatenation in log.debug/trace(msg) calls forces toString() and StringBuilder allocation regardless of log level.
>   The varargs overload log.debug/trace(format, args...) checks isDebugEnabled/isTraceEnabled before formatting, avoiding unnecessary work when the level is disabled.

https://redhat.atlassian.net/browse/JGRP-3006