### PR TITLE
Fix stale connection handling in BaseServer.getConnection() and handleIncomingConnection()

### DIFF
--- a/src/org/jgroups/blocks/cs/BaseServer.java
+++ b/src/org/jgroups/blocks/cs/BaseServer.java
@@ -302,6 +302,10 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         try {
             if(connected(conn=conns.get(dest)))
                 return conn;
+            if(conn != null) {
+                conns.remove(dest);
+                Util.close(conn);
+            }
             conn=createConnection(dest);
             handleOutgoingConnection(dest, conn);
         }
@@ -365,8 +369,14 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         Lock lock=getLock(peer_addr);
         lock.lock();
         try {
-            boolean conn_exists=hasConnection(peer_addr),
+            Connection existing=conns.get(peer_addr);
+            boolean conn_exists=connected(existing),
               replace=conn_exists && local_addr.compareTo(peer_addr) < 0; // bigger conn wins
+
+            if(!replace && conn_exists && isStale(existing)) {
+                replace=true;
+                log.trace("%s: existing connection to %s is stale, replacing", local_addr, peer_addr);
+            }
 
             if(!conn_exists || replace) {
                 notifyConnectionEstablished(conn);
@@ -384,6 +394,14 @@ public abstract class BaseServer implements Closeable, ConnectionListener {
         }
         if(close_conn)
             Util.close(conn); // closing the connection outside the lock scope (might block if TLS)
+    }
+
+    public boolean isStale(Connection conn) {
+        if(conn == null)
+            return false;
+        long now=conn.getTimestamp();
+        long threshold=TimeUnit.NANOSECONDS.convert(sock_conn_timeout, TimeUnit.MILLISECONDS);
+        return now - conn.last_access > threshold;
     }
 
     public BaseServer addConnectionListener(ConnectionListener cl) {

--- a/tests/junit-functional/org/jgroups/tests/StaleConnectionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/StaleConnectionTest.java
@@ -1,0 +1,86 @@
+package org.jgroups.tests;
+
+import org.jgroups.Global;
+import org.jgroups.blocks.cs.Connection;
+import org.jgroups.blocks.cs.TcpServer;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.Util;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+
+/**
+ * Tests for stale connection handling in BaseServer.
+ * <ul>
+ *   <li>Test 1: getConnection() cleans up a stale outgoing connection</li>
+ *   <li>Test 2: isStale() returns true for connections older than sock_conn_timeout</li>
+ * </ul>
+ * @see <a href="https://issues.redhat.com/browse/JGRP-2968">JGRP-2968</a>
+ */
+@Test(groups=Global.FUNCTIONAL, singleThreaded=true)
+public class StaleConnectionTest {
+    protected TcpServer serverA, serverB;
+
+    @AfterMethod
+    protected void destroy() {
+        Util.close(serverA, serverB);
+    }
+
+    /**
+     * getConnection() should remove and close a stale connection before creating a new one.
+     * A connects to B, B restarts (killing the socket), A.getConnection(B) should
+     * detect the dead connection, clean it up, and create a fresh one.
+     */
+    public void testGetConnectionCleansUpStaleOutgoing() throws Exception {
+        InetAddress loopback=Util.getLoopback();
+        serverA=new TcpServer(loopback, 0);
+        serverB=new TcpServer(loopback, 0);
+        serverA.start();
+        serverB.start();
+
+        IpAddress addrB=(IpAddress)serverB.localAddress();
+
+        Connection conn1=serverA.getConnection(addrB);
+        assert conn1 != null && !conn1.isClosed() : "initial connection should be open";
+
+        // Restart B → kills the old socket from B's side
+        int bPort=addrB.getPort();
+        serverB.stop();
+        Util.sleep(300);
+        serverB=new TcpServer(loopback, bPort);
+        serverB.start();
+        Util.sleep(500);
+
+        // getConnection should detect the dead connection, remove it, and create a new one
+        Connection conn2=serverA.getConnection(addrB);
+        assert conn2 != null && !conn2.isClosed() : "new connection should be open";
+        assert conn2 != conn1 : "should be a different connection object";
+    }
+
+    /**
+     * isStale() should return true for connections whose last_access exceeds sock_conn_timeout.
+     * Uses a single server — creates a connection, then waits past the threshold.
+     */
+    public void testIsStaleDetectsOldConnection() throws Exception {
+        InetAddress loopback=Util.getLoopback();
+        serverA=new TcpServer(loopback, 0);
+        serverB=new TcpServer(loopback, 0);
+        serverA.start();
+        serverB.start();
+
+        IpAddress addrB=(IpAddress)serverB.localAddress();
+
+        // Create a connection — its last_access is set to now
+        Connection conn=serverA.getConnection(addrB);
+        assert conn != null;
+        assert !serverA.isStale(conn) : "fresh connection should not be stale";
+
+        // Wait longer than sock_conn_timeout (default 1000ms)
+        int timeout=serverA.socketConnectionTimeout();
+        Util.sleep(timeout + 500);
+
+        // Now last_access is older than sock_conn_timeout → stale
+        assert serverA.isStale(conn) : "old connection should be detected as stale";
+    }
+}


### PR DESCRIPTION
getConnection(): when the locked path finds a connection in the conns map that is not connected (stale), remove and close it before creating a new one.

handleIncomingConnection(): when the "bigger address wins" logic would reject an incoming connection, first check if the existing connection is stale (last_access older than sock_conn_timeout). If stale, accept the incoming and replace the dead connection instead of rejecting. This prevents the infinite rejection loop where a node cannot rejoin the cluster because a peer holds a stale connection entry from a previous epoch.