### PR TITLE
Migrate JGroups unit tests from Ant+TestNG to Maven Surefire+TestNG

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,6 +144,27 @@ total ordering and so on.
 JGroups ships with multiple sample configurations, e.g. `tcp.xml`, which uses TCP instead of UDP as transport
 protocol. Consult the manual (link below) for more details.
 
+== Running the tests
+
+The unit tests are executed with Maven:
+
+[source,bash]
+----
+mvn test
+----
+
+This runs all TestNG suites (functional, encrypt, byteman, jdbc, stack-independent,
+time-sensitive, udp, udp-new, tcp, tcp-new, tcp-nio, tcp-nio-new).
+
+To run a single suite:
+
+[source,bash]
+----
+mvn surefire:test@functional
+----
+
+Replace `functional` with any of the suite names listed above.
+
 == Links
 * Web site: link:$$http://jgroups.org$$[http://www.jgroups.org]
 * Manual: link:$$http://www.jgroups.org/ug.html$$[http://www.jgroups.org/ug.html]

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
                           <source>tests/byteman</source>
                           <source>tests/junit</source>
                           <source>tests/junit-functional</source>
+                           <source>tests/util</source>
                           <!-- tests/other and tests/perf are included in the normal sources -->
                           <source>tests/stress</source>
                        </sources>
@@ -402,24 +403,352 @@
                 </executions>
             </plugin>
 
-            <!-- Disable default tests: they won't run since they are lacking configuration -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!--configuration>
-                    <skip>true</skip>
-                    <skipTests>true</skipTests>
-                </configuration-->
+                <version>3.5.6</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <keystore.dir>${project.basedir}/keystore</keystore.dir>
-                    </systemPropertyVariables>
-                    <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
-                    <systemPropertiesFile>build.properties</systemPropertiesFile>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                 </configuration>
                 <executions>
+                    <!-- Functional suite -->
                     <execution>
+                        <id>functional</id>
                         <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-functional.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- Encrypt suite -->
+                    <execution>
+                        <id>encrypt</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-encrypt.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- Byteman suite -->
+                    <execution>
+                        <id>byteman</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-byteman.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>
+                                -XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M
+                                -Dorg.jboss.byteman.contrib.bmunit.agent.inhibit=true
+                                -javaagent:${settings.localRepository}/org/jboss/byteman/byteman/${byteman.version}/byteman-${byteman.version}.jar=listener:true
+                            </argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- JDBC suite -->
+                    <execution>
+                        <id>jdbc</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-jdbc.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- Stack-independent suite -->
+                    <execution>
+                        <id>stack-independent</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-stack-independent.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- Time-sensitive suite -->
+                    <execution>
+                        <id>time-sensitive</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-time-sensitive.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>23000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>23000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- UDP suite -->
+                    <execution>
+                        <id>udp</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-udp.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>25000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>25000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- UDP-new suite -->
+                    <execution>
+                        <id>udp-new</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-udp-new.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>26000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>26000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- TCP suite -->
+                    <execution>
+                        <id>tcp</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-tcp.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>27000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>27000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- TCP-new suite -->
+                    <execution>
+                        <id>tcp-new</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-tcp-new.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>28000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>28000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- TCP-NIO suite -->
+                    <execution>
+                        <id>tcp-nio</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-tcp-nio.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>29000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>30000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <!-- TCP-NIO-new suite -->
+                    <execution>
+                        <id>tcp-nio-new</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng/testng-tcp-nio-new.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <argLine>-XX:+HeapDumpOnOutOfMemoryError -Xms400M -Xmx800M</argLine>
+                            <systemPropertyVariables>
+                                <keystore.dir>${project.basedir}/keystore</keystore.dir>
+                                <INITIAL_MCAST_ADDR>224.8.8.8</INITIAL_MCAST_ADDR>
+                                <INITIAL_MCAST_PORT>31000</INITIAL_MCAST_PORT>
+                                <INITIAL_TCP_PORT>32000</INITIAL_TCP_PORT>
+                                <tcp.recv_buf_size>1000000</tcp.recv_buf_size>
+                                <tcp.send_buf_size>500000</tcp.send_buf_size>
+                                <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                                <jgroups.udp.ip_ttl>0</jgroups.udp.ip_ttl>
+                                <jgroups.tcpping.initial_hosts>localhost[7800],localhost[7801]</jgroups.tcpping.initial_hosts>
+                                <jgroups.tunnel.gossip_router_hosts>localhost[12001]</jgroups.tunnel.gossip_router_hosts>
+                                <log4j.configurationFile>${project.basedir}/conf/log4j2.xml</log4j.configurationFile>
+                                <tests.tmp.dir>${project.build.directory}/tests-tmp</tests.tmp.dir>
+                                <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
+                            </systemPropertyVariables>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 </includes>
             </resource>
             <resource>
