### PR TITLE
Faster vt creation

### DIFF
--- a/src/org/jgroups/util/DefaultThreadFactory.java
+++ b/src/org/jgroups/util/DefaultThreadFactory.java
@@ -109,21 +109,19 @@ public class DefaultThreadFactory implements ThreadFactory {
             addr=this.address;
 
         String name=base_name != null? base_name : "thread";
-        int estimated_size=name.length() + 10; // additional space for numbering
-        if(cluster_name != null)
-            estimated_size+=cluster_name.length();
-        if(addr != null)
-            estimated_size+=addr.length();
 
-        StringBuilder sb=new StringBuilder(estimated_size).append(name);
         if(use_numbering) {
             int id=counter.incrementAndGet();
-            sb.append("-").append(id);
+            if(includeClusterName)
+                return includeLocalAddress? name + '-' + id + ',' + cluster_name + ',' + addr
+                  : name + '-' + id + ',' + cluster_name;
+            return includeLocalAddress? name + '-' + id + ',' + addr
+              : name + '-' + id;
         }
+
         if(includeClusterName)
-            sb.append(',').append(cluster_name);
-        if(includeLocalAddress)
-            sb.append(',').append(addr);
-        return sb.toString();
+            return includeLocalAddress? name + ',' + cluster_name + ',' + addr
+              : name + ',' + cluster_name;
+        return includeLocalAddress? name + ',' + addr : name;
     }
 }

--- a/src/org/jgroups/util/ThreadCreator.java
+++ b/src/org/jgroups/util/ThreadCreator.java
@@ -13,15 +13,10 @@ import java.lang.invoke.MethodType;
  */
 public class ThreadCreator {
     private static final Log                  LOG=LogFactory.getLog(ThreadCreator.class);
-    private static final MethodHandles.Lookup LOOKUP=MethodHandles.publicLookup();
     private static final String               OF_VIRTUAL_NAME="java.lang.Thread$Builder$OfVirtual";
-    private static final Class<?>             OF_VIRTUAL_CLASS;
-    private static final MethodHandle         OF_VIRTUAL;
     private static final MethodHandle         CREATE_VTHREAD;
 
     static {
-        OF_VIRTUAL_CLASS=getOfVirtualClass();
-        OF_VIRTUAL=getOfVirtualHandle();
         CREATE_VTHREAD=getCreateVThreadHandle();
     }
 
@@ -43,10 +38,8 @@ public class ThreadCreator {
 
     protected static Thread newVirtualThread(Runnable r) {
         if(CREATE_VTHREAD != null) {
-            // Thread.ofVirtual().unstarted()
             try {
-                Object of=OF_VIRTUAL.invoke();
-                return (Thread)CREATE_VTHREAD.invokeWithArguments(of, r);
+                return (Thread)CREATE_VTHREAD.invokeExact(r);
             }
             catch(Throwable t) {
             }
@@ -55,11 +48,17 @@ public class ThreadCreator {
     }
 
     protected static MethodHandle getCreateVThreadHandle() {
-        MethodType type=MethodType.methodType(Thread.class, Runnable.class);
         try {
-            return LOOKUP.findVirtual(OF_VIRTUAL_CLASS, "unstarted", type);
+            Class<?> ofVirtualClass=getOfVirtualClass();
+            if(ofVirtualClass == null)
+                return null;
+            MethodHandle ofVirtual=MethodHandles.publicLookup().findStatic(Thread.class, "ofVirtual",
+                                                                              MethodType.methodType(ofVirtualClass));
+            return MethodHandles.publicLookup().findVirtual(ofVirtualClass, "unstarted",
+                                                            MethodType.methodType(Thread.class, Runnable.class))
+              .bindTo(ofVirtual.invoke());
         }
-        catch(Exception ex) {
+        catch(Throwable ex) {
             LOG.debug("%s.unstarted() not found, falling back to regular threads", OF_VIRTUAL_NAME);
         }
         return null;
@@ -75,13 +74,4 @@ public class ThreadCreator {
         }
     }
 
-    protected static MethodHandle getOfVirtualHandle() {
-        try {
-            return OF_VIRTUAL_CLASS != null?
-              LOOKUP.findStatic(Thread.class, "ofVirtual", MethodType.methodType(OF_VIRTUAL_CLASS)) : null;
-        }
-        catch(Exception e) {
-            return null;
-        }
-    }
 }


### PR DESCRIPTION
While analyzing some tests from @jabolina I have found that these 2 code paths are very very costly, see

<img width="1622" height="735" alt="image" src="https://github.com/user-attachments/assets/43f3d981-eff0-4a61-8beb-10767ed1a45b" />

and larger

<img width="1622" height="1043" alt="image" src="https://github.com/user-attachments/assets/dc91779e-add7-424b-951d-b323752b4679" />

at the point that altogether cost as much as I/O.

The changes here should address both by:
- using JDK optimized String concat indy which can perform straight copies from source srcs and estimation of int params, into the resulting `String` without intermediate copies
- binding the `OfVirtual::unstarted` caller to be a singleton (which is fine as we don't mutate it in any form): in this way we could use `MethodHandle::invokeExact` which doesn't need to verify at runtime the provided arguments and will be as fast as NOT using reflection

Please @jabolina I haven't actually verified both my assumptions here, but I suppose you can verify quickly by running the original benchmark as it was really a super hot method ^^
