### PR TITLE
[TEST] EnableSuspectEventsDeterministicEventTest

### DIFF
--- a/conf/scripts/EnableSuspectEventsDeterministicEventTest/testRepeatedLeaveAndJoin.btm
+++ b/conf/scripts/EnableSuspectEventsDeterministicEventTest/testRepeatedLeaveAndJoin.btm
@@ -1,0 +1,59 @@
+
+## Trace + delay: log the critical points and delay the rejoining node's
+## replaceConnection to widen the race window for the concurrent connect.
+
+RULE T1_getConnection
+CLASS BaseServer
+METHOD getConnection
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T1] getConnection(" + $1 + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName())
+ENDRULE
+
+RULE T4_handleOutgoing
+CLASS BaseServer
+METHOD handleOutgoingConnection
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T4] handleOutgoingConnection(" + $1 + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName())
+ENDRULE
+
+RULE T4_handleIncoming
+CLASS BaseServer
+METHOD handleIncomingConnection
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T4] handleIncomingConnection(" + $1 + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName())
+ENDRULE
+
+RULE T5_notifyConnectionClosed
+CLASS BaseServer
+METHOD notifyConnectionClosed
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T5] notifyConnectionClosed(" + $1 + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName())
+ENDRULE
+
+RULE T6_removeConnectionIfPresent
+CLASS BaseServer
+METHOD removeConnectionIfPresent
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T6] removeConnectionIfPresent(" + $1 + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName())
+ENDRULE
+
+RULE T7_replaceConnection
+CLASS BaseServer
+METHOD replaceConnection
+AT ENTRY
+IF TRUE
+DO
+    System.out.println("--> " + Thread.currentThread().getName().substring(Thread.currentThread().getName().lastIndexOf(",") + 1) + " [T7] replaceConnection(" + $1 + ", closed=" + $2.isClosed() + ") node=" + $0.localAddress() + " thread=" + Thread.currentThread().getName());
+    org.jgroups.tests.helpers.EnableSuspectEventsTestHelper.maybePause($0.localAddress(), $1, $2, Thread.currentThread().getName())
+ENDRULE
+

--- a/tests/byteman/org/jgroups/tests/byteman/EnableSuspectEventsDeterministicEventTest.java
+++ b/tests/byteman/org/jgroups/tests/byteman/EnableSuspectEventsDeterministicEventTest.java
@@ -1,0 +1,175 @@
+package org.jgroups.tests.byteman;
+
+import org.jboss.byteman.contrib.bmunit.BMNGRunner;
+import org.jboss.byteman.contrib.bmunit.BMScript;
+import org.jgroups.*;
+import org.jgroups.protocols.*;
+import org.jgroups.protocols.pbcast.GMS;
+import org.jgroups.tests.helpers.EnableSuspectEventsTestHelper;
+import org.jgroups.util.Util;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Tests {@link BasicTCP#enableSuspectEvents(boolean)} to reproduce https://issues.redhat.com/browse/JGRP-2968 / https://issues.redhat.com/browse/WFLY-21236
+ *
+ * Uses Byteman to deterministically reproduce the race condition between conn.start() and
+ * replaceConnection() in {@link org.jgroups.blocks.cs.BaseServer#handleOutgoingConnection}.
+ *
+ * @author Radoslav Husar
+ */
+@Test(groups = Global.BYTEMAN, singleThreaded = true)
+public class EnableSuspectEventsDeterministicEventTest extends BMNGRunner {
+
+    private static final String  CLUSTER_NAME = EnableSuspectEventsDeterministicEventTest.class.getSimpleName();
+    private static final int     NUM_NODES = 3;
+    private static final int     BASE_PORT = 7800;
+    private static final int     NUM_ITERATIONS = 10;
+    private static final boolean FORCE_IPV6 = false;
+
+    private final LinkedList<JChannel> channels=new LinkedList<>();
+
+    @BeforeMethod
+    protected void setup() throws Exception {
+        String hostname = "localhost";
+
+        // IPv6?
+        if (FORCE_IPV6) {
+            System.setProperty("java.net.preferIPv6Addresses", "true");
+            hostname = "::1";
+        }
+
+        InetAddress localhost = InetAddress.getByName(hostname);
+        List<InetSocketAddress> initialHosts = new ArrayList<>();
+        for (int i = 0; i < NUM_NODES; i++) {
+            initialHosts.add(new InetSocketAddress(localhost, BASE_PORT + i));
+        }
+
+        // Create and connect all channels
+        for (int i = 0; i < NUM_NODES; i++) {
+            channels.add(createChannel(i, initialHosts, localhost).connect(CLUSTER_NAME));
+        }
+
+        // Wait for all channels to have the same view
+        Util.waitUntilAllChannelsHaveSameView(10000, 500, channels);
+
+        System.out.printf("-- Initial cluster formed with %d nodes\n", NUM_NODES);
+        for (JChannel ch: channels) {
+            System.out.printf("   %s: %s, physical address: %s\n",
+                    ch.getName(),
+                    ch.getView(),
+                    ch.down(new Event(Event.GET_PHYSICAL_ADDRESS, ch.getAddress())));
+        }
+    }
+
+    @AfterMethod
+    protected void tearDown() {
+        Util.close(channels);
+    }
+
+    @BMScript(dir="scripts/EnableSuspectEventsDeterministicEventTest", value="testRepeatedLeaveAndJoin")
+    public void testRepeatedLeaveAndJoin() throws Exception {
+        for (int iteration = 0; iteration < NUM_ITERATIONS; iteration++) {
+            JChannel coordinator = channels.removeFirst();
+            Address coord_addr=coordinator.address();
+            if (coordinator == null || !Objects.equals(coordinator.view().getCoord(), coordinator.address())) {
+                throw new IllegalStateException("No coordinator found!");
+            }
+
+            System.out.printf("\n=== Iteration %d: Coordinator %s leaving ===\n", iteration + 1, coordinator.name());
+
+            // Gracefully disconnect the coordinator simulating graceful node shutdown
+            // The bug manifests when TCP connections close after LEAVE, triggering suspect events
+            coordinator.disconnect();
+
+            // Check the views on the remaining nodes
+            System.out.print("   Checking remaining nodes:\n");
+            Util.waitUntil(5000, 100,
+                           () -> channels.stream().map(JChannel::view).allMatch(v -> v.size() == 2),
+                           () -> String.format("all views must have 2 members: %s", print(channels)));
+            System.out.printf("%s\n", print(channels));
+
+            System.out.printf("=== Node %s rejoining ===\n", coord_addr);
+
+            // Arm the Byteman race injection for the rejoining node
+            EnableSuspectEventsTestHelper.arm(coordinator.name());
+
+            // Reconnect the old coordinator (it was gracefully disconnected)
+            coordinator.connect(CLUSTER_NAME);
+            channels.add(coordinator);
+
+            // Wait for all nodes to have the same view again (should be 3 nodes)
+            Util.waitUntilAllChannelsHaveSameView(10000, 500, channels);
+
+            EnableSuspectEventsTestHelper.disarm();
+            System.out.printf("after joining:\n%s\n", print(channels));
+        }
+
+        System.out.printf("Completed %d iterations without concurrent leaves\n", NUM_ITERATIONS);
+    }
+
+    private static String print(List<JChannel> l) {
+        return l.stream().map(ch -> String.format("%s: %s", ch.address(), ch.view()))
+          .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Stack mimicking WF stack - https://github.com/wildfly/wildfly/blob/39.0.0.Beta1/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
+     * With the matching defaults - https://github.com/wildfly/wildfly/blob/39.0.0.Beta1/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+     */
+    private static JChannel createChannel(int index, List<InetSocketAddress> initialHosts, InetAddress bindAddr) throws Exception {
+        String name = String.valueOf((char)(index + 'A'));
+
+        TCP tcp = new TCP();
+        tcp.setBindAddress(bindAddr);  // Use IPv6 address
+        tcp.setPortRange(0);
+        tcp.setBindPort(BASE_PORT + index);
+        tcp.setSendBufSize(640000);  // 640k
+        tcp.setSockConnTimeout(300);  // 300ms
+        tcp.enableSuspectEvents(true); // Critical: enable suspect events on connection close!
+        tcp.setLevel("debug");
+
+        RED red = new RED();
+
+        TCPPING tcpping = new TCPPING()
+                .setInitialHosts(initialHosts)
+                .setPortRange(0)
+                .numDiscoveryRuns(3);
+
+        MERGE3 merge3 = new MERGE3()
+                .setMinInterval(10000)  // 10s
+                .setMaxInterval(30000);  // 30s
+
+        FD_ALL3 fdAll3 = new FD_ALL3()
+                .setInterval(15000)  // 15s
+                .setTimeout(60000);  // 60s
+
+        VERIFY_SUSPECT2 verifySuspect2 = new VERIFY_SUSPECT2()
+                .setTimeout(1000);  // 1s
+
+        NAKACK4 nakack4 = (NAKACK4) new NAKACK4()
+                .setXmitInterval(100);  // 100ms
+
+        UNICAST4 unicast4 = (UNICAST4) new UNICAST4()
+                .setXmitInterval(100);  // 100ms
+
+        GMS gms = new GMS()
+                .printLocalAddress(false);
+
+        FRAG4 frag4 = new FRAG4()
+                .setFragSize(60000);  // 60k
+
+        // Without VERIFY_SUSPECT2, suspect events will immediately cause removal
+        return new JChannel(tcp, red, tcpping, merge3, fdAll3, verifySuspect2, nakack4, unicast4, gms, frag4).name(name);
+    }
+
+}

--- a/tests/byteman/org/jgroups/tests/helpers/EnableSuspectEventsTestHelper.java
+++ b/tests/byteman/org/jgroups/tests/helpers/EnableSuspectEventsTestHelper.java
@@ -1,0 +1,60 @@
+package org.jgroups.tests.helpers;
+
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Byteman helper for EnableSuspectEventsDeterministicEventTest.
+ * <p>
+ * Delays the rejoining node's replaceConnection to widen the race window
+ * so the other node's concurrent connect completes first, causing rejection
+ * and socket close — producing a dead connection in the conns map.
+ */
+public class EnableSuspectEventsTestHelper extends Helper {
+
+    private static final AtomicBoolean armed = new AtomicBoolean(false);
+    private static final AtomicReference<String> armedNodeName = new AtomicReference<>();
+
+    protected EnableSuspectEventsTestHelper(Rule rule) {
+        super(rule);
+    }
+
+    /** Arm the delay for the given node name (e.g. "A", "B", "C") */
+    public static void arm(String nodeName) {
+        armedNodeName.set(nodeName);
+        armed.set(true);
+    }
+
+    public static void disarm() {
+        armed.set(false);
+        armedNodeName.set(null);
+    }
+
+    /**
+     * Called by Byteman at replaceConnection entry.
+     * Pauses only if armed AND the current thread belongs to the rejoining node.
+     * Thread names follow the pattern: pd-bundler-XX,ClusterName,NodeName
+     */
+    public static void maybePause(Object node, Object dest, Object conn, String threadName) {
+        if(!armed.get())
+            return;
+        String targetNode = armedNodeName.get();
+        if(targetNode == null || !threadName.endsWith("," + targetNode))
+            return;
+        // Fire once
+        armed.set(false);
+
+        System.out.println("--> [DELAY] replaceConnection PAUSING node=" + node
+                           + " dest=" + dest + " thread=" + threadName);
+        try {
+            Thread.sleep(3000);
+        }
+        catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        System.out.println("--> [DELAY] replaceConnection RESUMING node=" + node);
+    }
+}


### PR DESCRIPTION
@belaban @rhusar 

This test makes deterministic the connection closed poising by the test create by @rhusar. The only thing it does is to introduce a delay in the rejoining node to make the other nodes reject the connecttion (from their side) when they are trying to reconnect with the node. The dead connection causes the test to fail. The test is exacly the same as @rhusar did bu just addin this little delay.

Have a look and let me know if you think is worth fixing or not.