### PR TITLE
Create Ansible setup for JGroups

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,4 @@
+*_inventory.yaml
+*.pem
+ansible.cfg
+

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,30 @@
+# JGroups Ansible Setup
+
+Ansible playbook to prepare remote nodes for running JGroups clusters.
+
+## Prerequisites
+
+- Ansible installed locally
+- GCP (or AWS) nodes already running and accessible via SSH
+- An inventory file with the target hosts (see templates below)
+
+## Usage
+
+```bash
+ansible-playbook -i <inventory-file> setup.yml
+```
+
+## What `setup.yml` does
+
+- **Installs dependencies** (git, zip, unzip, net-tools, rsync, SDKMAN!, JDK 25, async-profiler).
+  Installed once and skipped on subsequent runs.
+  Delete the marker to force reinstallation (`/tmp/jgroups_deps_installed`).
+- **Uploads `bin/` and `target/`** from the JGroups project root to `$HOME` on each node.
+- **Generates `hosts.txt`** under `target/classes/` with private IPs of all instances for cluster discovery.
+  Only created when `target/` exists locally.
+
+## Inventory
+
+Copy and edit a template for your environment:
+
+- `gcp-inventory.yaml.template` — GCP nodes with placeholder IPs

--- a/ansible/gcp-inventory.yaml.template
+++ b/ansible/gcp-inventory.yaml.template
@@ -1,0 +1,27 @@
+controller:
+  vars:
+    ansible_user: bela
+  hosts:
+    vm1:
+      ansible_host: $0
+
+instances:
+  vars:
+    ansible_user: bela
+  hosts:
+     vm1:
+       ansible_host: $0
+     vm2:
+       ansible_host: $1
+     vm3:
+       ansible_host: $2
+     vm4:
+       ansible_host: $3
+     vm5:
+       ansible_host: $4
+     vm6:
+       ansible_host: $5
+     vm7:
+       ansible_host: $6
+     vm8:
+       ansible_host: $7

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,0 +1,121 @@
+- name: Setup JGroups cluster environment
+  hosts: instances
+  vars:
+    jdk_version: "25.0.2-open"
+    bin_folder: "../bin"
+    target_folder: "../target"
+    remote_folder: "/home/{{ ansible_user }}"
+    sdkman_folder: "/home/{{ ansible_user }}/.sdkman"
+    deps_marker: "/tmp/jgroups_deps_installed"
+    asprof_arch: "{{ 'arm64' if ansible_facts.architecture == 'aarch64' else 'x64' }}"
+
+  tasks:
+    - name: Check if dependencies already installed
+      ansible.builtin.stat:
+        path: "{{ deps_marker }}"
+      register: deps_installed
+
+    - name: Install dependencies
+      when: not deps_installed.stat.exists
+      block:
+        - name: Install packages
+          ansible.builtin.package:
+            name: "{{ item }}"
+            state: present
+          become: true
+          loop:
+            - git
+            - zip
+            - unzip
+            - net-tools
+            - rsync
+
+        - name: Install SDKMAN!
+          ansible.builtin.shell: "curl -s 'https://get.sdkman.io' | bash"
+          args:
+            creates: "{{ sdkman_folder }}/etc/config"
+
+        - name: Configure SDKMAN!
+          ansible.builtin.shell: |
+            sed -i 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' "{{ sdkman_folder }}/etc/config"
+
+        - name: Install JDK {{ jdk_version }}
+          ansible.builtin.shell: |
+            source {{ sdkman_folder }}/bin/sdkman-init.sh
+            sdk install java {{ jdk_version }}
+          args:
+            executable: /bin/bash
+          register: jdk_install_output
+          until: jdk_install_output.rc == 0
+          retries: 5
+          delay: 10
+
+        - name: Clean SDKMAN! cache
+          ansible.builtin.shell: |
+            source {{ sdkman_folder }}/bin/sdkman-init.sh
+            sdk flush
+          args:
+            executable: /bin/bash
+
+        - name: Install async-profiler
+          block:
+            - name: Download async-profiler ({{ asprof_arch }})
+              ansible.builtin.get_url:
+                url: "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-{{ asprof_arch }}.tar.gz"
+                dest: "{{ remote_folder }}/asprof.tar.gz"
+              register: asprof_download
+              ignore_errors: true
+
+            - name: Unarchive async-profiler
+              ansible.builtin.unarchive:
+                src: "{{ remote_folder }}/asprof.tar.gz"
+                dest: "{{ remote_folder }}"
+                remote_src: true
+              when: asprof_download is succeeded
+
+        - name: Mark dependencies as installed
+          ansible.builtin.file:
+            path: "{{ deps_marker }}"
+            state: touch
+
+    - name: Destroy previous artifacts
+      ansible.builtin.file:
+        state: absent
+        path: "{{ item }}"
+      loop:
+        - "{{ remote_folder }}/bin"
+        - "{{ remote_folder }}/target"
+
+    - name: Upload bin folder
+      ansible.posix.synchronize:
+        src: "{{ bin_folder }}"
+        dest: "{{ remote_folder }}"
+
+    - name: Check if target folder exists locally
+      ansible.builtin.stat:
+        path: "{{ target_folder }}"
+      delegate_to: localhost
+      register: target_exists
+
+    - name: Upload target and generate hosts.txt
+      when: target_exists.stat.exists
+      block:
+        - name: Upload target folder
+          ansible.posix.synchronize:
+            src: "{{ target_folder }}"
+            dest: "{{ remote_folder }}"
+
+        - name: Ensure target/classes directory exists
+          ansible.builtin.file:
+            path: "{{ remote_folder }}/target/classes"
+            state: directory
+
+        - name: Collect private IPs for cluster discovery
+          ansible.builtin.set_fact:
+            cluster_hosts: "{{ cluster_hosts | default([]) + [hostvars[item].ansible_facts.all_ipv4_addresses[0]] }}"
+          loop: "{{ groups['instances'] }}"
+
+        - name: Create hosts.txt
+          ansible.builtin.copy:
+            content: "{{ cluster_hosts | join('\n') }}\n"
+            dest: "{{ remote_folder }}/target/classes/hosts.txt"


### PR DESCRIPTION
This one is only a small setup. It installs the dependencies and pushes the local JGroups build remotely to all nodes. I've copied the inventory template we have in IspnPerf, too.

I haven't included any playbook that runs something, and also, no playbook that stops all Java processes in all nodes.
Let me know if you are interested in any of that.