-                <directory>${project.build.directory}/schema</directory>
+                <directory>conf</directory>
                 <includes>
                     <include>*.xsd</include>
                 </includes>
@@ -287,51 +287,51 @@
               </executions>
            </plugin>
            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
                 <executions>
-                     <execution>
-                         <id>generate-keystores</id>
-                         <phase>initialize</phase>
-                         <goals>
-                             <goal>run</goal>
-                         </goals>
-                         <configuration>
-                             <target>
-                                 <ant antfile="build.xml" target="make-keystore"/>
-                             </target>
-                         </configuration>
-                     </execution>
                     <execution>
-                        <id>compile</id>
+                        <id>generate-schema</id>
                         <phase>compile</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>java</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <property name="compile_classpath" refid="maven.compile.classpath" />
-                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <delete dir="${project.build.directory}/schema" failonerror="false" />
-                                <mkdir dir="${project.build.directory}/schema" />
-                                <java classname="org.jgroups.util.XMLSchemaGenerator" fork="true">
-                                    <classpath>
-                                        <pathelement path="${compile_classpath}" />
-                                        <pathelement path="${plugin_classpath}" />
-                                    </classpath>
-                                    <jvmarg value="-Dlog4j2.disable.jmx=true" />
-                                    <arg line="-o ${project.build.directory}/schema" />
-                                </java>
-                                <copy todir="${project.build.directory}/schema">
-                                    <fileset dir="conf">
-                                        <include name="*.xsd" />
-                                    </fileset>
-                                </copy>
-                                <copy todir="${project.build.outputDirectory}">
-                                    <fileset dir="${project.build.directory}/schema">
-                                        <include name="*.xsd" />
-                                    </fileset>
-                                </copy>
-                            </target>
+                            <mainClass>org.jgroups.util.XMLSchemaGenerator</mainClass>
+                            <commandlineArgs>-o ${project.build.directory}/schema</commandlineArgs>
+                            <classpathScope>compile</classpathScope>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>log4j2.disable.jmx</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-generated-schema</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/schema</directory>
+                                    <includes>
+                                        <include>*.xsd</include>
+                                    </includes>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>
@@ -411,6 +411,12 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                 </configuration>
                 <executions>
+                    <!-- Suppress the default-test execution so only the defined suites run -->
+                    <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                    </execution>
+
                     <!-- Functional suite -->
                     <execution>
                         <id>functional</id>
@@ -755,11 +761,6 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>3.2.0</version>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <nexus3.plugin.version>1.0.13</nexus3.plugin.version>
         <enforcer.plugin.version>3.6.3</enforcer.plugin.version>
         <gpg.plugin.version>3.2.8</gpg.plugin.version>
+        <byteman.version>4.0.27</byteman.version>
     </properties>
 
     <organization>
