### PR TITLE
JGRP-3023 TcpConnection.Receiver: don't warn when a in.readInt() races with in.close() and throws IOException("Stream closed")

### DIFF
--- a/src/org/jgroups/blocks/cs/TcpConnection.java
+++ b/src/org/jgroups/blocks/cs/TcpConnection.java
@@ -294,7 +294,11 @@ public class TcpConnection extends Connection {
                 ; // regular use case when a peer closes its connection - we don't want to log this as exception
             }
             catch(Exception e) {
-                if (e instanceof SSLException && e.getMessage().contains("Socket closed")) {
+                if (!isRunning() || isClosed()) {
+                    // the connection is being closed locally (in #doClose()): a in.readInt() races with in.close() throws IOException("Stream closed"), which is expected
+                    // we don't want to log this as exception
+                }
+                else if (e instanceof SSLException && e.getMessage().contains("Socket closed")) {
                     ; // regular use case when a peer closes its connection - we don't want to log this as exception
                 }
                 else if (e instanceof SSLHandshakeException && e.getCause() instanceof EOFException) {


### PR DESCRIPTION

When a connection is closed locally, doClose() closes the socket and streams while the Receiver thread may still be inside in.readInt(). If the thread is blocked in the underlying socket read it gets a SocketException, which is already ignored as a regular close. But if it is between buffered reads  BufferedInputStream throws IOException("Stream closed") instead, which fell through to the generic handler and was logged as 'WARNING: <addr>: failed handling message'. This is benign during stopping and safe to ignore, but it's commonly observed as intermittent warnings when JChannels over TCP are closed like in our test suites.

https://redhat.atlassian.net/browse/JGRP-3023