### PR TITLE
Runner stop deadlock

### DIFF
--- a/src/org/jgroups/util/Runner.java
+++ b/src/org/jgroups/util/Runner.java
@@ -61,11 +61,15 @@ public class Runner implements Runnable, Closeable {
         return this;
     }
 
-    public synchronized Runner stop() {
-        boolean rc=state(State.stopping);
-        if(!rc)
-            return this;
-        Thread tmp=thread;
+    public Runner stop() {
+        Thread tmp;
+        synchronized (this) {
+            boolean rc=state(State.stopping);
+            if(!rc)
+                return this;
+            tmp=thread;
+        }
+
         if(tmp != null) {
             tmp.interrupt();
             if(join_timeout > 0) {


### PR DESCRIPTION
* `Runner.stop` and `run` methods compete for the same intrinsic lock when stopping.

1. `t1`:  The `stop()` method is in a synchronized block and updates the state to `stopping`;
2. `t1`: While holding the lock, the `stop` method calls `Thread.join(timeout)` in the stopping thread.
3. `t2`: The `run()` methods sees `state != running` and proceed to stop;
4. `t2`: The `run()` method tries to acquire the same intrinsic lock held by `t1`, currently in `Thread.join`.
5. `t1`: Timeout in `stop()` elapses and the method returns; the lock is released.
6. `t2`: The `run()` method acquires the intrinsic lock and updates `state = stopped`.