@@ -97,14 +98,14 @@
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-bmunit</artifactId>
-            <version>4.0.27</version>
+            <version>${byteman.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
-            <version>4.0.27</version>
+            <version>${byteman.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,18 @@
            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
+                     <execution>
+                         <id>generate-keystores</id>
+                         <phase>initialize</phase>
+                         <goals>
+                             <goal>run</goal>
+                         </goals>
+                         <configuration>
+                             <target>
+                                 <ant antfile="build.xml" target="make-keystore"/>
+                             </target>
+                         </configuration>
+                     </execution>
                     <execution>
                         <id>compile</id>
                         <phase>compile</phase>

--- a/src/org/jgroups/util/XMLSchemaGenerator.java
+++ b/src/org/jgroups/util/XMLSchemaGenerator.java
@@ -21,7 +21,10 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
@@ -64,6 +67,11 @@ public class XMLSchemaGenerator {
 
         String version = Version.major + "." + Version.minor;
         File f = new File(outputDir, "jgroups-" + version + ".xsd");
+        try {
+            Files.createDirectories(Path.of(outputDir));
+        } catch(IOException e) {
+            throw new RuntimeException("Failed to create output directory " + outputDir, e);
+        }
         try(FileWriter fw = new FileWriter(f, false)) {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();

--- a/src/test/resources/testng/testng-byteman.xml
+++ b/src/test/resources/testng/testng-byteman.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups Byteman Tests" verbose="1"
+       parallel="classes" thread-count="1"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="Byteman">
+        <groups>
+            <run>
+                <include name="byteman"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-encrypt.xml
+++ b/src/test/resources/testng/testng-encrypt.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups Encrypt Tests" verbose="1"
+       parallel="classes" thread-count="10"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="Encrypt">
+        <groups>
+            <run>
+                <include name="encrypt"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-functional.xml
+++ b/src/test/resources/testng/testng-functional.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups Functional Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="Functional">
+        <groups>
+            <run>
+                <include name="functional"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-jdbc.xml
+++ b/src/test/resources/testng/testng-jdbc.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups JDBC Tests" verbose="1"
+       parallel="classes" thread-count="1"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="JDBC">
+        <groups>
+            <run>
+                <include name="jdbc"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-stack-independent.xml
+++ b/src/test/resources/testng/testng-stack-independent.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups Stack-Independent Tests" verbose="1"
+       parallel="classes" thread-count="1"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="Stack-Independent">
+        <groups>
+            <run>
+                <include name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-tcp-new.xml
+++ b/src/test/resources/testng/testng-tcp-new.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups TCP-New Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="tcp-new.xml"/>
+
+    <test name="TCP-New">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-tcp-nio-new.xml
+++ b/src/test/resources/testng/testng-tcp-nio-new.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups TCP-NIO-New Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="tcp-nio-new.xml"/>
+
+    <test name="TCP-NIO-New">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-tcp-nio.xml
+++ b/src/test/resources/testng/testng-tcp-nio.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups TCP-NIO Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="tcp-nio.xml"/>
+
+    <test name="TCP-NIO">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-tcp.xml
+++ b/src/test/resources/testng/testng-tcp.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups TCP Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="tcp.xml"/>
+
+    <test name="TCP">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-time-sensitive.xml
+++ b/src/test/resources/testng/testng-time-sensitive.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups Time-Sensitive Tests" verbose="1"
+       parallel="classes" thread-count="10"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <test name="Time-Sensitive">
+        <groups>
+            <run>
+                <include name="time-sensitive"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-udp-new.xml
+++ b/src/test/resources/testng/testng-udp-new.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups UDP-New Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="udp-new.xml"/>
+
+    <test name="UDP-New">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>

--- a/src/test/resources/testng/testng-udp.xml
+++ b/src/test/resources/testng/testng-udp.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="JGroups UDP Tests" verbose="1"
+       parallel="classes" thread-count="20"
+       time-out="1800000"
+       configfailurepolicy="continue"
+       usedefaultlisteners="false">
+
+    <parameter name="channel.conf" value="udp.xml"/>
+
+    <test name="UDP">
+        <groups>
+            <run>
+                <include name="base"/>
+                <include name="stack-dependent"/>
+                <exclude name="stack-independent"/>
+                <exclude name="broken"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.jgroups.tests.*"/>
+            <package name="org.jgroups.tests.byteman.*"/>
+            <package name="org.jgroups.tests.helpers.*"/>
+            <package name="org.jgroups.protocols.*"/>
+            <package name="org.jgroups.protocols.dns.*"/>
+            <package name="org.jgroups.blocks.*"/>
+            <package name="org.jgroups.util.*"/>
+        </packages>
+    </test>
+
+    <listeners>
+        <listener class-name="org.jgroups.util.JUnitXMLReporter"/>
+    </listeners>
+</suite>


### PR DESCRIPTION
This PR migrates JGroups unit test execution from the Ant-based TestNG runner to Maven Surefire + TestNG, while keeping the existing directory structure and Ant build intact.
What changed
- Added a byteman.version property and centralized both byteman and byteman-bmunit dependencies on it.
- Added 12 TestNG XML suite files under src/test/resources/testng/, mirroring the existing Ant suites:
- functional, encrypt, byteman, jdbc, stack-independent, time-sensitive, udp, udp-new, tcp, tcp-new, tcp-nio, tcp-nio-new
- Each suite defines the correct groups, exclusions, parallelism, thread count, and channel.conf parameter where needed.

- Surefire configuration
  - Replaced the placeholder Surefire config with 12 self-contained executions.
  - Each execution supplies its own suite XML, system properties, port ranges, and JVM arguments.
  - Removed the <systemPropertiesFile>build.properties</systemPropertiesFile> dependency and inlined test-relevant properties.
  - Added tests/util as a test source so the custom JUnitXMLReporter listener is available to Surefire.
  - Suppressed the default default-test execution so mvn test runs only the defined suites.

- Removed maven-antrun-plugin
  - Replaced the Ant-based XML schema generation with exec-maven-plugin.
  - Copied the generated XSD files with maven-resources-plugin.
  - Removed the plugin from <pluginManagement>.
  - Keystore files are created on demand by the encrypt tests via KeyStoreGenerator, so no separate lifecycle step is needed.
 
How to run
  **mvn test**                                                 # all suites sequentially (ant target `all-tests` didn't run jdbc which is bit different currently)
  **mvn surefire:test@<suite-name>**        # single suite, e.g. functional, encrypt
  
  Part of JGRP-2499