### PR TITLE
CI: use SHAs instead of tags for versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,11 @@ jobs:
           - 17
           - 21
           - 25
-          - 26
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
* This protects against malicious tag overwriting
* Dependabot can handle updates anyway